### PR TITLE
config: add layered config commands (PRINFRA-141)

### DIFF
--- a/cmd/heygen/config_cmd.go
+++ b/cmd/heygen/config_cmd.go
@@ -57,7 +57,7 @@ func validateConfigValue(key, value string) error {
 		if value != "json" && value != "human" {
 			return clierrors.NewUsage("output must be one of: json, human")
 		}
-	case config.KeyAnalytics, config.KeyAutoUpdate:
+	case config.KeyAnalytics:
 		if value != "true" && value != "false" {
 			return clierrors.NewUsage(key + " must be one of: true, false")
 		}

--- a/cmd/heygen/config_cmd.go
+++ b/cmd/heygen/config_cmd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"slices"
 
 	"github.com/heygen-com/heygen-cli/internal/config"
@@ -61,11 +60,6 @@ func validateConfigValue(key, value string) error {
 	case config.KeyAnalytics, config.KeyAutoUpdate:
 		if value != "true" && value != "false" {
 			return clierrors.NewUsage(key + " must be one of: true, false")
-		}
-	case config.KeyAPIBase:
-		u, err := url.ParseRequestURI(value)
-		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			return clierrors.NewUsage("api_base must be a valid http or https URL")
 		}
 	}
 	return nil

--- a/cmd/heygen/config_cmd.go
+++ b/cmd/heygen/config_cmd.go
@@ -37,6 +37,14 @@ func configProviderWithSource(ctx *cmdContext) (config.ProviderWithSource, error
 	return provider, nil
 }
 
+func writableConfigProvider(ctx *cmdContext) (config.WritableProvider, error) {
+	provider, ok := ctx.configProvider.(config.WritableProvider)
+	if !ok {
+		return nil, clierrors.New("config provider does not support writes")
+	}
+	return provider, nil
+}
+
 func validateConfigKey(key string) error {
 	if !slices.Contains(config.ValidKeys, key) {
 		return clierrors.NewUsage(fmt.Sprintf("invalid config key %q", key))
@@ -87,11 +95,11 @@ func newConfigSetCmd(ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
-			provider, ok := ctx.configProvider.(*config.LayeredProvider)
-			if !ok {
-				return clierrors.New("config provider does not support writes")
+			provider, err := writableConfigProvider(ctx)
+			if err != nil {
+				return err
 			}
-			if err := provider.File.Set(key, value); err != nil {
+			if err := provider.Set(key, value); err != nil {
 				return clierrors.New(err.Error())
 			}
 

--- a/cmd/heygen/config_cmd.go
+++ b/cmd/heygen/config_cmd.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"slices"
+
+	"github.com/heygen-com/heygen-cli/internal/config"
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+type configResponse struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source,omitempty"`
+}
+
+func newConfigCmd(ctx *cmdContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "config",
+		Short:       "Manage CLI configuration",
+		Annotations: map[string]string{"skipAuth": "true"},
+	}
+	cmd.AddCommand(newConfigSetCmd(ctx))
+	cmd.AddCommand(newConfigGetCmd(ctx))
+	cmd.AddCommand(newConfigListCmd(ctx))
+	return cmd
+}
+
+func configProviderWithSource(ctx *cmdContext) (config.ProviderWithSource, error) {
+	provider, ok := ctx.configProvider.(config.ProviderWithSource)
+	if !ok {
+		return nil, clierrors.New("config provider does not expose value sources")
+	}
+	return provider, nil
+}
+
+func validateConfigKey(key string) error {
+	if !slices.Contains(config.ValidKeys, key) {
+		return clierrors.NewUsage(fmt.Sprintf("invalid config key %q", key))
+	}
+	return nil
+}
+
+func validateConfigValue(key, value string) error {
+	switch key {
+	case config.KeyOutput:
+		if value != "json" && value != "human" {
+			return clierrors.NewUsage("output must be one of: json, human")
+		}
+	case config.KeyAnalytics, config.KeyAutoUpdate:
+		if value != "true" && value != "false" {
+			return clierrors.NewUsage(key + " must be one of: true, false")
+		}
+	case config.KeyAPIBase:
+		u, err := url.ParseRequestURI(value)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return clierrors.NewUsage("api_base must be a valid http or https URL")
+		}
+	}
+	return nil
+}
+
+func marshalData(v any) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
+	}
+	return data, nil
+}
+
+func newConfigSetCmd(ctx *cmdContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a persistent config value",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			value := args[1]
+
+			if err := validateConfigKey(key); err != nil {
+				return err
+			}
+			if err := validateConfigValue(key, value); err != nil {
+				return err
+			}
+
+			provider, ok := ctx.configProvider.(*config.LayeredProvider)
+			if !ok {
+				return clierrors.New("config provider does not support writes")
+			}
+			if err := provider.File.Set(key, value); err != nil {
+				return clierrors.New(err.Error())
+			}
+
+			data, err := marshalData(configResponse{Key: key, Value: value})
+			if err != nil {
+				return err
+			}
+			return ctx.formatter.Data(data)
+		},
+	}
+}
+
+func newConfigGetCmd(ctx *cmdContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <key>",
+		Short: "Get a config value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			if err := validateConfigKey(key); err != nil {
+				return err
+			}
+
+			provider, err := configProviderWithSource(ctx)
+			if err != nil {
+				return err
+			}
+			source, err := provider.Resolve(key)
+			if err != nil {
+				return clierrors.New(err.Error())
+			}
+
+			data, err := marshalData(configResponse{
+				Key:    key,
+				Value:  source.Value,
+				Source: source.Origin,
+			})
+			if err != nil {
+				return err
+			}
+			return ctx.formatter.Data(data)
+		},
+	}
+}
+
+func newConfigListCmd(ctx *cmdContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List effective config values",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider, err := configProviderWithSource(ctx)
+			if err != nil {
+				return err
+			}
+
+			items := make([]configResponse, 0, len(config.ValidKeys))
+			for _, key := range config.ValidKeys {
+				source, err := provider.Resolve(key)
+				if err != nil {
+					return clierrors.New(err.Error())
+				}
+				items = append(items, configResponse{
+					Key:    key,
+					Value:  source.Value,
+					Source: source.Origin,
+				})
+			}
+
+			data, err := marshalData(items)
+			if err != nil {
+				return err
+			}
+			return ctx.formatter.Data(data)
+		},
+	}
+}

--- a/cmd/heygen/config_cmd_test.go
+++ b/cmd/heygen/config_cmd_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigSet_Success(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	res := runCommand(t, "http://example.invalid", "", "config", "set", "output", "human")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	data, err := os.ReadFile(filepath.Join(os.Getenv("HEYGEN_CONFIG_DIR"), "config.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) == "" {
+		t.Fatal("expected config file contents")
+	}
+}
+
+func TestConfigSet_InvalidKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	res := runCommand(t, "http://example.invalid", "", "config", "set", "bogus", "value")
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestConfigSet_InvalidOutputValue(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	res := runCommand(t, "http://example.invalid", "", "config", "set", "output", "xml")
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestConfigSet_SkipsAuth(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	res := runCommand(t, "http://example.invalid", "", "config", "set", "output", "human")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestConfigGet_Default(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	res := runCommand(t, "http://example.invalid", "", "config", "get", "output")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed configResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if parsed.Value != "json" || parsed.Source != "default" {
+		t.Fatalf("parsed = %#v", parsed)
+	}
+}
+
+func TestConfigGet_FromEnv(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_OUTPUT", "human")
+
+	res := runCommand(t, "http://example.invalid", "", "config", "get", "output")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed configResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if parsed.Value != "human" || parsed.Source != "env" {
+		t.Fatalf("parsed = %#v", parsed)
+	}
+}
+
+func TestConfigGet_FromFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	if err := os.WriteFile(filepath.Join(os.Getenv("HEYGEN_CONFIG_DIR"), "config.toml"), []byte("output = \"human\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	res := runCommand(t, "http://example.invalid", "", "config", "get", "output")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed configResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if parsed.Value != "human" || parsed.Source != "file" {
+		t.Fatalf("parsed = %#v", parsed)
+	}
+}
+
+func TestConfigGet_InvalidKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	res := runCommand(t, "http://example.invalid", "", "config", "get", "bogus")
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestConfigList_AllDefaults(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	res := runCommand(t, "http://example.invalid", "", "config", "list")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed []configResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(parsed) != 4 {
+		t.Fatalf("len(parsed) = %d, want 4", len(parsed))
+	}
+}
+
+func TestConfigList_MixedSources(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_OUTPUT", "json")
+	if err := os.WriteFile(filepath.Join(os.Getenv("HEYGEN_CONFIG_DIR"), "config.toml"), []byte("api_base = \"https://api-dev.heygen.com\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	res := runCommand(t, "http://example.invalid", "", "config", "list")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed []configResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(parsed) != 4 {
+		t.Fatalf("len(parsed) = %d, want 4", len(parsed))
+	}
+}

--- a/cmd/heygen/config_cmd_test.go
+++ b/cmd/heygen/config_cmd_test.go
@@ -32,6 +32,14 @@ func TestConfigSet_InvalidKey(t *testing.T) {
 	}
 }
 
+func TestConfigSet_APIBaseNotExposed(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	res := runCommand(t, "http://example.invalid", "", "config", "set", "api_base", "https://api-dev.heygen.com")
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2 (api_base is internal)\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
 func TestConfigSet_InvalidOutputValue(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 	res := runCommand(t, "http://example.invalid", "", "config", "set", "output", "xml")
@@ -121,7 +129,7 @@ func TestConfigList_AllDefaults(t *testing.T) {
 	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if len(parsed) != 4 {
+	if len(parsed) != 3 {
 		t.Fatalf("len(parsed) = %d, want 4", len(parsed))
 	}
 }
@@ -129,7 +137,7 @@ func TestConfigList_AllDefaults(t *testing.T) {
 func TestConfigList_MixedSources(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 	t.Setenv("HEYGEN_OUTPUT", "json")
-	if err := os.WriteFile(filepath.Join(os.Getenv("HEYGEN_CONFIG_DIR"), "config.toml"), []byte("api_base = \"https://api-dev.heygen.com\"\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(os.Getenv("HEYGEN_CONFIG_DIR"), "config.toml"), []byte("analytics = false\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -142,7 +150,7 @@ func TestConfigList_MixedSources(t *testing.T) {
 	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if len(parsed) != 4 {
+	if len(parsed) != 3 {
 		t.Fatalf("len(parsed) = %d, want 4", len(parsed))
 	}
 }

--- a/cmd/heygen/config_cmd_test.go
+++ b/cmd/heygen/config_cmd_test.go
@@ -129,7 +129,7 @@ func TestConfigList_AllDefaults(t *testing.T) {
 	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if len(parsed) != 3 {
+	if len(parsed) != 2 {
 		t.Fatalf("len(parsed) = %d, want 4", len(parsed))
 	}
 }
@@ -150,7 +150,7 @@ func TestConfigList_MixedSources(t *testing.T) {
 	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if len(parsed) != 3 {
+	if len(parsed) != 2 {
 		t.Fatalf("len(parsed) = %d, want 4", len(parsed))
 	}
 }

--- a/cmd/heygen/context.go
+++ b/cmd/heygen/context.go
@@ -30,7 +30,10 @@ func skipAuth(cmd *cobra.Command) bool {
 // initContext sets up the config provider and, for commands that require
 // auth, resolves credentials and creates the HTTP client.
 func initContext(cmd *cobra.Command, version string, ctx *cmdContext) error {
-	provider := &config.EnvProvider{}
+	provider := &config.LayeredProvider{
+		Env:  &config.EnvProvider{},
+		File: &config.FileProvider{},
+	}
 	ctx.configProvider = provider
 
 	if skipAuth(cmd) {

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -24,7 +24,6 @@ Environment Variables:
   HEYGEN_API_KEY            API key for authentication (overrides stored credentials)
   HEYGEN_OUTPUT             Output format: json, human (default: json)
   HEYGEN_NO_ANALYTICS       Disable analytics when set (default: enabled)
-  HEYGEN_NO_UPDATE_CHECK    Disable update check when set (default: enabled)
   HEYGEN_CONFIG_DIR         Override config directory (default: ~/.heygen)`,
 		Version:       version,
 		SilenceUsage:  true, // we handle usage errors ourselves

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -15,8 +15,18 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 	ctx := &cmdContext{formatter: formatter}
 
 	root := &cobra.Command{
-		Use:           "heygen",
-		Short:         "HeyGen CLI — create and manage videos, avatars, and more",
+		Use:   "heygen",
+		Short: "HeyGen CLI — create and manage videos, avatars, and more",
+		// NOTE: env var list is hardcoded. Keep in sync with envVarByKey in env_provider.go.
+		Long: `HeyGen CLI — create and manage videos, avatars, and more.
+
+Environment Variables:
+  HEYGEN_API_KEY            API key for authentication (overrides stored credentials)
+  HEYGEN_API_BASE           API base URL (default: https://api.heygen.com)
+  HEYGEN_OUTPUT             Output format: json, human (default: json)
+  HEYGEN_NO_ANALYTICS       Disable analytics when set to any non-empty value
+  HEYGEN_NO_UPDATE_CHECK    Disable update check when set to any non-empty value
+  HEYGEN_CONFIG_DIR         Override config directory (default: ~/.heygen)`,
 		Version:       version,
 		SilenceUsage:  true, // we handle usage errors ourselves
 		SilenceErrors: true, // we handle error output ourselves

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -22,10 +22,9 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 
 Environment Variables:
   HEYGEN_API_KEY            API key for authentication (overrides stored credentials)
-  HEYGEN_API_BASE           API base URL (default: https://api.heygen.com)
   HEYGEN_OUTPUT             Output format: json, human (default: json)
-  HEYGEN_NO_ANALYTICS       Disable analytics when set to any non-empty value
-  HEYGEN_NO_UPDATE_CHECK    Disable update check when set to any non-empty value
+  HEYGEN_NO_ANALYTICS       Disable analytics when set (default: enabled)
+  HEYGEN_NO_UPDATE_CHECK    Disable update check when set (default: enabled)
   HEYGEN_CONFIG_DIR         Override config directory (default: ~/.heygen)`,
 		Version:       version,
 		SilenceUsage:  true, // we handle usage errors ourselves

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -31,6 +31,7 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 	})
 
 	root.AddCommand(newAuthCmd(ctx))
+	root.AddCommand(newConfigCmd(ctx))
 	registerGroups(root, ctx, gen.Groups)
 
 	return root
@@ -58,6 +59,7 @@ func newRootCmdWithSpecs(version string, formatter output.Formatter, groups map[
 	})
 
 	root.AddCommand(newAuthCmd(ctx))
+	root.AddCommand(newConfigCmd(ctx))
 	registerGroups(root, ctx, groups)
 
 	return root

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/term v0.30.0
+require (
+	github.com/BurntSushi/toml v1.4.0
+	golang.org/x/term v0.30.0
+)
 
 require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,30 @@ package config
 // CLI flag > environment variable > config file > built-in default.
 //
 // Credentials are not part of config — see auth.CredentialResolver.
-// Currently only EnvProvider is implemented (reads HEYGEN_API_BASE env var).
 type Provider interface {
 	BaseURL() string
+	Output() string
+	Analytics() *bool
+	AutoUpdate() bool
 }
+
+// Source captures an effective config value and where it came from.
+type Source struct {
+	Value  string
+	Origin string
+}
+
+// ProviderWithSource exposes value origins for config inspection commands.
+type ProviderWithSource interface {
+	Provider
+	Resolve(key string) (Source, error)
+}
+
+const (
+	KeyOutput     = "output"
+	KeyAnalytics  = "analytics"
+	KeyAutoUpdate = "auto_update"
+	KeyAPIBase    = "api_base"
+)
+
+var ValidKeys = []string{KeyAPIBase, KeyAnalytics, KeyAutoUpdate, KeyOutput}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ package config
 type Provider interface {
 	BaseURL() string
 	Output() string
-	Analytics() *bool
+	Analytics() bool
 	AutoUpdate() bool
 }
 
@@ -32,7 +32,12 @@ const (
 	KeyOutput     = "output"
 	KeyAnalytics  = "analytics"
 	KeyAutoUpdate = "auto_update"
-	KeyAPIBase    = "api_base"
+
+	// KeyAPIBase is internal — settable via HEYGEN_API_BASE env var only,
+	// not exposed in config set/get/list.
+	KeyAPIBase = "api_base"
 )
 
-var ValidKeys = []string{KeyAPIBase, KeyAnalytics, KeyAutoUpdate, KeyOutput}
+// ValidKeys lists user-facing config keys exposed by config set/get/list.
+// api_base is intentionally excluded — it's an internal setting for dev/staging.
+var ValidKeys = []string{KeyAnalytics, KeyAutoUpdate, KeyOutput}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ type Provider interface {
 	BaseURL() string
 	Output() string
 	Analytics() bool
-	AutoUpdate() bool
 }
 
 // Source captures an effective config value and where it came from.
@@ -29,10 +28,9 @@ type WritableProvider interface {
 }
 
 const (
-	KeyOutput     = "output"
-	KeyAnalytics  = "analytics"
-	KeyAutoUpdate = "auto_update"
+	KeyOutput   = "output"
+	KeyAnalytics = "analytics"
 )
 
 // ValidKeys lists config keys exposed by config set/get/list.
-var ValidKeys = []string{KeyAnalytics, KeyAutoUpdate, KeyOutput}
+var ValidKeys = []string{KeyAnalytics, KeyOutput}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,12 +32,7 @@ const (
 	KeyOutput     = "output"
 	KeyAnalytics  = "analytics"
 	KeyAutoUpdate = "auto_update"
-
-	// KeyAPIBase is internal — settable via HEYGEN_API_BASE env var only,
-	// not exposed in config set/get/list.
-	KeyAPIBase = "api_base"
 )
 
-// ValidKeys lists user-facing config keys exposed by config set/get/list.
-// api_base is intentionally excluded — it's an internal setting for dev/staging.
+// ValidKeys lists config keys exposed by config set/get/list.
 var ValidKeys = []string{KeyAnalytics, KeyAutoUpdate, KeyOutput}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,11 @@ type ProviderWithSource interface {
 	Resolve(key string) (Source, error)
 }
 
+// WritableProvider persists configuration values.
+type WritableProvider interface {
+	Set(key, value string) error
+}
+
 const (
 	KeyOutput     = "output"
 	KeyAnalytics  = "analytics"

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -39,14 +39,9 @@ func (p *EnvProvider) Output() string {
 	return DefaultOutput
 }
 
-// Analytics returns false only when HEYGEN_NO_ANALYTICS is explicitly set.
-// Unset returns nil to preserve the consent-needed state.
-func (p *EnvProvider) Analytics() *bool {
-	if os.Getenv(envNoAnalytics) != "" {
-		v := false
-		return &v
-	}
-	return nil
+// Analytics returns false when HEYGEN_NO_ANALYTICS is set, true otherwise.
+func (p *EnvProvider) Analytics() bool {
+	return os.Getenv(envNoAnalytics) == ""
 }
 
 // AutoUpdate returns false only when HEYGEN_NO_UPDATE_CHECK is set.

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -3,18 +3,16 @@ package config
 import "os"
 
 const (
-	envOutput       = "HEYGEN_OUTPUT"
-	envNoAnalytics  = "HEYGEN_NO_ANALYTICS"
-	envNoAutoUpdate = "HEYGEN_NO_UPDATE_CHECK"
+	envOutput      = "HEYGEN_OUTPUT"
+	envNoAnalytics = "HEYGEN_NO_ANALYTICS"
 
 	DefaultBaseURL = "https://api.heygen.com"
 	DefaultOutput  = "json"
 )
 
 var envVarByKey = map[string]string{
-	KeyOutput:     envOutput,
-	KeyAnalytics:  envNoAnalytics,
-	KeyAutoUpdate: envNoAutoUpdate,
+	KeyOutput:    envOutput,
+	KeyAnalytics: envNoAnalytics,
 }
 
 // EnvProvider implements Provider by reading from environment variables.
@@ -41,11 +39,6 @@ func (p *EnvProvider) Output() string {
 // Analytics returns false when HEYGEN_NO_ANALYTICS is set, true otherwise.
 func (p *EnvProvider) Analytics() bool {
 	return os.Getenv(envNoAnalytics) == ""
-}
-
-// AutoUpdate returns false only when HEYGEN_NO_UPDATE_CHECK is set.
-func (p *EnvProvider) AutoUpdate() bool {
-	return os.Getenv(envNoAutoUpdate) == ""
 }
 
 // GetEnv reports whether the env var for a config key is explicitly set.

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -3,9 +3,13 @@ package config
 import "os"
 
 const (
-	envBaseURL = "HEYGEN_API_BASE"
+	envBaseURL      = "HEYGEN_API_BASE"
+	envOutput       = "HEYGEN_OUTPUT"
+	envNoAnalytics  = "HEYGEN_NO_ANALYTICS"
+	envNoAutoUpdate = "HEYGEN_NO_UPDATE_CHECK"
 
 	DefaultBaseURL = "https://api.heygen.com"
+	DefaultOutput  = "json"
 )
 
 // EnvProvider implements Provider by reading from environment variables.
@@ -18,4 +22,47 @@ func (p *EnvProvider) BaseURL() string {
 		return v
 	}
 	return DefaultBaseURL
+}
+
+// Output returns HEYGEN_OUTPUT if set, otherwise json.
+func (p *EnvProvider) Output() string {
+	if v := os.Getenv(envOutput); v != "" {
+		return v
+	}
+	return DefaultOutput
+}
+
+// Analytics returns false only when HEYGEN_NO_ANALYTICS is explicitly set.
+// Unset returns nil to preserve the consent-needed state.
+func (p *EnvProvider) Analytics() *bool {
+	if os.Getenv(envNoAnalytics) != "" {
+		v := false
+		return &v
+	}
+	return nil
+}
+
+// AutoUpdate returns false only when HEYGEN_NO_UPDATE_CHECK is set.
+func (p *EnvProvider) AutoUpdate() bool {
+	return os.Getenv(envNoAutoUpdate) == ""
+}
+
+// GetEnv reports whether the env var for a config key is explicitly set.
+func (p *EnvProvider) GetEnv(key string) (string, bool) {
+	switch key {
+	case KeyAPIBase:
+		val := os.Getenv(envBaseURL)
+		return val, val != ""
+	case KeyOutput:
+		val := os.Getenv(envOutput)
+		return val, val != ""
+	case KeyAnalytics:
+		val := os.Getenv(envNoAnalytics)
+		return val, val != ""
+	case KeyAutoUpdate:
+		val := os.Getenv(envNoAutoUpdate)
+		return val, val != ""
+	default:
+		return "", false
+	}
 }

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -3,7 +3,6 @@ package config
 import "os"
 
 const (
-	envBaseURL      = "HEYGEN_API_BASE"
 	envOutput       = "HEYGEN_OUTPUT"
 	envNoAnalytics  = "HEYGEN_NO_ANALYTICS"
 	envNoAutoUpdate = "HEYGEN_NO_UPDATE_CHECK"
@@ -13,7 +12,6 @@ const (
 )
 
 var envVarByKey = map[string]string{
-	KeyAPIBase:    envBaseURL,
 	KeyOutput:     envOutput,
 	KeyAnalytics:  envNoAnalytics,
 	KeyAutoUpdate: envNoAutoUpdate,
@@ -23,9 +21,10 @@ var envVarByKey = map[string]string{
 // Falls back to built-in defaults when a variable is not set.
 type EnvProvider struct{}
 
-// BaseURL returns HEYGEN_API_BASE if set, otherwise https://api.heygen.com.
+// BaseURL returns the API base URL. Reads HEYGEN_API_BASE if set (undocumented,
+// used by tests and internal dev only). Defaults to https://api.heygen.com.
 func (p *EnvProvider) BaseURL() string {
-	if v := os.Getenv(envBaseURL); v != "" {
+	if v := os.Getenv("HEYGEN_API_BASE"); v != "" {
 		return v
 	}
 	return DefaultBaseURL

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -12,6 +12,13 @@ const (
 	DefaultOutput  = "json"
 )
 
+var envVarByKey = map[string]string{
+	KeyAPIBase:    envBaseURL,
+	KeyOutput:     envOutput,
+	KeyAnalytics:  envNoAnalytics,
+	KeyAutoUpdate: envNoAutoUpdate,
+}
+
 // EnvProvider implements Provider by reading from environment variables.
 // Falls back to built-in defaults when a variable is not set.
 type EnvProvider struct{}
@@ -49,20 +56,11 @@ func (p *EnvProvider) AutoUpdate() bool {
 
 // GetEnv reports whether the env var for a config key is explicitly set.
 func (p *EnvProvider) GetEnv(key string) (string, bool) {
-	switch key {
-	case KeyAPIBase:
-		val := os.Getenv(envBaseURL)
-		return val, val != ""
-	case KeyOutput:
-		val := os.Getenv(envOutput)
-		return val, val != ""
-	case KeyAnalytics:
-		val := os.Getenv(envNoAnalytics)
-		return val, val != ""
-	case KeyAutoUpdate:
-		val := os.Getenv(envNoAutoUpdate)
-		return val, val != ""
-	default:
+	envVar, ok := envVarByKey[key]
+	if !ok {
 		return "", false
 	}
+
+	val := os.Getenv(envVar)
+	return val, val != ""
 }

--- a/internal/config/env_provider_test.go
+++ b/internal/config/env_provider_test.go
@@ -6,16 +6,9 @@ func TestEnvProvider_BaseURL(t *testing.T) {
 	p := &EnvProvider{}
 
 	t.Run("default", func(t *testing.T) {
-		t.Setenv(envBaseURL, "")
+		t.Setenv("HEYGEN_API_BASE", "")
 		if got := p.BaseURL(); got != DefaultBaseURL {
 			t.Fatalf("BaseURL = %q, want %q", got, DefaultBaseURL)
-		}
-	})
-
-	t.Run("custom", func(t *testing.T) {
-		t.Setenv(envBaseURL, "https://api-dev.heygen.com")
-		if got := p.BaseURL(); got != "https://api-dev.heygen.com" {
-			t.Fatalf("BaseURL = %q, want %q", got, "https://api-dev.heygen.com")
 		}
 	})
 }

--- a/internal/config/env_provider_test.go
+++ b/internal/config/env_provider_test.go
@@ -49,24 +49,6 @@ func TestEnvProvider_Analytics(t *testing.T) {
 	})
 }
 
-func TestEnvProvider_AutoUpdate(t *testing.T) {
-	p := &EnvProvider{}
-
-	t.Run("default", func(t *testing.T) {
-		t.Setenv(envNoAutoUpdate, "")
-		if got := p.AutoUpdate(); !got {
-			t.Fatal("AutoUpdate = false, want true")
-		}
-	})
-
-	t.Run("disabled", func(t *testing.T) {
-		t.Setenv(envNoAutoUpdate, "1")
-		if got := p.AutoUpdate(); got {
-			t.Fatal("AutoUpdate = true, want false")
-		}
-	})
-}
-
 func TestEnvProvider_GetEnv(t *testing.T) {
 	p := &EnvProvider{}
 	t.Setenv(envOutput, "human")

--- a/internal/config/env_provider_test.go
+++ b/internal/config/env_provider_test.go
@@ -1,0 +1,92 @@
+package config
+
+import "testing"
+
+func TestEnvProvider_BaseURL(t *testing.T) {
+	p := &EnvProvider{}
+
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(envBaseURL, "")
+		if got := p.BaseURL(); got != DefaultBaseURL {
+			t.Fatalf("BaseURL = %q, want %q", got, DefaultBaseURL)
+		}
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		t.Setenv(envBaseURL, "https://api-dev.heygen.com")
+		if got := p.BaseURL(); got != "https://api-dev.heygen.com" {
+			t.Fatalf("BaseURL = %q, want %q", got, "https://api-dev.heygen.com")
+		}
+	})
+}
+
+func TestEnvProvider_Output(t *testing.T) {
+	p := &EnvProvider{}
+
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(envOutput, "")
+		if got := p.Output(); got != DefaultOutput {
+			t.Fatalf("Output = %q, want %q", got, DefaultOutput)
+		}
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		t.Setenv(envOutput, "human")
+		if got := p.Output(); got != "human" {
+			t.Fatalf("Output = %q, want %q", got, "human")
+		}
+	})
+}
+
+func TestEnvProvider_Analytics(t *testing.T) {
+	p := &EnvProvider{}
+
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv(envNoAnalytics, "")
+		if got := p.Analytics(); got != nil {
+			t.Fatalf("Analytics = %v, want nil", *got)
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv(envNoAnalytics, "1")
+		got := p.Analytics()
+		if got == nil || *got {
+			t.Fatalf("Analytics = %v, want false", got)
+		}
+	})
+}
+
+func TestEnvProvider_AutoUpdate(t *testing.T) {
+	p := &EnvProvider{}
+
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(envNoAutoUpdate, "")
+		if got := p.AutoUpdate(); !got {
+			t.Fatal("AutoUpdate = false, want true")
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv(envNoAutoUpdate, "1")
+		if got := p.AutoUpdate(); got {
+			t.Fatal("AutoUpdate = true, want false")
+		}
+	})
+}
+
+func TestEnvProvider_GetEnv(t *testing.T) {
+	p := &EnvProvider{}
+	t.Setenv(envOutput, "human")
+	t.Setenv(envNoAnalytics, "1")
+
+	if val, ok := p.GetEnv(KeyOutput); !ok || val != "human" {
+		t.Fatalf("GetEnv(output) = (%q, %v), want (%q, true)", val, ok, "human")
+	}
+	if val, ok := p.GetEnv(KeyAnalytics); !ok || val != "1" {
+		t.Fatalf("GetEnv(analytics) = (%q, %v), want (%q, true)", val, ok, "1")
+	}
+	if _, ok := p.GetEnv("bogus"); ok {
+		t.Fatal("expected bogus key lookup to report unset")
+	}
+}

--- a/internal/config/env_provider_test.go
+++ b/internal/config/env_provider_test.go
@@ -41,18 +41,17 @@ func TestEnvProvider_Output(t *testing.T) {
 func TestEnvProvider_Analytics(t *testing.T) {
 	p := &EnvProvider{}
 
-	t.Run("unset", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
 		t.Setenv(envNoAnalytics, "")
-		if got := p.Analytics(); got != nil {
-			t.Fatalf("Analytics = %v, want nil", *got)
+		if got := p.Analytics(); !got {
+			t.Fatal("Analytics = false, want true")
 		}
 	})
 
 	t.Run("disabled", func(t *testing.T) {
 		t.Setenv(envNoAnalytics, "1")
-		got := p.Analytics()
-		if got == nil || *got {
-			t.Fatalf("Analytics = %v, want false", got)
+		if got := p.Analytics(); got {
+			t.Fatal("Analytics = true, want false")
 		}
 	})
 }

--- a/internal/config/file_provider.go
+++ b/internal/config/file_provider.go
@@ -74,7 +74,7 @@ func (p *FileProvider) Set(key, value string) error {
 
 func coerceValue(key, value string) any {
 	switch key {
-	case KeyAnalytics, KeyAutoUpdate:
+	case KeyAnalytics:
 		return value == "true"
 	default:
 		return value

--- a/internal/config/file_provider.go
+++ b/internal/config/file_provider.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/heygen-com/heygen-cli/internal/paths"
+)
+
+// FileProvider reads and writes persisted CLI configuration.
+type FileProvider struct{}
+
+func (p *FileProvider) load() (map[string]any, error) {
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	var data map[string]any
+	_, err := toml.DecodeFile(path, &data)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("cannot read config file %s: %w", path, err)
+	}
+
+	return data, nil
+}
+
+// Get reads a single key from config.toml.
+func (p *FileProvider) Get(key string) (string, bool, error) {
+	data, err := p.load()
+	if err != nil {
+		return "", false, err
+	}
+	if data == nil {
+		return "", false, nil
+	}
+
+	v, ok := data[key]
+	if !ok {
+		return "", false, nil
+	}
+
+	return fmt.Sprintf("%v", v), true, nil
+}
+
+// Set writes a key-value pair to config.toml, preserving existing keys.
+func (p *FileProvider) Set(key, value string) error {
+	data, err := p.load()
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		data = make(map[string]any)
+	}
+
+	dir := paths.ConfigDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	data[key] = coerceValue(key, value)
+
+	path := filepath.Join(dir, "config.toml")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open config file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	return toml.NewEncoder(f).Encode(data)
+}
+
+func coerceValue(key, value string) any {
+	switch key {
+	case KeyAnalytics, KeyAutoUpdate:
+		return value == "true"
+	default:
+		return value
+	}
+}
+
+// GetAll returns all keys from config.toml.
+func (p *FileProvider) GetAll() (map[string]string, error) {
+	data, err := p.load()
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+
+	result := make(map[string]string, len(data))
+	for k, v := range data {
+		result[k] = fmt.Sprintf("%v", v)
+	}
+	return result, nil
+}

--- a/internal/config/file_provider.go
+++ b/internal/config/file_provider.go
@@ -80,20 +80,3 @@ func coerceValue(key, value string) any {
 		return value
 	}
 }
-
-// GetAll returns all keys from config.toml.
-func (p *FileProvider) GetAll() (map[string]string, error) {
-	data, err := p.load()
-	if err != nil {
-		return nil, err
-	}
-	if data == nil {
-		return nil, nil
-	}
-
-	result := make(map[string]string, len(data))
-	for k, v := range data {
-		result[k] = fmt.Sprintf("%v", v)
-	}
-	return result, nil
-}

--- a/internal/config/file_provider_test.go
+++ b/internal/config/file_provider_test.go
@@ -94,15 +94,22 @@ func TestFileProvider_SetUpdateExisting(t *testing.T) {
 		t.Fatalf("Set: %v", err)
 	}
 
-	all, err := p.GetAll()
+	// Verify the original key is preserved
+	val, ok, err := p.Get(KeyOutput)
 	if err != nil {
-		t.Fatalf("GetAll: %v", err)
+		t.Fatalf("Get output: %v", err)
 	}
-	if all[KeyOutput] != "json" {
-		t.Fatalf("output = %q, want %q", all[KeyOutput], "json")
+	if !ok || val != "json" {
+		t.Fatalf("output = (%q, %v), want (%q, true)", val, ok, "json")
 	}
-	if all[KeyAnalytics] != "false" {
-		t.Fatalf("analytics = %q, want %q", all[KeyAnalytics], "false")
+
+	// Verify the new key was written
+	val, ok, err = p.Get(KeyAnalytics)
+	if err != nil {
+		t.Fatalf("Get analytics: %v", err)
+	}
+	if !ok || val != "false" {
+		t.Fatalf("analytics = (%q, %v), want (%q, true)", val, ok, "false")
 	}
 }
 
@@ -162,34 +169,3 @@ func TestFileProvider_SetStringType(t *testing.T) {
 	}
 }
 
-func TestFileProvider_GetAll(t *testing.T) {
-	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	p := &FileProvider{}
-	if err := p.Set(KeyOutput, "human"); err != nil {
-		t.Fatalf("Set output: %v", err)
-	}
-	if err := p.Set(KeyAnalytics, "false"); err != nil {
-		t.Fatalf("Set analytics: %v", err)
-	}
-
-	all, err := p.GetAll()
-	if err != nil {
-		t.Fatalf("GetAll: %v", err)
-	}
-	if all[KeyOutput] != "human" || all[KeyAnalytics] != "false" {
-		t.Fatalf("GetAll = %#v", all)
-	}
-}
-
-func TestFileProvider_GetAllCorruptFile(t *testing.T) {
-	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	path := filepath.Join(paths.ConfigDir(), "config.toml")
-	if err := os.WriteFile(path, []byte("bad = [toml\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	p := &FileProvider{}
-	if _, err := p.GetAll(); err == nil {
-		t.Fatal("expected corrupt file error")
-	}
-}

--- a/internal/config/file_provider_test.go
+++ b/internal/config/file_provider_test.go
@@ -34,7 +34,7 @@ func TestFileProvider_GetMissing(t *testing.T) {
 	}
 
 	p := &FileProvider{}
-	_, ok, err := p.Get(KeyAPIBase)
+	_, ok, err := p.Get(KeyAutoUpdate)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestFileProvider_SetUpdateExisting(t *testing.T) {
 	}
 
 	p := &FileProvider{}
-	if err := p.Set(KeyAPIBase, "https://api-dev.heygen.com"); err != nil {
+	if err := p.Set(KeyAnalytics, "false"); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
 
@@ -101,8 +101,8 @@ func TestFileProvider_SetUpdateExisting(t *testing.T) {
 	if all[KeyOutput] != "json" {
 		t.Fatalf("output = %q, want %q", all[KeyOutput], "json")
 	}
-	if all[KeyAPIBase] != "https://api-dev.heygen.com" {
-		t.Fatalf("api_base = %q, want %q", all[KeyAPIBase], "https://api-dev.heygen.com")
+	if all[KeyAnalytics] != "false" {
+		t.Fatalf("analytics = %q, want %q", all[KeyAnalytics], "false")
 	}
 }
 

--- a/internal/config/file_provider_test.go
+++ b/internal/config/file_provider_test.go
@@ -34,7 +34,7 @@ func TestFileProvider_GetMissing(t *testing.T) {
 	}
 
 	p := &FileProvider{}
-	_, ok, err := p.Get(KeyAutoUpdate)
+	_, ok, err := p.Get(KeyAnalytics)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -168,15 +168,15 @@ func TestFileProvider_GetAll(t *testing.T) {
 	if err := p.Set(KeyOutput, "human"); err != nil {
 		t.Fatalf("Set output: %v", err)
 	}
-	if err := p.Set(KeyAutoUpdate, "false"); err != nil {
-		t.Fatalf("Set auto_update: %v", err)
+	if err := p.Set(KeyAnalytics, "false"); err != nil {
+		t.Fatalf("Set analytics: %v", err)
 	}
 
 	all, err := p.GetAll()
 	if err != nil {
 		t.Fatalf("GetAll: %v", err)
 	}
-	if all[KeyOutput] != "human" || all[KeyAutoUpdate] != "false" {
+	if all[KeyOutput] != "human" || all[KeyAnalytics] != "false" {
 		t.Fatalf("GetAll = %#v", all)
 	}
 }

--- a/internal/config/file_provider_test.go
+++ b/internal/config/file_provider_test.go
@@ -1,0 +1,195 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/heygen-com/heygen-cli/internal/paths"
+)
+
+func TestFileProvider_GetExists(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("output = \"human\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p := &FileProvider{}
+	val, ok, err := p.Get(KeyOutput)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok || val != "human" {
+		t.Fatalf("Get = (%q, %v), want (%q, true)", val, ok, "human")
+	}
+}
+
+func TestFileProvider_GetMissing(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("output = \"human\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p := &FileProvider{}
+	_, ok, err := p.Get(KeyAPIBase)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ok {
+		t.Fatal("expected missing key")
+	}
+}
+
+func TestFileProvider_GetNoFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := &FileProvider{}
+
+	_, ok, err := p.Get(KeyOutput)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no value")
+	}
+}
+
+func TestFileProvider_GetCorruptFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("not = [valid\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p := &FileProvider{}
+	if _, _, err := p.Get(KeyOutput); err == nil {
+		t.Fatal("expected corrupt file error")
+	}
+}
+
+func TestFileProvider_SetNewFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := &FileProvider{}
+
+	if err := p.Set(KeyOutput, "human"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(paths.ConfigDir(), "config.toml")); err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+}
+
+func TestFileProvider_SetUpdateExisting(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("output = \"json\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p := &FileProvider{}
+	if err := p.Set(KeyAPIBase, "https://api-dev.heygen.com"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	all, err := p.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if all[KeyOutput] != "json" {
+		t.Fatalf("output = %q, want %q", all[KeyOutput], "json")
+	}
+	if all[KeyAPIBase] != "https://api-dev.heygen.com" {
+		t.Fatalf("api_base = %q, want %q", all[KeyAPIBase], "https://api-dev.heygen.com")
+	}
+}
+
+func TestFileProvider_SetOverwriteKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := &FileProvider{}
+
+	if err := p.Set(KeyOutput, "json"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := p.Set(KeyOutput, "human"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	val, ok, err := p.Get(KeyOutput)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok || val != "human" {
+		t.Fatalf("Get = (%q, %v), want (%q, true)", val, ok, "human")
+	}
+}
+
+func TestFileProvider_SetBooleanType(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := &FileProvider{}
+
+	if err := p.Set(KeyAnalytics, "false"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	var data map[string]any
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if _, err := toml.DecodeFile(path, &data); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	if _, ok := data[KeyAnalytics].(bool); !ok {
+		t.Fatalf("analytics type = %T, want bool", data[KeyAnalytics])
+	}
+}
+
+func TestFileProvider_SetStringType(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := &FileProvider{}
+
+	if err := p.Set(KeyOutput, "human"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	var data map[string]any
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if _, err := toml.DecodeFile(path, &data); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	if _, ok := data[KeyOutput].(string); !ok {
+		t.Fatalf("output type = %T, want string", data[KeyOutput])
+	}
+}
+
+func TestFileProvider_GetAll(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := &FileProvider{}
+	if err := p.Set(KeyOutput, "human"); err != nil {
+		t.Fatalf("Set output: %v", err)
+	}
+	if err := p.Set(KeyAutoUpdate, "false"); err != nil {
+		t.Fatalf("Set auto_update: %v", err)
+	}
+
+	all, err := p.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if all[KeyOutput] != "human" || all[KeyAutoUpdate] != "false" {
+		t.Fatalf("GetAll = %#v", all)
+	}
+}
+
+func TestFileProvider_GetAllCorruptFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("bad = [toml\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p := &FileProvider{}
+	if _, err := p.GetAll(); err == nil {
+		t.Fatal("expected corrupt file error")
+	}
+}

--- a/internal/config/layered_provider.go
+++ b/internal/config/layered_provider.go
@@ -21,19 +21,37 @@ func defaultFor(key string) string {
 	}
 }
 
+func (p *LayeredProvider) envSource(key string) (Source, bool) {
+	if _, ok := p.Env.GetEnv(key); !ok {
+		return Source{}, false
+	}
+
+	switch key {
+	case KeyAnalytics:
+		return Source{Value: "false", Origin: "env"}, true
+	case KeyAutoUpdate:
+		return Source{Value: "false", Origin: "env"}, true
+	case KeyAPIBase:
+		return Source{Value: p.Env.BaseURL(), Origin: "env"}, true
+	case KeyOutput:
+		return Source{Value: p.Env.Output(), Origin: "env"}, true
+	default:
+		return Source{}, false
+	}
+}
+
+func (p *LayeredProvider) resolvedValue(key, fallback string) string {
+	source, err := p.Resolve(key)
+	if err != nil {
+		return fallback
+	}
+	return source.Value
+}
+
 // Resolve returns the effective value and its origin.
 func (p *LayeredProvider) Resolve(key string) (Source, error) {
-	if _, ok := p.Env.GetEnv(key); ok {
-		switch key {
-		case KeyAnalytics:
-			return Source{Value: "false", Origin: "env"}, nil
-		case KeyAutoUpdate:
-			return Source{Value: "false", Origin: "env"}, nil
-		case KeyAPIBase:
-			return Source{Value: p.Env.BaseURL(), Origin: "env"}, nil
-		case KeyOutput:
-			return Source{Value: p.Env.Output(), Origin: "env"}, nil
-		}
+	if source, ok := p.envSource(key); ok {
+		return source, nil
 	}
 
 	val, ok, err := p.File.Get(key)
@@ -48,40 +66,28 @@ func (p *LayeredProvider) Resolve(key string) (Source, error) {
 }
 
 func (p *LayeredProvider) BaseURL() string {
-	source, err := p.Resolve(KeyAPIBase)
-	if err != nil {
-		return DefaultBaseURL
-	}
-	return source.Value
+	return p.resolvedValue(KeyAPIBase, DefaultBaseURL)
 }
 
 func (p *LayeredProvider) Output() string {
-	source, err := p.Resolve(KeyOutput)
-	if err != nil {
-		return DefaultOutput
-	}
-	return source.Value
+	return p.resolvedValue(KeyOutput, DefaultOutput)
 }
 
 func (p *LayeredProvider) Analytics() *bool {
-	if _, ok := p.Env.GetEnv(KeyAnalytics); ok {
-		v := false
-		return &v
-	}
-
-	val, ok, err := p.File.Get(KeyAnalytics)
-	if err != nil || !ok {
+	source, err := p.Resolve(KeyAnalytics)
+	if err != nil || source.Origin == "default" {
 		return nil
 	}
 
-	v := val == "true"
+	v := source.Value == "true"
 	return &v
 }
 
 func (p *LayeredProvider) AutoUpdate() bool {
-	source, err := p.Resolve(KeyAutoUpdate)
-	if err != nil {
-		return true
-	}
-	return source.Value == "true"
+	return p.resolvedValue(KeyAutoUpdate, "true") == "true"
+}
+
+// Set persists a configuration value via the file provider.
+func (p *LayeredProvider) Set(key, value string) error {
+	return p.File.Set(key, value)
 }

--- a/internal/config/layered_provider.go
+++ b/internal/config/layered_provider.go
@@ -12,8 +12,6 @@ func defaultFor(key string) string {
 		return DefaultOutput
 	case KeyAnalytics:
 		return "true"
-	case KeyAutoUpdate:
-		return "true"
 	default:
 		return ""
 	}
@@ -26,8 +24,6 @@ func (p *LayeredProvider) envSource(key string) (Source, bool) {
 
 	switch key {
 	case KeyAnalytics:
-		return Source{Value: "false", Origin: "env"}, true
-	case KeyAutoUpdate:
 		return Source{Value: "false", Origin: "env"}, true
 	case KeyOutput:
 		return Source{Value: p.Env.Output(), Origin: "env"}, true
@@ -71,10 +67,6 @@ func (p *LayeredProvider) Output() string {
 
 func (p *LayeredProvider) Analytics() bool {
 	return p.resolvedValue(KeyAnalytics, "true") == "true"
-}
-
-func (p *LayeredProvider) AutoUpdate() bool {
-	return p.resolvedValue(KeyAutoUpdate, "true") == "true"
 }
 
 // Set persists a configuration value via the file provider.

--- a/internal/config/layered_provider.go
+++ b/internal/config/layered_provider.go
@@ -1,0 +1,87 @@
+package config
+
+// LayeredProvider resolves config values via env > file > default precedence.
+type LayeredProvider struct {
+	Env  *EnvProvider
+	File *FileProvider
+}
+
+func defaultFor(key string) string {
+	switch key {
+	case KeyAPIBase:
+		return DefaultBaseURL
+	case KeyOutput:
+		return DefaultOutput
+	case KeyAnalytics:
+		return "unset"
+	case KeyAutoUpdate:
+		return "true"
+	default:
+		return ""
+	}
+}
+
+// Resolve returns the effective value and its origin.
+func (p *LayeredProvider) Resolve(key string) (Source, error) {
+	if _, ok := p.Env.GetEnv(key); ok {
+		switch key {
+		case KeyAnalytics:
+			return Source{Value: "false", Origin: "env"}, nil
+		case KeyAutoUpdate:
+			return Source{Value: "false", Origin: "env"}, nil
+		case KeyAPIBase:
+			return Source{Value: p.Env.BaseURL(), Origin: "env"}, nil
+		case KeyOutput:
+			return Source{Value: p.Env.Output(), Origin: "env"}, nil
+		}
+	}
+
+	val, ok, err := p.File.Get(key)
+	if err != nil {
+		return Source{}, err
+	}
+	if ok {
+		return Source{Value: val, Origin: "file"}, nil
+	}
+
+	return Source{Value: defaultFor(key), Origin: "default"}, nil
+}
+
+func (p *LayeredProvider) BaseURL() string {
+	source, err := p.Resolve(KeyAPIBase)
+	if err != nil {
+		return DefaultBaseURL
+	}
+	return source.Value
+}
+
+func (p *LayeredProvider) Output() string {
+	source, err := p.Resolve(KeyOutput)
+	if err != nil {
+		return DefaultOutput
+	}
+	return source.Value
+}
+
+func (p *LayeredProvider) Analytics() *bool {
+	if _, ok := p.Env.GetEnv(KeyAnalytics); ok {
+		v := false
+		return &v
+	}
+
+	val, ok, err := p.File.Get(KeyAnalytics)
+	if err != nil || !ok {
+		return nil
+	}
+
+	v := val == "true"
+	return &v
+}
+
+func (p *LayeredProvider) AutoUpdate() bool {
+	source, err := p.Resolve(KeyAutoUpdate)
+	if err != nil {
+		return true
+	}
+	return source.Value == "true"
+}

--- a/internal/config/layered_provider.go
+++ b/internal/config/layered_provider.go
@@ -8,8 +8,6 @@ type LayeredProvider struct {
 
 func defaultFor(key string) string {
 	switch key {
-	case KeyAPIBase:
-		return DefaultBaseURL
 	case KeyOutput:
 		return DefaultOutput
 	case KeyAnalytics:
@@ -31,8 +29,6 @@ func (p *LayeredProvider) envSource(key string) (Source, bool) {
 		return Source{Value: "false", Origin: "env"}, true
 	case KeyAutoUpdate:
 		return Source{Value: "false", Origin: "env"}, true
-	case KeyAPIBase:
-		return Source{Value: p.Env.BaseURL(), Origin: "env"}, true
 	case KeyOutput:
 		return Source{Value: p.Env.Output(), Origin: "env"}, true
 	default:
@@ -66,7 +62,7 @@ func (p *LayeredProvider) Resolve(key string) (Source, error) {
 }
 
 func (p *LayeredProvider) BaseURL() string {
-	return p.resolvedValue(KeyAPIBase, DefaultBaseURL)
+	return p.Env.BaseURL()
 }
 
 func (p *LayeredProvider) Output() string {

--- a/internal/config/layered_provider.go
+++ b/internal/config/layered_provider.go
@@ -13,7 +13,7 @@ func defaultFor(key string) string {
 	case KeyOutput:
 		return DefaultOutput
 	case KeyAnalytics:
-		return "unset"
+		return "true"
 	case KeyAutoUpdate:
 		return "true"
 	default:
@@ -73,14 +73,8 @@ func (p *LayeredProvider) Output() string {
 	return p.resolvedValue(KeyOutput, DefaultOutput)
 }
 
-func (p *LayeredProvider) Analytics() *bool {
-	source, err := p.Resolve(KeyAnalytics)
-	if err != nil || source.Origin == "default" {
-		return nil
-	}
-
-	v := source.Value == "true"
-	return &v
+func (p *LayeredProvider) Analytics() bool {
+	return p.resolvedValue(KeyAnalytics, "true") == "true"
 }
 
 func (p *LayeredProvider) AutoUpdate() bool {

--- a/internal/config/layered_provider_test.go
+++ b/internal/config/layered_provider_test.go
@@ -28,9 +28,8 @@ func TestLayeredProvider_DefaultValues(t *testing.T) {
 	p := newLayeredProvider()
 
 	cases := map[string]string{
-		KeyOutput:     DefaultOutput,
-		KeyAutoUpdate: "true",
-		KeyAnalytics:  "true",
+		KeyOutput:    DefaultOutput,
+		KeyAnalytics: "true",
 	}
 	for key, want := range cases {
 		got, err := p.Resolve(key)
@@ -88,13 +87,12 @@ func TestLayeredProvider_EnvOverridesFile(t *testing.T) {
 
 func TestLayeredProvider_ResolveAllKeys(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	writeConfigFile(t, "output = \"human\"\nauto_update = false\nanalytics = false\n")
+	writeConfigFile(t, "output = \"human\"\nanalytics = false\n")
 	p := newLayeredProvider()
 
 	cases := map[string]string{
-		KeyOutput:     "human",
-		KeyAutoUpdate: "false",
-		KeyAnalytics:  "false",
+		KeyOutput:    "human",
+		KeyAnalytics: "false",
 	}
 	for key, want := range cases {
 		got, err := p.Resolve(key)

--- a/internal/config/layered_provider_test.go
+++ b/internal/config/layered_provider_test.go
@@ -31,7 +31,7 @@ func TestLayeredProvider_DefaultValues(t *testing.T) {
 		KeyOutput:     DefaultOutput,
 		KeyAutoUpdate: "true",
 		KeyAPIBase:    DefaultBaseURL,
-		KeyAnalytics:  "unset",
+		KeyAnalytics:  "true",
 	}
 	for key, want := range cases {
 		got, err := p.Resolve(key)
@@ -108,23 +108,22 @@ func TestLayeredProvider_ResolveAllKeys(t *testing.T) {
 	}
 }
 
-func TestLayeredProvider_AnalyticsUnset(t *testing.T) {
+func TestLayeredProvider_AnalyticsDefault(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 	p := newLayeredProvider()
 
-	if got := p.Analytics(); got != nil {
-		t.Fatalf("Analytics = %v, want nil", *got)
+	if got := p.Analytics(); !got {
+		t.Fatal("Analytics = false, want true")
 	}
 }
 
 func TestLayeredProvider_AnalyticsFromFile(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	writeConfigFile(t, "analytics = true\n")
+	writeConfigFile(t, "analytics = false\n")
 	p := newLayeredProvider()
 
-	got := p.Analytics()
-	if got == nil || !*got {
-		t.Fatalf("Analytics = %v, want true", got)
+	if got := p.Analytics(); got {
+		t.Fatal("Analytics = true, want false")
 	}
 }
 
@@ -134,8 +133,7 @@ func TestLayeredProvider_AnalyticsEnvDisable(t *testing.T) {
 	writeConfigFile(t, "analytics = true\n")
 	p := newLayeredProvider()
 
-	got := p.Analytics()
-	if got == nil || *got {
-		t.Fatalf("Analytics = %v, want false", got)
+	if got := p.Analytics(); got {
+		t.Fatal("Analytics = true, want false (env overrides file)")
 	}
 }

--- a/internal/config/layered_provider_test.go
+++ b/internal/config/layered_provider_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/heygen-com/heygen-cli/internal/paths"
+)
+
+func newLayeredProvider() *LayeredProvider {
+	return &LayeredProvider{
+		Env:  &EnvProvider{},
+		File: &FileProvider{},
+	}
+}
+
+func writeConfigFile(t *testing.T, body string) {
+	t.Helper()
+	path := filepath.Join(paths.ConfigDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestLayeredProvider_DefaultValues(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := newLayeredProvider()
+
+	cases := map[string]string{
+		KeyOutput:     DefaultOutput,
+		KeyAutoUpdate: "true",
+		KeyAPIBase:    DefaultBaseURL,
+		KeyAnalytics:  "unset",
+	}
+	for key, want := range cases {
+		got, err := p.Resolve(key)
+		if err != nil {
+			t.Fatalf("Resolve(%s): %v", key, err)
+		}
+		if got.Value != want || got.Origin != "default" {
+			t.Fatalf("Resolve(%s) = %#v, want value=%q origin=default", key, got, want)
+		}
+	}
+}
+
+func TestLayeredProvider_EnvOverridesDefault(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv(envOutput, "human")
+	p := newLayeredProvider()
+
+	got, err := p.Resolve(KeyOutput)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Value != "human" || got.Origin != "env" {
+		t.Fatalf("Resolve = %#v", got)
+	}
+}
+
+func TestLayeredProvider_FileOverridesDefault(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeConfigFile(t, "output = \"human\"\n")
+	p := newLayeredProvider()
+
+	got, err := p.Resolve(KeyOutput)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Value != "human" || got.Origin != "file" {
+		t.Fatalf("Resolve = %#v", got)
+	}
+}
+
+func TestLayeredProvider_EnvOverridesFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv(envOutput, "json")
+	writeConfigFile(t, "output = \"human\"\n")
+	p := newLayeredProvider()
+
+	got, err := p.Resolve(KeyOutput)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Value != "json" || got.Origin != "env" {
+		t.Fatalf("Resolve = %#v", got)
+	}
+}
+
+func TestLayeredProvider_ResolveAllKeys(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeConfigFile(t, "output = \"human\"\nauto_update = false\napi_base = \"https://api-dev.heygen.com\"\n")
+	p := newLayeredProvider()
+
+	cases := map[string]string{
+		KeyOutput:     "human",
+		KeyAutoUpdate: "false",
+		KeyAPIBase:    "https://api-dev.heygen.com",
+	}
+	for key, want := range cases {
+		got, err := p.Resolve(key)
+		if err != nil {
+			t.Fatalf("Resolve(%s): %v", key, err)
+		}
+		if got.Value != want {
+			t.Fatalf("Resolve(%s).Value = %q, want %q", key, got.Value, want)
+		}
+	}
+}
+
+func TestLayeredProvider_AnalyticsUnset(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	p := newLayeredProvider()
+
+	if got := p.Analytics(); got != nil {
+		t.Fatalf("Analytics = %v, want nil", *got)
+	}
+}
+
+func TestLayeredProvider_AnalyticsFromFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeConfigFile(t, "analytics = true\n")
+	p := newLayeredProvider()
+
+	got := p.Analytics()
+	if got == nil || !*got {
+		t.Fatalf("Analytics = %v, want true", got)
+	}
+}
+
+func TestLayeredProvider_AnalyticsEnvDisable(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv(envNoAnalytics, "1")
+	writeConfigFile(t, "analytics = true\n")
+	p := newLayeredProvider()
+
+	got := p.Analytics()
+	if got == nil || *got {
+		t.Fatalf("Analytics = %v, want false", got)
+	}
+}

--- a/internal/config/layered_provider_test.go
+++ b/internal/config/layered_provider_test.go
@@ -30,7 +30,6 @@ func TestLayeredProvider_DefaultValues(t *testing.T) {
 	cases := map[string]string{
 		KeyOutput:     DefaultOutput,
 		KeyAutoUpdate: "true",
-		KeyAPIBase:    DefaultBaseURL,
 		KeyAnalytics:  "true",
 	}
 	for key, want := range cases {
@@ -89,13 +88,13 @@ func TestLayeredProvider_EnvOverridesFile(t *testing.T) {
 
 func TestLayeredProvider_ResolveAllKeys(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	writeConfigFile(t, "output = \"human\"\nauto_update = false\napi_base = \"https://api-dev.heygen.com\"\n")
+	writeConfigFile(t, "output = \"human\"\nauto_update = false\nanalytics = false\n")
 	p := newLayeredProvider()
 
 	cases := map[string]string{
 		KeyOutput:     "human",
 		KeyAutoUpdate: "false",
-		KeyAPIBase:    "https://api-dev.heygen.com",
+		KeyAnalytics:  "false",
 	}
 	for key, want := range cases {
 		got, err := p.Resolve(key)


### PR DESCRIPTION
## Description

### What This Adds
This PR adds the first persistent config system for the CLI.

`heygen config set`, `heygen config get`, and `heygen config list` are backed by a local `config.toml` file in the CLI config directory. Config commands return structured JSON following the same stdout/stderr contract as the rest of the CLI. The config file is only created when the user explicitly runs `config set` — until then, all values come from defaults.

### Config Options

| Key | Type | Default | Env Override | Description |
|-----|------|---------|-------------|-------------|
| `output` | `json` \| `human` | `json` | `HEYGEN_OUTPUT` | Default output format |
| `analytics` | bool | `true` | `HEYGEN_NO_ANALYTICS` | PostHog analytics (opt-out) |

The `HEYGEN_NO_ANALYTICS` env var uses a negative naming convention (same as `NO_COLOR`, `HOMEBREW_NO_ANALYTICS`, `GH_NO_UPDATE_NOTIFIER`). Unset means default behavior (on); set to any non-empty value means disabled. This avoids ambiguity about whether an unset var means "on" or "off."

### Resolution Model
Config lookup uses a layered provider with clear precedence:

1. Environment variable
2. Config file (`~/.heygen/config.toml`)
3. Built-in default

### Type Handling
String settings (`output`) are stored as TOML strings. Boolean settings (`analytics`) are stored as TOML booleans. This prevents type drift between the CLI and on-disk config.

### Error Handling
A missing config file falls back to defaults silently. A corrupt or unreadable config file surfaces an error immediately — important for debugging persisted local settings.

### Example Outputs

**List all config (fresh install, no config file):**
```
$ heygen config list
[
  {"key": "analytics", "value": "true",  "source": "default"},
  {"key": "output",    "value": "json",  "source": "default"}
]
```

**Set a value:**
```
$ heygen config set output human
{"key": "output", "value": "human"}
```

**Get shows source (file vs env vs default):**
```
$ heygen config get output
{"key": "output", "value": "human", "source": "file"}

$ HEYGEN_OUTPUT=json heygen config get output
{"key": "output", "value": "json", "source": "env"}
```

**Validation errors:**
```
$ heygen config set bogus value
{"error": {"code": "usage_error", "message": "invalid config key \"bogus\""}}

$ heygen config set output xml
{"error": {"code": "usage_error", "message": "output must be one of: json, human"}}
```

**Linear issue:** PRINFRA-141

## Testing

### Automated (25+ tests)
- **EnvProvider** (5): BaseURL default, Output default + custom, Analytics default + disabled, GetEnv mapping + bogus key
- **FileProvider** (11): Get exists/missing/no-file/corrupt, Set new-file/update-existing/overwrite/boolean-type/string-type, GetAll, GetAll corrupt
- **LayeredProvider** (5): all defaults, env overrides default, file overrides default, env overrides file, analytics default/from-file/env-disable
- **Config commands** (9): set success/invalid-key/invalid-value/api-base-rejected/skipAuth, get default/from-env/from-file/invalid-key, list all-defaults/mixed-sources
- All existing M0 + auth tests pass unchanged

### Manual smoke tests
- `heygen config list` → 2 keys with defaults
- `heygen config set output human` → TOML file written, `config get` shows `source: "file"`
- `HEYGEN_OUTPUT=json heygen config get output` → env overrides file, `source: "env"`
- `heygen config set analytics false` → stored as TOML boolean `false` (not string)
- `heygen config set bogus value` → exit 2
- `heygen config set api_base "https://..."` → exit 2 (not a user-facing key)