### PR TITLE
fix(cmd): register generated commands as nested Cobra paths (PRINFRA-121)

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -64,10 +64,22 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 	return cmd
 }
 
-// buildUseLine constructs the Cobra Use string from the spec name and args.
-// Example: "get <video-id>" or "list"
+// commandPathParts splits a generated command path into nested Cobra tokens.
+// Example: "sessions messages create" -> ["sessions", "messages", "create"].
+func commandPathParts(spec *command.Spec) []string {
+	return strings.Fields(spec.Name)
+}
+
+// buildUseLine constructs the leaf Cobra Use string from the spec name and args.
+// Example: "create <video-id>" or "list".
 func buildUseLine(spec *command.Spec) string {
-	parts := []string{spec.Name}
+	path := commandPathParts(spec)
+	name := spec.Name
+	if len(path) > 0 {
+		name = path[len(path)-1]
+	}
+
+	parts := []string{name}
 	for _, arg := range spec.Args {
 		parts = append(parts, "<"+arg.Name+">")
 	}

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/heygen-com/heygen-cli/internal/command"
@@ -41,9 +43,8 @@ func TestGenBuilder_VideoList_Success(t *testing.T) {
 	})
 	defer srv.Close()
 
-	// Build a Cobra tree using the generic builder instead of hand-written newVideoListCmd
-	ctx := &cmdContext{formatter: nil} // will be set by runGenCommand
-	res := runGenCommand(t, srv.URL, "test-key", ctx, videoListSpec, "list")
+	// Build a Cobra tree using the generic builder instead of hand-written newVideoListCmd.
+	res := runGenCommand(t, srv.URL, "test-key", videoListSpec, "list")
 
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
@@ -84,8 +85,7 @@ func TestGenBuilder_VideoList_Flags(t *testing.T) {
 	})
 	defer srv.Close()
 
-	ctx := &cmdContext{}
-	res := runGenCommand(t, srv.URL, "test-key", ctx, videoListSpec,
+	res := runGenCommand(t, srv.URL, "test-key", videoListSpec,
 		"list", "--limit", "25", "--folder-id", "folder_abc", "--token", "cursor_xyz")
 
 	if res.ExitCode != 0 {
@@ -123,8 +123,7 @@ func TestGenBuilder_PostWithBodyFlags(t *testing.T) {
 		Examples: []string{"heygen webhook create --url https://example.com/hook"},
 	}
 
-	ctx := &cmdContext{}
-	res := runGenCommand(t, srv.URL, "test-key", ctx, spec,
+	res := runGenCommand(t, srv.URL, "test-key", spec,
 		"create", "--url", "https://example.com/hook", "--entity-id", "proj_456")
 
 	if res.ExitCode != 0 {
@@ -159,8 +158,7 @@ func TestGenBuilder_PathParam(t *testing.T) {
 		Examples: []string{"heygen video get abc123"},
 	}
 
-	ctx := &cmdContext{}
-	res := runGenCommand(t, srv.URL, "test-key", ctx, spec, "get", "abc123")
+	res := runGenCommand(t, srv.URL, "test-key", spec, "get", "abc123")
 
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
@@ -193,8 +191,7 @@ func TestGenBuilder_BodylessPost_NoBodySent(t *testing.T) {
 		Examples: []string{"heygen avatar create"},
 	}
 
-	ctx := &cmdContext{}
-	res := runGenCommand(t, srv.URL, "test-key", ctx, spec, "create")
+	res := runGenCommand(t, srv.URL, "test-key", spec, "create")
 
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
@@ -217,11 +214,177 @@ func TestGenBuilder_EnumValidation(t *testing.T) {
 		Examples: []string{"heygen voice list --type public"},
 	}
 
-	ctx := &cmdContext{}
-	res := runGenCommand(t, srv.URL, "test-key", ctx, spec, "list", "--type", "invalid")
+	res := runGenCommand(t, srv.URL, "test-key", spec, "list", "--type", "invalid")
 
 	if res.ExitCode != 2 {
 		t.Errorf("ExitCode = %d, want 2 (usage error)\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestGenBuilder_NestedCommand_Executes(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/voices/speech": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"speech_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &gotBody)
+			},
+		},
+	})
+	defer srv.Close()
+
+	spec := &command.Spec{
+		Group:        "voice",
+		Name:         "speech create",
+		Summary:      "Create speech audio",
+		Endpoint:     "/v3/voices/speech",
+		Method:       "POST",
+		BodyEncoding: "json",
+		Flags: []command.FlagSpec{
+			{Name: "text", Type: "string", Source: "body", JSONName: "text", Required: true},
+			{Name: "voice-id", Type: "string", Source: "body", JSONName: "voice_id", Required: true},
+		},
+		Examples: []string{"heygen voice speech create --text 'Hello world' --voice-id en_male"},
+	}
+
+	res := runGenCommand(t, srv.URL, "test-key", spec, "speech", "create",
+		"--text", "Hello world", "--voice-id", "en_male")
+
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if gotBody["text"] != "Hello world" {
+		t.Errorf("body.text = %v, want %q", gotBody["text"], "Hello world")
+	}
+	if gotBody["voice_id"] != "en_male" {
+		t.Errorf("body.voice_id = %v, want %q", gotBody["voice_id"], "en_male")
+	}
+}
+
+func TestGenBuilder_DeepNestedCommand_Executes(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/video-agents/sessions/sess_123/messages": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"msg_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &gotBody)
+			},
+		},
+	})
+	defer srv.Close()
+
+	spec := &command.Spec{
+		Group:        "video-agent",
+		Name:         "sessions messages create",
+		Summary:      "Create a session message",
+		Endpoint:     "/v3/video-agents/sessions/{session_id}/messages",
+		Method:       "POST",
+		BodyEncoding: "json",
+		Args: []command.ArgSpec{
+			{Name: "session-id", Param: "session_id"},
+		},
+		Flags: []command.FlagSpec{
+			{Name: "message", Type: "string", Source: "body", JSONName: "message", Required: true},
+		},
+		Examples: []string{"heygen video-agent sessions messages create <session-id> --message 'Add intro'"},
+	}
+
+	res := runGenCommand(t, srv.URL, "test-key", spec, "sessions", "messages", "create",
+		"sess_123", "--message", "Add intro")
+
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if gotBody["message"] != "Add intro" {
+		t.Errorf("body.message = %v, want %q", gotBody["message"], "Add intro")
+	}
+}
+
+func TestGenBuilder_IntermediateHelp_ShowsChildCommands(t *testing.T) {
+	spec := &command.Spec{
+		Group:        "voice",
+		Name:         "speech create",
+		Summary:      "Create speech audio",
+		Endpoint:     "/v3/voices/speech",
+		Method:       "POST",
+		BodyEncoding: "json",
+		Flags: []command.FlagSpec{
+			{Name: "text", Type: "string", Source: "body", JSONName: "text", Required: true},
+		},
+		Examples: []string{"heygen voice speech create --text 'Hello world'"},
+	}
+
+	res := runGeneratedRootCommand(t, "http://example.test", "test-key",
+		map[string][]*command.Spec{"voice": {spec}},
+		"voice", "speech", "--help")
+
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "Usage:\n  heygen voice speech [command]") {
+		t.Errorf("help missing nested usage\nstdout: %s", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, "Available Commands:") || !strings.Contains(res.Stdout, "create") {
+		t.Errorf("help missing child command listing\nstdout: %s", res.Stdout)
+	}
+	if strings.Contains(res.Stdout, "--text") {
+		t.Errorf("intermediate help should not show leaf flags\nstdout: %s", res.Stdout)
+	}
+}
+
+func TestGenBuilder_MultipartFileFlag_RoutesToInvocationFilePath(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "upload-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer tmpFile.Close()
+	if _, err := tmpFile.WriteString("hello upload"); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/assets": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"asset_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "multipart/form-data;") {
+					t.Errorf("Content-Type = %q, want multipart/form-data", got)
+				}
+				body, _ := io.ReadAll(r.Body)
+				if !strings.Contains(string(body), "hello upload") {
+					t.Errorf("multipart body missing file content: %q", string(body))
+				}
+			},
+		},
+	})
+	defer srv.Close()
+
+	spec := &command.Spec{
+		Group:        "asset",
+		Name:         "create",
+		Summary:      "Upload an asset",
+		Endpoint:     "/v3/assets",
+		Method:       "POST",
+		BodyEncoding: "multipart",
+		Flags: []command.FlagSpec{
+			{Name: "file", Type: "string", Source: "file", JSONName: "file", Required: true},
+		},
+		Examples: []string{"heygen asset create --file ./video.mp4"},
+	}
+
+	res := runGenCommand(t, srv.URL, "test-key", spec, "create", "--file", tmpFile.Name())
+
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
 }
 
@@ -231,7 +394,15 @@ func TestGenBuilder_EnumValidation(t *testing.T) {
 // It creates a fresh root command (with PersistentPreRunE that sets up the client)
 // and adds the spec-built command under a group. The cmdContext is shared between
 // PersistentPreRunE (which sets ctx.client) and the spec command (which uses it).
-func runGenCommand(t *testing.T, serverURL, apiKey string, _ *cmdContext, spec *command.Spec, args ...string) cmdResult {
+func runGenCommand(t *testing.T, serverURL, apiKey string, spec *command.Spec, args ...string) cmdResult {
+	t.Helper()
+
+	return runGeneratedRootCommand(t, serverURL, apiKey, map[string][]*command.Spec{
+		spec.Group: {spec},
+	}, append([]string{spec.Group}, args...)...)
+}
+
+func runGeneratedRootCommand(t *testing.T, serverURL, apiKey string, groups map[string][]*command.Spec, args ...string) cmdResult {
 	t.Helper()
 
 	var stdout, stderr bytes.Buffer
@@ -240,15 +411,10 @@ func runGenCommand(t *testing.T, serverURL, apiKey string, _ *cmdContext, spec *
 	t.Setenv("HEYGEN_API_KEY", apiKey)
 	t.Setenv("HEYGEN_API_BASE", serverURL)
 
-	// Build a root command that registers the spec via the generic builder.
-	// newRootCmdWithSpecs shares a cmdContext between PersistentPreRunE (which
-	// creates the HTTP client) and buildCobraCommand (which uses it in RunE).
-	root := newRootCmdWithSpecs("test", formatter, map[string][]*command.Spec{
-		spec.Group: {spec},
-	})
-
-	fullArgs := append([]string{spec.Group}, args...)
-	root.SetArgs(fullArgs)
+	root := newRootCmdWithSpecs("test", formatter, groups)
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(args)
 
 	err := root.Execute()
 
@@ -271,4 +437,3 @@ func runGenCommand(t *testing.T, serverURL, apiKey string, _ *cmdContext, spec *
 		ExitCode: exitCode,
 	}
 }
-

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/heygen-com/heygen-cli/internal/auth"
 	"github.com/heygen-com/heygen-cli/internal/client"
 	"github.com/heygen-com/heygen-cli/internal/command"
@@ -13,8 +15,8 @@ import (
 // cmdContext holds shared dependencies created in PersistentPreRunE
 // and consumed by child commands via closures.
 type cmdContext struct {
-	client    *client.Client
-	formatter output.Formatter
+	client         *client.Client
+	formatter      output.Formatter
 	configProvider config.Provider
 }
 
@@ -97,12 +99,53 @@ func newRootCmdWithSpecs(version string, formatter output.Formatter, groups map[
 
 	// Register spec-based commands grouped by name
 	for groupName, specs := range groups {
-		groupCmd := &cobra.Command{Use: groupName, Short: "Create and manage " + groupName + "s"}
+		groupCmd := &cobra.Command{Use: groupName, Short: humanizeCommandToken(groupName) + " commands"}
 		for _, spec := range specs {
-			groupCmd.AddCommand(buildCobraCommand(spec, ctx))
+			registerSpecCommand(groupCmd, spec, ctx)
 		}
 		root.AddCommand(groupCmd)
 	}
 
 	return root
+}
+
+func registerSpecCommand(groupCmd *cobra.Command, spec *command.Spec, ctx *cmdContext) {
+	path := commandPathParts(spec)
+	if len(path) == 0 {
+		groupCmd.AddCommand(buildCobraCommand(spec, ctx))
+		return
+	}
+
+	parent := groupCmd
+	for _, token := range path[:len(path)-1] {
+		parent = ensureIntermediateCommand(parent, token)
+	}
+
+	parent.AddCommand(buildCobraCommand(spec, ctx))
+}
+
+func ensureIntermediateCommand(parent *cobra.Command, token string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == token {
+			return child
+		}
+	}
+
+	child := &cobra.Command{
+		Use:   token,
+		Short: humanizeCommandToken(token) + " commands",
+	}
+	parent.AddCommand(child)
+	return child
+}
+
+func humanizeCommandToken(token string) string {
+	parts := strings.Split(token, "-")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
 }


### PR DESCRIPTION
## Description

Fixes a mismatch between how the codegen names commands and how the runtime registers them.

**The problem:** The codegen produces `command.Spec.Name` as a space-delimited path like `"speech create"` or `"sessions messages create"`. But the builder was registering this as a single Cobra command with `Use: "speech create"`. Cobra treats that as one command named `speech create` — so `heygen voice speech create` would fail with `accepts 0 arg(s), received 1`.

**The fix:** When registering a spec, split `Name` on spaces and create intermediate Cobra commands for each segment. `"sessions messages create"` becomes:

```
voice (group)
  └── sessions (intermediate, help-only)
        └── messages (intermediate, help-only)
              └── create (leaf, has flags/args/RunE)
```

Intermediate nodes are help-only grouping commands — no flags, no execution. Flags, args, examples, and RunE live only on the leaf.

**Key functions:**
- `registerSpecCommand` — walks the name path, creates intermediates via `ensureIntermediateCommand`, adds the leaf
- `commandPathParts` — splits `Spec.Name` into tokens
- `buildUseLine` — now uses only the last token for the leaf `Use` string
- `ensureIntermediateCommand` — finds or creates a child command by name, reuses existing nodes

## Testing

4 new tests:
- `TestGenBuilder_NestedCommand_Executes` — `voice speech create` sends correct body
- `TestGenBuilder_DeepNestedCommand_Executes` — `video-agent sessions messages create` at 3 levels deep
- `TestGenBuilder_IntermediateHelp_ShowsChildCommands` — `voice speech --help` shows `create` as child, no leaf flags leak
- `TestGenBuilder_MultipartFileFlag_RoutesToInvocationFilePath` — `asset create --file` routes to multipart

## Files
- `cmd/heygen/builder.go` — `commandPathParts`, `buildUseLine` uses last token only
- `cmd/heygen/builder_test.go` — 4 new tests, `runGenCommand` simplified (removed unused param), `runGeneratedRootCommand` added
- `cmd/heygen/root.go` — `registerSpecCommand`, `ensureIntermediateCommand`, `humanizeCommandToken`