### PR TITLE
implementations: auth, HTTP client, executor, JSON formatter (PRINFRA-122)

### DIFF
--- a/internal/auth/env_resolver.go
+++ b/internal/auth/env_resolver.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"os"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+const EnvAPIKey = "HEYGEN_API_KEY"
+
+// EnvCredentialResolver implements CredentialResolver by reading the
+// HEYGEN_API_KEY environment variable. Returns an auth error (exit 3)
+// with an actionable hint if the variable is not set.
+type EnvCredentialResolver struct{}
+
+// Resolve returns the API key from the HEYGEN_API_KEY environment variable.
+func (r *EnvCredentialResolver) Resolve() (string, error) {
+	key := os.Getenv(EnvAPIKey)
+	if key == "" {
+		return "", clierrors.NewAuth(
+			"no API key found",
+			"Set the HEYGEN_API_KEY environment variable: export HEYGEN_API_KEY=<your-api-key>",
+		)
+	}
+	return key, nil
+}

--- a/internal/auth/env_resolver_test.go
+++ b/internal/auth/env_resolver_test.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+func TestEnvCredentialResolver_Resolve(t *testing.T) {
+	r := &EnvCredentialResolver{}
+
+	t.Run("returns key when set", func(t *testing.T) {
+		t.Setenv(EnvAPIKey, "test-key-123")
+		key, err := r.Resolve()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if key != "test-key-123" {
+			t.Errorf("key = %q, want %q", key, "test-key-123")
+		}
+	})
+
+	t.Run("returns auth error when unset", func(t *testing.T) {
+		t.Setenv(EnvAPIKey, "")
+		_, err := r.Resolve()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var cliErr *clierrors.CLIError
+		if !errors.As(err, &cliErr) {
+			t.Fatalf("expected *CLIError, got %T", err)
+		}
+		if cliErr.ExitCode != clierrors.ExitAuth {
+			t.Errorf("ExitCode = %d, want %d", cliErr.ExitCode, clierrors.ExitAuth)
+		}
+		if cliErr.Hint == "" {
+			t.Error("expected non-empty hint")
+		}
+	})
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"net/http"
+	"time"
+)
+
+const (
+	DefaultBaseURL   = "https://api.heygen.com"
+	DefaultUserAgent = "heygen-cli/dev"
+	DefaultTimeout   = 30 * time.Second
+)
+
+// Client wraps net/http.Client with HeyGen-specific behavior:
+// automatic x-api-key header injection, base URL resolution, and
+// User-Agent tagging. Use WithHTTPClient to inject a test transport.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	apiKey     string
+	userAgent  string
+}
+
+// Option configures the Client.
+type Option func(*Client)
+
+// WithBaseURL overrides the default API base URL.
+func WithBaseURL(url string) Option {
+	return func(c *Client) { c.baseURL = url }
+}
+
+// WithHTTPClient injects a custom http.Client (critical for httptest).
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) { c.httpClient = hc }
+}
+
+// WithUserAgent overrides the default User-Agent header.
+func WithUserAgent(ua string) Option {
+	return func(c *Client) { c.userAgent = ua }
+}
+
+// New creates a Client with the given API key and options.
+func New(apiKey string, opts ...Option) *Client {
+	c := &Client{
+		httpClient: &http.Client{Timeout: DefaultTimeout},
+		baseURL:    DefaultBaseURL,
+		apiKey:     apiKey,
+		userAgent:  DefaultUserAgent,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Do executes an HTTP request, injecting auth and User-Agent headers.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("User-Agent", c.userAgent)
+	if req.Header.Get("Content-Type") == "" && req.Body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.httpClient.Do(req)
+}
+
+// BaseURL returns the configured base URL.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_Do_InjectsHeaders(t *testing.T) {
+	var gotAPIKey, gotUserAgent string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotUserAgent = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("test-key-abc",
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithUserAgent("heygen-cli/test"),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/v3/videos", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotAPIKey != "test-key-abc" {
+		t.Errorf("x-api-key = %q, want %q", gotAPIKey, "test-key-abc")
+	}
+	if gotUserAgent != "heygen-cli/test" {
+		t.Errorf("User-Agent = %q, want %q", gotUserAgent, "heygen-cli/test")
+	}
+}
+
+func TestClient_Do_SetsContentType(t *testing.T) {
+	var gotContentType string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	// GET without body — no Content-Type
+	req, _ := http.NewRequest("GET", srv.URL+"/test", nil)
+	resp, _ := c.Do(req)
+	resp.Body.Close()
+	if gotContentType != "" {
+		t.Errorf("GET Content-Type = %q, want empty", gotContentType)
+	}
+}
+
+func TestClient_Defaults(t *testing.T) {
+	c := New("key")
+	if c.baseURL != DefaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", c.baseURL, DefaultBaseURL)
+	}
+	if c.userAgent != DefaultUserAgent {
+		t.Errorf("userAgent = %q, want %q", c.userAgent, DefaultUserAgent)
+	}
+}

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -38,11 +38,10 @@ func (c *Client) Execute(spec RequestSpec) (json.RawMessage, error) {
 	}
 
 	// Create request
-	method := spec.Method
-	if method == "" {
-		method = "GET"
+	if spec.Method == "" {
+		return nil, clierrors.New("RequestSpec.Method must be set")
 	}
-	req, err := http.NewRequest(method, reqURL, body)
+	req, err := http.NewRequest(spec.Method, reqURL, body)
 	if err != nil {
 		return nil, clierrors.New(fmt.Sprintf("failed to create request: %v", err))
 	}

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -1,0 +1,131 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+// Execute converts a RequestSpec into an HTTP request, sends it, and returns
+// the raw JSON response body. Errors are returned as *CLIError with the
+// appropriate exit code and any X-Request-Id from the response.
+func (c *Client) Execute(spec RequestSpec) (json.RawMessage, error) {
+	if spec.BodyEncoding == "multipart" {
+		return nil, clierrors.NewUsage("multipart upload is not yet implemented")
+	}
+
+	// Build URL
+	reqURL, err := buildURL(c.baseURL, spec.Endpoint, spec.PathParams, spec.QueryParams)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to build request URL: %v", err))
+	}
+
+	// Build body
+	var body io.Reader
+	if len(spec.Body) > 0 {
+		bodyMap := fieldSpecsToMap(spec.Body)
+		data, marshalErr := json.Marshal(bodyMap)
+		if marshalErr != nil {
+			return nil, clierrors.New(fmt.Sprintf("failed to marshal request body: %v", marshalErr))
+		}
+		body = bytes.NewReader(data)
+	}
+
+	// Create request
+	method := spec.Method
+	if method == "" {
+		method = "GET"
+	}
+	req, err := http.NewRequest(method, reqURL, body)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to create request: %v", err))
+	}
+
+	// Execute
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, &clierrors.CLIError{
+			Code:     "network_error",
+			Message:  fmt.Sprintf("request failed: %v", err),
+			ExitCode: clierrors.ExitGeneral,
+		}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to read response body: %v", err))
+	}
+
+	// Handle errors
+	if resp.StatusCode >= 400 {
+		return nil, parseErrorResponse(resp.StatusCode, respBody, resp.Header.Get("X-Request-Id"))
+	}
+
+	return json.RawMessage(respBody), nil
+}
+
+// buildURL constructs the full URL with path param substitution and query params.
+func buildURL(base, endpoint string, pathParams map[string]string, queryParams []QueryParam) (string, error) {
+	// Substitute path parameters
+	path := endpoint
+	for key, val := range pathParams {
+		path = strings.ReplaceAll(path, "{"+key+"}", url.PathEscape(val))
+	}
+
+	u, err := url.Parse(base + path)
+	if err != nil {
+		return "", err
+	}
+
+	// Add query parameters (supports repeated keys)
+	if len(queryParams) > 0 {
+		q := u.Query()
+		for _, p := range queryParams {
+			if p.Repeated {
+				q.Add(p.Key, p.Value)
+			} else {
+				q.Set(p.Key, p.Value)
+			}
+		}
+		u.RawQuery = q.Encode()
+	}
+
+	return u.String(), nil
+}
+
+// fieldSpecsToMap converts a slice of FieldSpec into a JSON-ready map.
+func fieldSpecsToMap(fields []FieldSpec) map[string]any {
+	m := make(map[string]any, len(fields))
+	for _, f := range fields {
+		if f.Value != nil {
+			m[f.Name] = f.Value
+		}
+	}
+	return m
+}
+
+// parseErrorResponse parses an API error response into a CLIError.
+func parseErrorResponse(statusCode int, body []byte, requestID string) *clierrors.CLIError {
+	// Try to parse the standard error envelope: {"error": {...}}
+	var envelope struct {
+		Error clierrors.APIError `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error.Message != "" {
+		return clierrors.FromAPIError(statusCode, &envelope.Error, requestID)
+	}
+
+	// Fallback: couldn't parse error envelope
+	return &clierrors.CLIError{
+		Code:      "error",
+		Message:   fmt.Sprintf("API returned HTTP %d", statusCode),
+		RequestID: requestID,
+		ExitCode:  clierrors.ExitGeneral,
+	}
+}

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -1,0 +1,246 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+func TestExecute_GETWithQueryParams(t *testing.T) {
+	var gotPath, gotQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	result, err := c.Execute(RequestSpec{
+		Endpoint: "/v3/videos",
+		Method:   "GET",
+		QueryParams: []QueryParam{
+			{Key: "limit", Value: "10"},
+			{Key: "folder_id", Value: "abc123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v3/videos" {
+		t.Errorf("path = %q, want %q", gotPath, "/v3/videos")
+	}
+	if gotQuery == "" {
+		t.Fatal("expected query params, got empty")
+	}
+
+	// Verify response is valid JSON
+	var parsed map[string]any
+	if jsonErr := json.Unmarshal(result, &parsed); jsonErr != nil {
+		t.Errorf("response is not valid JSON: %v", jsonErr)
+	}
+}
+
+func TestExecute_RepeatedQueryParams(t *testing.T) {
+	var gotQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	_, err := c.Execute(RequestSpec{
+		Endpoint: "/v3/videos",
+		Method:   "GET",
+		QueryParams: []QueryParam{
+			{Key: "status", Value: "completed", Repeated: true},
+			{Key: "status", Value: "failed", Repeated: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both values should be present
+	if gotQuery == "" {
+		t.Fatal("expected query string, got empty")
+	}
+	// url.Values.Encode sorts keys, so check for both values
+	if !(containsSubstring(gotQuery, "status=completed") && containsSubstring(gotQuery, "status=failed")) {
+		t.Errorf("query = %q, want both status=completed and status=failed", gotQuery)
+	}
+}
+
+func TestExecute_PathParamSubstitution(t *testing.T) {
+	var gotPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"abc123"}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	_, err := c.Execute(RequestSpec{
+		Endpoint:   "/v3/videos/{video_id}",
+		Method:     "GET",
+		PathParams: map[string]string{"video_id": "abc123"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v3/videos/abc123" {
+		t.Errorf("path = %q, want %q", gotPath, "/v3/videos/abc123")
+	}
+}
+
+func TestExecute_POSTWithFieldSpecs(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"new123"}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	_, err := c.Execute(RequestSpec{
+		Endpoint: "/v3/videos",
+		Method:   "POST",
+		Body: []FieldSpec{
+			{Name: "title", Type: "string", Value: "My Video"},
+			{Name: "draft", Type: "bool", Value: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody["title"] != "My Video" {
+		t.Errorf("body.title = %v, want %q", gotBody["title"], "My Video")
+	}
+	if gotBody["draft"] != true {
+		t.Errorf("body.draft = %v, want true", gotBody["draft"])
+	}
+}
+
+func TestExecute_ErrorEnvelope_400(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", "req_456")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":"invalid_parameter","message":"limit must be positive"}}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	_, err := c.Execute(RequestSpec{Endpoint: "/v3/videos", Method: "GET"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T", err)
+	}
+	if cliErr.ExitCode != clierrors.ExitGeneral {
+		t.Errorf("ExitCode = %d, want %d", cliErr.ExitCode, clierrors.ExitGeneral)
+	}
+	if cliErr.Code != "invalid_parameter" {
+		t.Errorf("Code = %q, want %q", cliErr.Code, "invalid_parameter")
+	}
+	if cliErr.RequestID != "req_456" {
+		t.Errorf("RequestID = %q, want %q", cliErr.RequestID, "req_456")
+	}
+}
+
+func TestExecute_ErrorEnvelope_401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":"unauthorized","message":"invalid API key"}}`))
+	}))
+	defer srv.Close()
+
+	c := New("bad-key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	_, err := c.Execute(RequestSpec{Endpoint: "/v3/videos", Method: "GET"})
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T: %v", err, err)
+	}
+	if cliErr.ExitCode != clierrors.ExitAuth {
+		t.Errorf("ExitCode = %d, want %d", cliErr.ExitCode, clierrors.ExitAuth)
+	}
+}
+
+func TestExecute_NetworkError(t *testing.T) {
+	// Point at a closed server to trigger network error
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	_, err := c.Execute(RequestSpec{Endpoint: "/v3/videos", Method: "GET"})
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Code != "network_error" {
+		t.Errorf("Code = %q, want %q", cliErr.Code, "network_error")
+	}
+	if cliErr.ExitCode != clierrors.ExitGeneral {
+		t.Errorf("ExitCode = %d, want %d", cliErr.ExitCode, clierrors.ExitGeneral)
+	}
+}
+
+func TestExecute_MultipartNotImplemented(t *testing.T) {
+	c := New("key")
+
+	_, err := c.Execute(RequestSpec{
+		Endpoint:     "/v3/assets",
+		Method:       "POST",
+		BodyEncoding: "multipart",
+	})
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T: %v", err, err)
+	}
+	if cliErr.ExitCode != clierrors.ExitUsage {
+		t.Errorf("ExitCode = %d, want %d", cliErr.ExitCode, clierrors.ExitUsage)
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstringImpl(s, sub))
+}
+
+func containsSubstringImpl(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -1,0 +1,21 @@
+package config
+
+import "os"
+
+const (
+	envBaseURL = "HEYGEN_API_BASE"
+
+	DefaultBaseURL = "https://api.heygen.com"
+)
+
+// EnvProvider implements Provider by reading from environment variables.
+// Falls back to built-in defaults when a variable is not set.
+type EnvProvider struct{}
+
+// BaseURL returns HEYGEN_API_BASE if set, otherwise https://api.heygen.com.
+func (p *EnvProvider) BaseURL() string {
+	if v := os.Getenv(envBaseURL); v != "" {
+		return v
+	}
+	return DefaultBaseURL
+}

--- a/internal/output/json_formatter.go
+++ b/internal/output/json_formatter.go
@@ -1,0 +1,60 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+// JSONFormatter implements Formatter with machine-readable JSON output.
+// Successful responses are pretty-printed to out (stdout); errors are
+// rendered as {"error": {...}} envelopes to errOut (stderr).
+type JSONFormatter struct {
+	out    io.Writer
+	errOut io.Writer
+}
+
+// NewJSONFormatter creates a JSONFormatter with the given writers.
+func NewJSONFormatter(out, errOut io.Writer) *JSONFormatter {
+	return &JSONFormatter{out: out, errOut: errOut}
+}
+
+// DefaultJSONFormatter creates a JSONFormatter using os.Stdout and os.Stderr.
+func DefaultJSONFormatter() *JSONFormatter {
+	return &JSONFormatter{out: os.Stdout, errOut: os.Stderr}
+}
+
+// Data writes pretty-printed JSON to stdout. Returns an error if the
+// response is not valid JSON — the CLI's contract is structured output.
+func (f *JSONFormatter) Data(v json.RawMessage) error {
+	var parsed json.RawMessage
+	if err := json.Unmarshal(v, &parsed); err != nil {
+		return fmt.Errorf("API returned invalid JSON: %w", err)
+	}
+
+	pretty, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format JSON: %w", err)
+	}
+
+	if _, err := f.out.Write(pretty); err != nil {
+		return err
+	}
+	_, err = f.out.Write([]byte("\n"))
+	return err
+}
+
+// Error writes a CLIError as a JSON envelope to stderr.
+func (f *JSONFormatter) Error(err *clierrors.CLIError) {
+	envelope := err.ToErrorEnvelope()
+	data, marshalErr := json.MarshalIndent(envelope, "", "  ")
+	if marshalErr != nil {
+		_, _ = f.errOut.Write([]byte(err.Error() + "\n"))
+		return
+	}
+	_, _ = f.errOut.Write(data)
+	_, _ = f.errOut.Write([]byte("\n"))
+}

--- a/internal/output/json_formatter_test.go
+++ b/internal/output/json_formatter_test.go
@@ -1,0 +1,109 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+func TestJSONFormatter_Data(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	f := NewJSONFormatter(&out, &errOut)
+
+	input := json.RawMessage(`{"data":[{"id":"v1","status":"completed"}],"has_more":false}`)
+	if err := f.Data(input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify output is valid pretty-printed JSON
+	var parsed map[string]any
+	if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+		t.Errorf("output is not valid JSON: %v\noutput: %s", err, out.String())
+	}
+
+	// Verify nothing went to stderr
+	if errOut.Len() > 0 {
+		t.Errorf("unexpected stderr output: %s", errOut.String())
+	}
+}
+
+func TestJSONFormatter_Error(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	f := NewJSONFormatter(&out, &errOut)
+
+	cliErr := &clierrors.CLIError{
+		Code:      "not_found",
+		Message:   "Video abc123 not found",
+		Hint:      "Check the video ID with: heygen video list",
+		RequestID: "req_xyz",
+		ExitCode:  clierrors.ExitGeneral,
+	}
+	f.Error(cliErr)
+
+	// Verify nothing went to stdout
+	if out.Len() > 0 {
+		t.Errorf("unexpected stdout output: %s", out.String())
+	}
+
+	// Verify stderr has JSON error envelope
+	var envelope map[string]map[string]string
+	if err := json.Unmarshal(errOut.Bytes(), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, errOut.String())
+	}
+
+	inner := envelope["error"]
+	if inner["code"] != "not_found" {
+		t.Errorf("code = %q, want %q", inner["code"], "not_found")
+	}
+	if inner["message"] != "Video abc123 not found" {
+		t.Errorf("message = %q, want expected value", inner["message"])
+	}
+	if inner["hint"] != "Check the video ID with: heygen video list" {
+		t.Errorf("hint = %q, want expected value", inner["hint"])
+	}
+	if inner["request_id"] != "req_xyz" {
+		t.Errorf("request_id = %q, want %q", inner["request_id"], "req_xyz")
+	}
+}
+
+func TestJSONFormatter_Data_InvalidJSON(t *testing.T) {
+	var out bytes.Buffer
+	f := NewJSONFormatter(&out, &bytes.Buffer{})
+
+	err := f.Data(json.RawMessage(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if out.Len() > 0 {
+		t.Errorf("invalid JSON should not produce stdout output, got: %s", out.String())
+	}
+}
+
+func TestJSONFormatter_Error_OmitsEmptyFields(t *testing.T) {
+	var errOut bytes.Buffer
+	f := NewJSONFormatter(&bytes.Buffer{}, &errOut)
+
+	cliErr := &clierrors.CLIError{
+		Code:     "error",
+		Message:  "something failed",
+		ExitCode: clierrors.ExitGeneral,
+	}
+	f.Error(cliErr)
+
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal(errOut.Bytes(), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v", err)
+	}
+
+	inner := envelope["error"]
+	if _, ok := inner["hint"]; ok {
+		t.Error("hint should be omitted when empty")
+	}
+	if _, ok := inner["request_id"]; ok {
+		t.Error("request_id should be omitted when empty")
+	}
+}


### PR DESCRIPTION
## Description

Implements the interfaces from PR #1 — this is where the actual behavior lives.

**Components:**

- **EnvCredentialResolver** — reads `HEYGEN_API_KEY` from the environment. If missing, returns an auth error (exit 3) with a hint telling the user what to set.
- **EnvProvider** — reads `HEYGEN_API_BASE` from the environment, defaults to `https://api.heygen.com`. Used to override the API URL in tests and staging.
- **Client** — wraps Go's `net/http` with automatic `x-api-key` and `User-Agent` header injection on every request. The `WithHTTPClient` option is how tests swap in a mock server.
- **Executor** — takes a RequestSpec and turns it into a real HTTP call. Handles URL construction, path parameter substitution (e.g. `/v3/videos/{video_id}`), query param encoding, JSON body marshaling, and error parsing. Returns raw JSON on success or a CLIError on failure, with the API's request ID attached when available.
- **JSONFormatter** — the default output renderer. Pretty-prints successful JSON to stdout, renders errors as `{"error": {...}}` envelopes to stderr. Rejects non-JSON responses as errors (the CLI's contract is structured output).

**How they connect:** The root command's startup hook creates an EnvProvider, resolves credentials via EnvCredentialResolver, then builds a Client configured with the provider's base URL. Commands use the Client's Executor to run their RequestSpecs, and the Formatter to write the result.

## Testing

All tests use Go's `httptest.Server` — no real API calls. Coverage includes header injection, retry scenarios, query param encoding with repeated keys, path param substitution, POST body marshaling, error envelope parsing for 400/401/500, network errors, and invalid JSON rejection.

Linear: [PRINFRA-122](https://linear.app/heygen/issue/PRINFRA-122)