### PR TITLE
feat: use OpenAPI tag descriptions for group help text (PRINFRA-146)

### DIFF
--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -111,7 +111,11 @@ func registerGroups(root *cobra.Command, ctx *cmdContext, groups map[string][]*c
 	slices.Sort(groupNames)
 
 	for _, groupName := range groupNames {
-		groupCmd := &cobra.Command{Use: groupName, Short: humanizeCommandToken(groupName) + " commands"}
+		short := gen.GroupDescriptions[groupName]
+		if short == "" {
+			short = humanizeCommandToken(groupName) + " commands"
+		}
+		groupCmd := &cobra.Command{Use: groupName, Short: short}
 		for _, spec := range groups[groupName] {
 			registerSpecCommand(groupCmd, spec, ctx)
 		}

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -32,7 +32,7 @@ import (
 //
 // All output is gofmt'd. Variable names are PascalCase derived from
 // group + command name via strcase.ToCamel.
-func Generate(groups command.Groups, tmplDir, outDir string) error {
+func Generate(groups command.Groups, descriptions GroupDescriptions, tmplDir, outDir string) error {
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		return fmt.Errorf("creating output directory: %w", err)
 	}
@@ -63,9 +63,10 @@ func Generate(groups command.Groups, tmplDir, outDir string) error {
 
 	// Registry file
 	regData := struct {
-		Groups     command.Groups
-		GroupNames []string
-	}{groups, groupNames}
+		Groups       command.Groups
+		GroupNames   []string
+		Descriptions GroupDescriptions
+	}{groups, groupNames, descriptions}
 	regFilename := filepath.Join(outDir, "registry.go")
 	if err := writeFromTemplate(regTmpl, regData, regFilename); err != nil {
 		return fmt.Errorf("generating registry: %w", err)

--- a/codegen/generate_test.go
+++ b/codegen/generate_test.go
@@ -29,7 +29,7 @@ func TestGoldenFiles(t *testing.T) {
 		t.Fatalf("LoadExamples failed: %v", err)
 	}
 
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestGoldenFiles(t *testing.T) {
 	}
 
 	outDir := t.TempDir()
-	if err := Generate(groups, "templates", outDir); err != nil {
+	if err := Generate(groups, nil, "templates", outDir); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 

--- a/codegen/grouper.go
+++ b/codegen/grouper.go
@@ -53,8 +53,21 @@ import (
 //	  → sessions → sub-group, {session_id} → arg, stop → sub-group
 //	  → x-cli-action: true → no terminal verb appended
 //	  → result: heygen video-agent sessions stop <session-id>
-func GroupEndpoints(doc *openapi3.T, examples Examples) (command.Groups, error) {
+// GroupDescriptions maps group name → description from the OpenAPI tag.
+// Used by the builder for group command help text.
+type GroupDescriptions map[string]string
+
+func GroupEndpoints(doc *openapi3.T, examples Examples) (command.Groups, GroupDescriptions, error) {
 	groups := make(command.Groups)
+	descriptions := make(GroupDescriptions)
+
+	// Collect tag descriptions from the spec's top-level tags array
+	for _, tag := range doc.Tags {
+		groupName := deriveGroupName(tag.Name)
+		if tag.Description != "" {
+			descriptions[groupName] = tag.Description
+		}
+	}
 
 	for _, path := range sortedMapKeys(doc.Paths.Map()) {
 		pathItem := doc.Paths.Find(path)
@@ -86,10 +99,10 @@ func GroupEndpoints(doc *openapi3.T, examples Examples) (command.Groups, error) 
 	}
 
 	if err := validateFlagNames(groups); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return groups, nil
+	return groups, descriptions, nil
 }
 
 // buildSpec creates a command.Spec from an OpenAPI operation.

--- a/codegen/grouper_test.go
+++ b/codegen/grouper_test.go
@@ -27,7 +27,7 @@ func loadTestExamples(t *testing.T) Examples {
 func TestGroupEndpoints_FilterHidden(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestGroupEndpoints_FilterHidden(t *testing.T) {
 func TestGroupEndpoints_GroupNames(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestGroupEndpoints_GroupNames(t *testing.T) {
 func TestGroupEndpoints_TerminalVerbs(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestGroupEndpoints_TerminalVerbs(t *testing.T) {
 func TestGroupEndpoints_QueryFlags(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestGroupEndpoints_QueryFlags(t *testing.T) {
 func TestGroupEndpoints_BodyFlagsSkipComplex(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestGroupEndpoints_BodyFlagsSkipComplex(t *testing.T) {
 func TestGroupEndpoints_PathArgs(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestGroupEndpoints_PathArgs(t *testing.T) {
 func TestGroupEndpoints_Pagination(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestGroupEndpoints_Pagination(t *testing.T) {
 func TestGroupEndpoints_Multipart(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestGroupEndpoints_Multipart(t *testing.T) {
 func TestGroupEndpoints_Examples(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestGroupEndpoints_Examples(t *testing.T) {
 func TestGroupEndpoints_XCliAction(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestGroupEndpoints_XCliAction(t *testing.T) {
 func TestGroupEndpoints_SubGroupNaming(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestGroupEndpoints_SubGroupNaming(t *testing.T) {
 func TestGroupEndpoints_SingletonGetUsesGetVerb(t *testing.T) {
 	doc := loadGroupTestSpec(t)
 	examples := loadTestExamples(t)
-	groups, err := GroupEndpoints(doc, examples)
+	groups, _, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		t.Fatalf("GroupEndpoints: %v", err)
 	}

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	// Step 3: Group endpoints into command specs
-	groups, err := GroupEndpoints(doc, examples)
+	groups, descriptions, err := GroupEndpoints(doc, examples)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// Step 5: Generate Go source files
-	if err := Generate(groups, "codegen/templates", *outDir); err != nil {
+	if err := Generate(groups, descriptions, "codegen/templates", *outDir); err != nil {
 		fmt.Fprintf(os.Stderr, "error generating: %v\n", err)
 		os.Exit(1)
 	}

--- a/codegen/templates/registry.go.tmpl
+++ b/codegen/templates/registry.go.tmpl
@@ -17,3 +17,13 @@ var Groups = map[string][]*command.Spec{
 	},
 {{- end}}
 }
+
+// GroupDescriptions maps group name → help text from OpenAPI tag descriptions.
+var GroupDescriptions = map[string]string{
+{{- range .GroupNames}}
+{{- $desc := index $.Descriptions .}}
+{{- if $desc}}
+	{{quote .}}: {{quote $desc}},
+{{- end}}
+{{- end}}
+}

--- a/codegen/testdata/golden/registry.go
+++ b/codegen/testdata/golden/registry.go
@@ -20,3 +20,6 @@ var Groups = map[string][]*command.Spec{
 		WidgetList,
 	},
 }
+
+// GroupDescriptions maps group name → help text from OpenAPI tag descriptions.
+var GroupDescriptions = map[string]string{}

--- a/gen/registry.go
+++ b/gen/registry.go
@@ -73,3 +73,16 @@ var Groups = map[string][]*command.Spec{
 		WebhookEventsList,
 	},
 }
+
+// GroupDescriptions maps group name → help text from OpenAPI tag descriptions.
+var GroupDescriptions = map[string]string{
+	"asset":           "Upload files for use in video creation",
+	"avatar":          "List and manage avatars and looks",
+	"overdub":         "Dub or replace audio on existing videos",
+	"user":            "Account information and billing",
+	"video":           "Create, list, retrieve, and delete videos",
+	"video-agent":     "Create videos from text prompts using AI",
+	"video-translate": "Translate videos into other languages",
+	"voice":           "Text-to-speech and voice management",
+	"webhook":         "Manage webhook endpoints and events",
+}


### PR DESCRIPTION
## Description

Group commands in `--help` now show meaningful descriptions from the OpenAPI spec instead of generic "X commands" text.

**Before:**
```
asset           Asset commands
avatar          Avatar commands
video           Video commands
```

**After:**
```
asset           Upload files for use in video creation
avatar          List and manage avatars and looks
video           Create, list, retrieve, and delete videos
video-agent     Create videos from text prompts using AI
video-translate Translate videos into other languages
```

**How it works:**
- The grouper reads tag descriptions from the OpenAPI spec's top-level `tags` array
- Returns `GroupDescriptions` map alongside the command groups
- The registry template generates a `GroupDescriptions` map in `gen/registry.go`
- `root.go` reads `gen.GroupDescriptions[groupName]` when registering groups, falls back to humanized token if missing

Tag descriptions are maintained in the EF spec generator (`TAG_DESCRIPTIONS` dict). PR: experiment-framework#33460

## Testing

All tests pass. Golden files updated.

## Files
- `codegen/grouper.go` — returns GroupDescriptions alongside groups
- `codegen/generate.go` — passes descriptions to template
- `codegen/templates/registry.go.tmpl` — generates GroupDescriptions map
- `codegen/main.go` — passes descriptions through pipeline
- `cmd/heygen/root.go` — reads GroupDescriptions for group Short text
- `gen/registry.go` — regenerated with descriptions
- `codegen/generate_test.go` + `codegen/grouper_test.go` — updated for new return type