### PR TITLE
add CI: build, test, lint on PRs and main pushes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,5 @@
+## Description
+<!-- What changed and why? Explain the change, not just the files touched. -->
+
+## Testing
+<!-- How was this tested? Describe automated and manual tests. -->

--- a/.github/scripts/check_pr_template.py
+++ b/.github/scripts/check_pr_template.py
@@ -1,0 +1,37 @@
+import json
+import os
+import sys
+
+import requests
+
+MIN_DESCRIPTION_LENGTH = 50
+
+# Load the GitHub event data
+event_path = os.getenv("GITHUB_EVENT_PATH")
+assert event_path
+with open(event_path, "r") as f:
+    event_data = json.load(f)
+
+# Get the pull request number
+pr_number = event_data["pull_request"]["number"]
+repo = os.getenv("GITHUB_REPOSITORY")
+token = os.getenv("GITHUB_TOKEN")
+
+# GitHub API to get PR details
+url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+
+headers = {
+    "Authorization": f"token {token}",
+    "Accept": "application/vnd.github.v3+json",
+}
+
+response = requests.get(url, headers=headers)
+pr_data = response.json()
+pr_body = (pr_data.get("body") or "").strip()
+
+if len(pr_body) < MIN_DESCRIPTION_LENGTH:
+    print(f"ERROR: PR description must be at least {MIN_DESCRIPTION_LENGTH} characters (currently {len(pr_body)}).")
+    sys.exit(1)
+
+print(f"PR description is {len(pr_body)} characters. OK.")
+sys.exit(0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Set git to use LF
+        run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  pr-template:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate PR template
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pip install requests && python .github/scripts/check_pr_template.py
+
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION="8.28.0"
+          cd /tmp
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gitleaks.tar.gz
+          tar xzf gitleaks.tar.gz gitleaks
+          sudo mv gitleaks /usr/local/bin/
+          rm -f gitleaks.tar.gz
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --redact=10 --verbose
+
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: check

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,10 +18,12 @@ builds:
       - -X main.version={{.Version}}
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
   version_template: "{{ .Tag }}-next"


### PR DESCRIPTION
## Description

Adds GitHub Actions CI and PR template for heygen-cli. Six jobs run on every PR and main push, taking inspiration from [stripe/stripe-cli](https://github.com/stripe/stripe-cli) and our own experiment-framework CI:

- **test** — build + mocked tests on **ubuntu, macOS, and Windows** (cross-platform matrix from stripe-cli, catches path/permission/line-ending bugs)
- **lint** — golangci-lint
- **pr-template** — enforces 50+ char PR body (Python script, same pattern as experiment-framework)
- **secrets** — gitleaks CLI scan on git history (same install pattern as experiment-framework, free — no org license needed)
- **goreleaser-check** — validates `.goreleaser.yaml` config on PRs (from stripe-cli, catches broken release configs before tag push)

Also adds `.github/PULL_REQUEST_TEMPLATE` with Description and Testing sections, and fixes deprecated `archives.format` → `archives.formats` in `.goreleaser.yaml`.

Concurrency group cancels in-progress CI when a branch updates.

## Testing

CI self-validates on this PR — all 8 checks pass (3 platform tests + lint + pr-template + secrets + goreleaser-check + WIP).