### PR TITLE
walking skeleton: Cobra root, video list command, test harness (PRINFRA-142)

### DIFF
--- a/.github/GIT_CONVENTIONS.md
+++ b/.github/GIT_CONVENTIONS.md
@@ -48,12 +48,12 @@ docs: update CLAUDE.md
 
 ## PR Titles
 
-Same format as commit messages — the PR title becomes the squash commit on main.
+Same format as commit messages, with the Linear issue ID appended in parentheses. The PR title becomes the squash commit on main. The issue ID in the title triggers Linear's GitHub integration to link the PR to the issue.
 
 ```
-auth: add file-based credential storage
-add --wait polling with status tracking
-ci: add cross-platform test matrix
+auth: add file-based credential storage (PRINFRA-123)
+add --wait polling with status tracking (PRINFRA-125)
+ci: add cross-platform test matrix (PRINFRA-143)
 ```
 
 ## PR Descriptions

--- a/cmd/heygen/main.go
+++ b/cmd/heygen/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"os"
+	"strings"
 
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 	"github.com/heygen-com/heygen-cli/internal/output"
@@ -23,9 +24,26 @@ func main() {
 			formatter.Error(cliErr)
 			os.Exit(cliErr.ExitCode)
 		}
-		// Wrap unexpected errors so they also get JSON envelope treatment.
-		wrapped := clierrors.New(err.Error())
+		// Cobra returns plain errors for unknown commands and arg validation.
+		// Detect these and wrap as usage errors (exit 2).
+		wrapped := classifyError(err)
 		formatter.Error(wrapped)
 		os.Exit(wrapped.ExitCode)
 	}
+}
+
+// classifyError wraps non-CLIError errors with the appropriate exit code.
+// Cobra usage errors (unknown command, wrong arg count) get exit 2;
+// everything else gets exit 1.
+func classifyError(err error) *clierrors.CLIError {
+	msg := err.Error()
+	if strings.HasPrefix(msg, "unknown command") ||
+		strings.HasPrefix(msg, "unknown flag") ||
+		strings.HasPrefix(msg, "unknown shorthand flag") ||
+		strings.Contains(msg, "accepts ") ||
+		strings.HasPrefix(msg, "required flag") ||
+		strings.HasPrefix(msg, "invalid argument") {
+		return clierrors.NewUsage(msg)
+	}
+	return clierrors.New(msg)
 }

--- a/cmd/heygen/main.go
+++ b/cmd/heygen/main.go
@@ -1,14 +1,31 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"os"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+	"github.com/heygen-com/heygen-cli/internal/output"
 )
 
 // version is set at build time via ldflags.
 var version = "dev"
 
 func main() {
-	fmt.Fprintf(os.Stderr, "heygen-cli %s\n", version)
-	os.Exit(0)
+	// Bootstrap formatter created before the Cobra tree so it's available
+	// for errors from PersistentPreRunE (auth failures, config loading).
+	formatter := output.DefaultJSONFormatter()
+
+	cmd := newRootCmd(version, formatter)
+	if err := cmd.Execute(); err != nil {
+		var cliErr *clierrors.CLIError
+		if errors.As(err, &cliErr) {
+			formatter.Error(cliErr)
+			os.Exit(cliErr.ExitCode)
+		}
+		// Wrap unexpected errors so they also get JSON envelope treatment.
+		wrapped := clierrors.New(err.Error())
+		formatter.Error(wrapped)
+		os.Exit(wrapped.ExitCode)
+	}
 }

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -4,6 +4,7 @@ import (
 	"github.com/heygen-com/heygen-cli/internal/auth"
 	"github.com/heygen-com/heygen-cli/internal/client"
 	"github.com/heygen-com/heygen-cli/internal/config"
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 	"github.com/heygen-com/heygen-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,7 @@ import (
 type cmdContext struct {
 	client    *client.Client
 	formatter output.Formatter
-	config    config.Provider
+	configProvider config.Provider
 }
 
 func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
@@ -26,12 +27,12 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 		SilenceUsage:  true, // we handle usage errors ourselves
 		SilenceErrors: true, // we handle error output ourselves
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// 1. Create config provider
+			// 1. Create config provider (BaseURL only — auth is Resolver's job)
 			provider := &config.EnvProvider{}
-			ctx.config = provider
+			ctx.configProvider = provider
 
-			// 2. Resolve auth
-			resolver := &auth.EnvResolver{}
+			// 2. Resolve credentials (env var today; keyring/file later)
+			resolver := &auth.EnvCredentialResolver{}
 			apiKey, err := resolver.Resolve()
 			if err != nil {
 				return err
@@ -46,6 +47,11 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 			return nil
 		},
 	}
+
+	// Map Cobra flag-parsing errors to CLIError with ExitUsage (exit code 2).
+	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return clierrors.NewUsage(err.Error())
+	})
 
 	// Register subcommands
 	root.AddCommand(newVideoCmd(ctx))

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"github.com/heygen-com/heygen-cli/internal/auth"
+	"github.com/heygen-com/heygen-cli/internal/client"
+	"github.com/heygen-com/heygen-cli/internal/config"
+	"github.com/heygen-com/heygen-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// cmdContext holds shared dependencies created in PersistentPreRunE
+// and consumed by child commands via closures.
+type cmdContext struct {
+	client    *client.Client
+	formatter output.Formatter
+	config    config.Provider
+}
+
+func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
+	ctx := &cmdContext{formatter: formatter}
+
+	root := &cobra.Command{
+		Use:           "heygen",
+		Short:         "HeyGen CLI — manage videos, avatars, and more",
+		Version:       version,
+		SilenceUsage:  true, // we handle usage errors ourselves
+		SilenceErrors: true, // we handle error output ourselves
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// 1. Create config provider
+			provider := &config.EnvProvider{}
+			ctx.config = provider
+
+			// 2. Resolve auth
+			resolver := &auth.EnvResolver{}
+			apiKey, err := resolver.Resolve()
+			if err != nil {
+				return err
+			}
+
+			// 3. Create client using config.Provider for BaseURL
+			ctx.client = client.New(apiKey,
+				client.WithBaseURL(provider.BaseURL()),
+				client.WithUserAgent("heygen-cli/"+version),
+			)
+
+			return nil
+		},
+	}
+
+	// Register subcommands
+	root.AddCommand(newVideoCmd(ctx))
+
+	return root
+}

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -31,7 +31,7 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 			provider := &config.EnvProvider{}
 			ctx.configProvider = provider
 
-			// 2. Resolve credentials (env var today; keyring/file later)
+			// 2. Resolve credentials (env var today; file-based storage later)
 			resolver := &auth.EnvCredentialResolver{}
 			apiKey, err := resolver.Resolve()
 			if err != nil {

--- a/cmd/heygen/testutil_test.go
+++ b/cmd/heygen/testutil_test.go
@@ -37,7 +37,7 @@ func setupTestServer(t *testing.T, handlers map[string]testHandler) *httptest.Se
 		if !ok {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{"error":{"code":"not_found","message":"no handler registered"}}`))
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"no handler registered"}}`))
 			return
 		}
 		if h.ValidateRequest != nil {
@@ -47,7 +47,7 @@ func setupTestServer(t *testing.T, handlers map[string]testHandler) *httptest.Se
 			w.Header().Set(k, v)
 		}
 		w.WriteHeader(h.StatusCode)
-		w.Write([]byte(h.Body))
+		_, _ = w.Write([]byte(h.Body))
 	}))
 }
 
@@ -76,12 +76,14 @@ func runCommand(t *testing.T, serverURL, apiKey string, args ...string) cmdResul
 	var exitCode int
 	if err != nil {
 		// Render through formatter — same path as main()
+		// Mirror the classification logic from main() so tests
+		// see the same exit codes production emits.
 		var cliErr *clierrors.CLIError
 		if errors.As(err, &cliErr) {
 			formatter.Error(cliErr)
 			exitCode = cliErr.ExitCode
 		} else {
-			wrapped := clierrors.New(err.Error())
+			wrapped := classifyError(err)
 			formatter.Error(wrapped)
 			exitCode = wrapped.ExitCode
 		}

--- a/cmd/heygen/testutil_test.go
+++ b/cmd/heygen/testutil_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+	"github.com/heygen-com/heygen-cli/internal/output"
+)
+
+// testHandler is a handler for the mock API server.
+type testHandler struct {
+	StatusCode int
+	Body       string
+	Headers    map[string]string
+	// ValidateRequest allows tests to inspect the incoming request.
+	ValidateRequest func(t *testing.T, r *http.Request)
+}
+
+// cmdResult captures the output of a CLI command execution.
+type cmdResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// setupTestServer creates an httptest.Server with registered handlers.
+// handlers maps "METHOD /path" → testHandler.
+func setupTestServer(t *testing.T, handlers map[string]testHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		h, ok := handlers[key]
+		if !ok {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":{"code":"not_found","message":"no handler registered"}}`))
+			return
+		}
+		if h.ValidateRequest != nil {
+			h.ValidateRequest(t, r)
+		}
+		for k, v := range h.Headers {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(h.StatusCode)
+		w.Write([]byte(h.Body))
+	}))
+}
+
+// runCommand executes a CLI command against a test server, mirroring the
+// production error-rendering path from main().
+//
+// It creates a fresh Cobra command tree with a JSONFormatter backed by
+// buffers, executes the command, and renders returned errors through the
+// formatter — same path as main(). This ensures stderr content in tests
+// matches what production emits.
+func runCommand(t *testing.T, serverURL, apiKey string, args ...string) cmdResult {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	formatter := output.NewJSONFormatter(&stdout, &stderr)
+
+	// Set env vars for this test
+	t.Setenv("HEYGEN_API_KEY", apiKey)
+	t.Setenv("HEYGEN_API_BASE", serverURL)
+
+	cmd := newRootCmd("test", formatter)
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	var exitCode int
+	if err != nil {
+		// Render through formatter — same path as main()
+		var cliErr *clierrors.CLIError
+		if errors.As(err, &cliErr) {
+			formatter.Error(cliErr)
+			exitCode = cliErr.ExitCode
+		} else {
+			wrapped := clierrors.New(err.Error())
+			formatter.Error(wrapped)
+			exitCode = wrapped.ExitCode
+		}
+	}
+
+	return cmdResult{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}
+}

--- a/cmd/heygen/video.go
+++ b/cmd/heygen/video.go
@@ -1,0 +1,12 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newVideoCmd(ctx *cmdContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "video",
+		Short: "Manage videos",
+	}
+	cmd.AddCommand(newVideoListCmd(ctx))
+	return cmd
+}

--- a/cmd/heygen/video_list.go
+++ b/cmd/heygen/video_list.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/heygen-com/heygen-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func newVideoListCmd(ctx *cmdContext) *cobra.Command {
+	var limit int
+	var token string
+	var folderID string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List videos",
+		Long:  "List videos in your HeyGen account with optional filtering.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spec := client.RequestSpec{
+				Endpoint:   "/v3/videos",
+				Method:     "GET",
+				Paginated:  true,
+				DataField:  "data",
+				TokenField: "next_token",
+			}
+
+			if limit > 0 {
+				spec.QueryParams = append(spec.QueryParams, client.QueryParam{Key: "limit", Value: strconv.Itoa(limit)})
+			}
+			if token != "" {
+				spec.QueryParams = append(spec.QueryParams, client.QueryParam{Key: "token", Value: token})
+			}
+			if folderID != "" {
+				spec.QueryParams = append(spec.QueryParams, client.QueryParam{Key: "folder_id", Value: folderID})
+			}
+
+			result, err := ctx.client.Execute(spec)
+			if err != nil {
+				return err
+			}
+
+			return ctx.formatter.Data(result)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of videos to return (1-100, default 10)")
+	cmd.Flags().StringVar(&token, "token", "", "Pagination cursor from previous response")
+	cmd.Flags().StringVar(&folderID, "folder-id", "", "Filter by folder ID")
+
+	return cmd
+}

--- a/cmd/heygen/video_list.go
+++ b/cmd/heygen/video_list.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/heygen-com/heygen-cli/internal/client"
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +19,13 @@ func newVideoListCmd(ctx *cmdContext) *cobra.Command {
 		Short: "List videos",
 		Long:  "List videos in your HeyGen account with optional filtering.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate --limit if explicitly provided
+			if cmd.Flags().Changed("limit") {
+				if limit < 1 || limit > 100 {
+					return clierrors.NewUsage(fmt.Sprintf("--limit must be between 1 and 100, got %d", limit))
+				}
+			}
+
 			spec := client.RequestSpec{
 				Endpoint:   "/v3/videos",
 				Method:     "GET",
@@ -25,7 +34,7 @@ func newVideoListCmd(ctx *cmdContext) *cobra.Command {
 				TokenField: "next_token",
 			}
 
-			if limit > 0 {
+			if cmd.Flags().Changed("limit") {
 				spec.QueryParams = append(spec.QueryParams, client.QueryParam{Key: "limit", Value: strconv.Itoa(limit)})
 			}
 			if token != "" {
@@ -44,7 +53,7 @@ func newVideoListCmd(ctx *cmdContext) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of videos to return (1-100, default 10)")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of videos to return (1-100)")
 	cmd.Flags().StringVar(&token, "token", "", "Pagination cursor from previous response")
 	cmd.Flags().StringVar(&folderID, "folder-id", "", "Filter by folder ID")
 

--- a/cmd/heygen/video_list_test.go
+++ b/cmd/heygen/video_list_test.go
@@ -140,6 +140,56 @@ func TestVideoList_Flags(t *testing.T) {
 	}
 }
 
+func TestVideoList_LimitOutOfRange(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	tests := []struct {
+		name  string
+		limit string
+	}{
+		{"too high", "999"},
+		{"zero", "0"},
+		{"negative", "-5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := runCommand(t, srv.URL, "test-key", "video", "list", "--limit", tt.limit)
+
+			if res.ExitCode != clierrors.ExitUsage {
+				t.Errorf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+			}
+
+			var envelope map[string]map[string]any
+			if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
+				t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+			}
+			if envelope["error"]["code"] != "usage_error" {
+				t.Errorf("error.code = %v, want %q", envelope["error"]["code"], "usage_error")
+			}
+		})
+	}
+}
+
+func TestVideoList_UnknownFlag(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "list", "--bogus")
+
+	if res.ExitCode != clierrors.ExitUsage {
+		t.Errorf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+	}
+
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+	}
+	if envelope["error"]["code"] != "usage_error" {
+		t.Errorf("error.code = %v, want %q", envelope["error"]["code"], "usage_error")
+	}
+}
+
 func TestVideoList_ServerError(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
 		"GET /v3/videos": {
@@ -158,5 +208,24 @@ func TestVideoList_ServerError(t *testing.T) {
 	var envelope map[string]map[string]any
 	if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
 		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+	}
+}
+
+func TestUnknownCommand(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "nonexistent", "subcommand")
+
+	if res.ExitCode != clierrors.ExitUsage {
+		t.Errorf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+	}
+
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+	}
+	if envelope["error"]["code"] != "usage_error" {
+		t.Errorf("error.code = %v, want %q", envelope["error"]["code"], "usage_error")
 	}
 }

--- a/cmd/heygen/video_list_test.go
+++ b/cmd/heygen/video_list_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+func TestVideoList_Success(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":[{"id":"v1","title":"Demo","status":"completed"}],"has_more":false,"next_token":null}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "list")
+
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	// Verify stdout is valid JSON with data array
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, res.Stdout)
+	}
+	data, ok := parsed["data"].([]any)
+	if !ok {
+		t.Fatalf("data field missing or not array: %v", parsed)
+	}
+	if len(data) != 1 {
+		t.Errorf("data length = %d, want 1", len(data))
+	}
+}
+
+func TestVideoList_AuthMissing(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "", "video", "list")
+
+	if res.ExitCode != clierrors.ExitAuth {
+		t.Errorf("ExitCode = %d, want %d", res.ExitCode, clierrors.ExitAuth)
+	}
+
+	// Verify stderr has JSON error envelope
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+	}
+	inner := envelope["error"]
+	if inner["code"] != "auth_error" {
+		t.Errorf("error.code = %v, want %q", inner["code"], "auth_error")
+	}
+	if inner["hint"] == nil || inner["hint"] == "" {
+		t.Error("expected non-empty hint in error envelope")
+	}
+}
+
+func TestVideoList_APIError401(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 401,
+			Body:       `{"error":{"code":"unauthorized","message":"invalid API key"}}`,
+			Headers:    map[string]string{"X-Request-Id": "req_auth_fail"},
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "bad-key", "video", "list")
+
+	if res.ExitCode != clierrors.ExitAuth {
+		t.Errorf("ExitCode = %d, want %d", res.ExitCode, clierrors.ExitAuth)
+	}
+
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+	}
+	if envelope["error"]["request_id"] != "req_auth_fail" {
+		t.Errorf("request_id = %v, want %q", envelope["error"]["request_id"], "req_auth_fail")
+	}
+}
+
+func TestVideoList_APIError400(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 400,
+			Body:       `{"error":{"code":"invalid_parameter","message":"limit must be between 1 and 100"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "list")
+
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Errorf("ExitCode = %d, want %d", res.ExitCode, clierrors.ExitGeneral)
+	}
+
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+	}
+	if envelope["error"]["code"] != "invalid_parameter" {
+		t.Errorf("error.code = %v, want %q", envelope["error"]["code"], "invalid_parameter")
+	}
+}
+
+func TestVideoList_Flags(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":[],"has_more":false}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				q := r.URL.Query()
+				if got := q.Get("limit"); got != "25" {
+					t.Errorf("limit = %q, want %q", got, "25")
+				}
+				if got := q.Get("folder_id"); got != "folder_abc" {
+					t.Errorf("folder_id = %q, want %q", got, "folder_abc")
+				}
+				if got := q.Get("token"); got != "cursor_xyz" {
+					t.Errorf("token = %q, want %q", got, "cursor_xyz")
+				}
+			},
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key",
+		"video", "list", "--limit", "25", "--folder-id", "folder_abc", "--token", "cursor_xyz")
+
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestVideoList_ServerError(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 500,
+			Body:       `{"error":{"code":"internal_error","message":"something went wrong"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "list")
+
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Errorf("ExitCode = %d, want %d", res.ExitCode, clierrors.ExitGeneral)
+	}
+
+	var envelope map[string]map[string]any
+	if err := json.Unmarshal([]byte(res.Stderr), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nstderr: %s", err, res.Stderr)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/heygen-com/heygen-cli
 
 go 1.23.8
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Description

Wires everything from PRs #1 and #2 into a working CLI. After this, `heygen video list` works end-to-end against the real HeyGen API.

**What happens when you run `heygen video list --limit 5`:**

1. `main.go` creates a JSON formatter before anything else — so even early failures (bad auth, bad flags) get structured JSON error output, never plain text.
2. Cobra parses the command and flags. Unknown commands and bad flags are caught and returned as usage errors (exit 2).
3. The root command's startup hook runs: creates a config provider, resolves the API key, and builds an HTTP client.
4. The `video list` command validates `--limit` is 1-100, builds a RequestSpec, and hands it to the executor.
5. The executor makes the HTTP call and returns raw JSON. The formatter pretty-prints it to stdout.
6. If anything fails at any step, the error flows back to `main.go` where it's classified (auth → exit 3, usage → exit 2, everything else → exit 1) and rendered as a JSON envelope to stderr.

**Test harness:** `runCommand()` in the test helper mirrors this exact flow — fresh Cobra tree, buffer-backed formatter, same error classification. Tests assert on exit codes and the JSON envelope shape, not just whether an error occurred.

## Testing

10 command tests using httptest mocks:
- Success with valid JSON response
- Missing auth (exit 3 with hint)
- API 401 and 400 responses (correct exit codes, request ID preserved)
- Flags passed correctly as query params
- Limit validation (exit 2 for 0, -5, 999)
- Unknown flag and unknown command (exit 2)
- Server error (exit 1)

Manual smoke test: `HEYGEN_API_KEY=<key> ./bin/heygen video list --limit 2` returns real video JSON.

Linear: [PRINFRA-142](https://linear.app/heygen/issue/PRINFRA-142)