### PR TITLE
client: add multipart form-data support for file uploads (PRINFRA-121)

### DIFF
--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/heygen-com/heygen-cli/internal/command"
@@ -20,10 +23,6 @@ import (
 // and behavioral flags (pagination, polling). The Invocation provides
 // the concrete path params, query params, body, and file path.
 func (c *Client) Execute(spec *command.Spec, inv *command.Invocation) (json.RawMessage, error) {
-	if spec.BodyEncoding == "multipart" {
-		return nil, clierrors.NewUsage("multipart upload is not yet implemented")
-	}
-
 	if spec.Method == "" {
 		return nil, clierrors.New("Spec.Method must be set")
 	}
@@ -34,19 +33,16 @@ func (c *Client) Execute(spec *command.Spec, inv *command.Invocation) (json.RawM
 		return nil, clierrors.New(fmt.Sprintf("failed to build request URL: %v", err))
 	}
 
-	// Build body — only if Invocation has body content
-	var body io.Reader
-	if inv.Body != nil {
-		data, marshalErr := json.Marshal(inv.Body)
-		if marshalErr != nil {
-			return nil, clierrors.New(fmt.Sprintf("failed to marshal request body: %v", marshalErr))
-		}
-		body = bytes.NewReader(data)
+	// Build request based on body encoding
+	var req *http.Request
+	switch spec.BodyEncoding {
+	case "multipart":
+		req, err = buildMultipartRequest(spec.Method, reqURL, inv.FilePath)
+	default:
+		req, err = buildJSONRequest(spec.Method, reqURL, inv.Body)
 	}
-
-	req, err := http.NewRequest(spec.Method, reqURL, body)
 	if err != nil {
-		return nil, clierrors.New(fmt.Sprintf("failed to create request: %v", err))
+		return nil, err
 	}
 
 	resp, err := c.Do(req)
@@ -94,6 +90,63 @@ func buildURL(base, endpoint string, pathParams map[string]string, queryParams u
 	}
 
 	return u.String(), nil
+}
+
+// buildJSONRequest creates an HTTP request with an optional JSON body.
+// If body is nil, no request body is sent (used by GET, DELETE, and bodyless POST endpoints).
+func buildJSONRequest(method, reqURL string, body map[string]any) (*http.Request, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, clierrors.New(fmt.Sprintf("failed to marshal request body: %v", err))
+		}
+		reader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, reqURL, reader)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to create request: %v", err))
+	}
+	return req, nil
+}
+
+// buildMultipartRequest creates an HTTP request with a multipart/form-data body
+// containing the file at the given path. The file is sent under the field name "file".
+func buildMultipartRequest(method, reqURL, filePath string) (*http.Request, error) {
+	if filePath == "" {
+		return nil, clierrors.New("file path is required for multipart upload")
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to open file %q: %v", filePath, err))
+	}
+	defer file.Close()
+
+	var requestBody bytes.Buffer
+	multipartWriter := multipart.NewWriter(&requestBody)
+
+	filePart, err := multipartWriter.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to create form file: %v", err))
+	}
+
+	if _, err := io.Copy(filePart, file); err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to write file to form: %v", err))
+	}
+
+	if err := multipartWriter.Close(); err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to close multipart writer: %v", err))
+	}
+
+	req, err := http.NewRequest(method, reqURL, &requestBody)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to create request: %v", err))
+	}
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+
+	return req, nil
 }
 
 // parseErrorResponse parses an API error response into a CLIError.

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -244,20 +245,108 @@ func TestExecute_NetworkError(t *testing.T) {
 	}
 }
 
-func TestExecute_MultipartNotImplemented(t *testing.T) {
+func TestExecute_MultipartUpload(t *testing.T) {
+	var gotContentType string
+	var gotFileContent string
+	var gotFileName string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("failed to get form file: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+		gotFileName = header.Filename
+		data, _ := io.ReadAll(file)
+		gotFileContent = string(data)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"asset_id":"asset_123"}}`))
+	}))
+	defer srv.Close()
+
+	// Create a temp file to upload
+	tmpFile, err := os.CreateTemp("", "test-upload-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	_, _ = tmpFile.WriteString("test file content")
+	tmpFile.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+
+	spec := &command.Spec{Endpoint: "/v3/assets", Method: "POST", BodyEncoding: "multipart"}
+	inv := &command.Invocation{
+		PathParams:  make(map[string]string),
+		QueryParams: make(url.Values),
+		FilePath:    tmpFile.Name(),
+	}
+
+	result, err := c.Execute(spec, inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify multipart content type
+	if !strings.Contains(gotContentType, "multipart/form-data") {
+		t.Errorf("Content-Type = %q, want multipart/form-data", gotContentType)
+	}
+
+	// Verify file was received
+	if gotFileContent != "test file content" {
+		t.Errorf("file content = %q, want %q", gotFileContent, "test file content")
+	}
+
+	// Verify filename is the base name
+	if !strings.HasPrefix(gotFileName, "test-upload-") {
+		t.Errorf("filename = %q, expected to start with test-upload-", gotFileName)
+	}
+
+	// Verify response
+	var parsed map[string]any
+	if jsonErr := json.Unmarshal(result, &parsed); jsonErr != nil {
+		t.Errorf("response is not valid JSON: %v", jsonErr)
+	}
+}
+
+func TestExecute_MultipartMissingFilePath(t *testing.T) {
 	c := New("key")
 
 	spec := &command.Spec{Endpoint: "/v3/assets", Method: "POST", BodyEncoding: "multipart"}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 
 	_, err := c.Execute(spec, inv)
+	if err == nil {
+		t.Fatal("expected error for missing file path, got nil")
+	}
 
 	var cliErr *clierrors.CLIError
 	if !errors.As(err, &cliErr) {
 		t.Fatalf("expected *CLIError, got %T: %v", err, err)
 	}
-	if cliErr.ExitCode != clierrors.ExitUsage {
-		t.Errorf("ExitCode = %d, want %d", cliErr.ExitCode, clierrors.ExitUsage)
+}
+
+func TestExecute_MultipartNonExistentFile(t *testing.T) {
+	c := New("key")
+
+	spec := &command.Spec{Endpoint: "/v3/assets", Method: "POST", BodyEncoding: "multipart"}
+	inv := &command.Invocation{
+		PathParams:  make(map[string]string),
+		QueryParams: make(url.Values),
+		FilePath:    "/tmp/nonexistent-file-abc123.txt",
+	}
+
+	_, err := c.Execute(spec, inv)
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T: %v", err, err)
 	}
 }
 


### PR DESCRIPTION
## Description

Teaches the HTTP executor to handle file uploads. When a Spec has `BodyEncoding: "multipart"`, the executor reads the file from `Invocation.FilePath`, wraps it in a `multipart/form-data` body, and sends it with the correct Content-Type boundary.

This enables the `asset upload` command (POST /v3/assets), which is the only multipart endpoint in the HeyGen v3 API. Without this, the executor would reject multipart requests with a usage error.

Error handling: missing file path and non-existent files both return clear error messages.

## Testing

3 new tests: successful multipart upload (verifies server receives correct form data, filename, and content), missing file path error, non-existent file error. All using httptest with a temp file.

## Files
- `internal/client/executor.go` — multipart/form-data body construction
- `internal/client/executor_test.go` — upload, missing file, non-existent file tests