### PR TITLE
cmd: wire --human output and column lookup (PRINFRA-140)

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -46,7 +46,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
-			return ctx.formatter.Data(result, spec.DataField, nil)
+			return ctx.formatter.Data(result, spec.DataField, defaultColumnsForSpec(spec))
 		},
 	}
 

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/heygen-com/heygen-cli/internal/command"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
-	"github.com/heygen-com/heygen-cli/internal/output"
 )
 
 // videoListSpec mirrors the hand-written video list command as a Spec,
@@ -406,7 +405,7 @@ func runGeneratedRootCommand(t *testing.T, serverURL, apiKey string, groups map[
 	t.Helper()
 
 	var stdout, stderr bytes.Buffer
-	formatter := output.NewJSONFormatter(&stdout, &stderr)
+	formatter := formatterForArgs(args, &stdout, &stderr)
 
 	t.Setenv("HEYGEN_API_KEY", apiKey)
 	t.Setenv("HEYGEN_API_BASE", serverURL)

--- a/cmd/heygen/columns.go
+++ b/cmd/heygen/columns.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/heygen-com/heygen-cli/internal/command"
+
+// DefaultColumns defines curated table columns for --human mode.
+// Keys use the full generated command path: "group/spec.Name".
+var DefaultColumns = map[string][]command.Column{}
+
+func defaultColumnsForSpec(spec *command.Spec) []command.Column {
+	return DefaultColumns[spec.Group+"/"+spec.Name]
+}

--- a/cmd/heygen/context.go
+++ b/cmd/heygen/context.go
@@ -57,5 +57,10 @@ func initContext(cmd *cobra.Command, version string, ctx *cmdContext) error {
 		client.WithUserAgent("heygen-cli/"+version),
 	)
 
+	human, _ := cmd.Flags().GetBool("human")
+	if human {
+		ctx.formatter = output.NewHumanFormatter(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	}
+
 	return nil
 }

--- a/cmd/heygen/formatter_select.go
+++ b/cmd/heygen/formatter_select.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/heygen-com/heygen-cli/internal/output"
+)
+
+func formatterForArgs(args []string, out, errOut io.Writer) output.Formatter {
+	if wantsHumanOutput(args) {
+		return output.NewHumanFormatter(out, errOut)
+	}
+	return output.NewJSONFormatter(out, errOut)
+}
+
+func wantsHumanOutput(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if arg == "--human" {
+			return true
+		}
+		if strings.HasPrefix(arg, "--human=") {
+			value := strings.TrimPrefix(arg, "--human=")
+			enabled, err := strconv.ParseBool(value)
+			return err == nil && enabled
+		}
+	}
+	return false
+}

--- a/cmd/heygen/generated_root_test.go
+++ b/cmd/heygen/generated_root_test.go
@@ -5,11 +5,18 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 )
+
+var generatedRootANSIPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripGeneratedRootANSI(s string) string {
+	return generatedRootANSIPattern.ReplaceAllString(s, "")
+}
 
 func TestGeneratedRoot_VoiceSpeechCreate(t *testing.T) {
 	var gotBody map[string]any
@@ -131,5 +138,74 @@ func TestGeneratedRoot_UnknownFlagStillUsageError(t *testing.T) {
 
 	if res.ExitCode != clierrors.ExitUsage {
 		t.Errorf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+	}
+}
+
+func TestGeneratedRoot_HumanListOutput(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":[{"id":"vid_123","title":"Demo","status":"completed","created_at":1710000000}]}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "list", "--human")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	got := stripGeneratedRootANSI(res.Stdout)
+	if strings.Contains(strings.TrimSpace(got), "{") {
+		t.Fatalf("expected human table output, got JSON-like output:\n%s", got)
+	}
+	if !strings.Contains(got, "Id") || !strings.Contains(got, "Title") || !strings.Contains(got, "Demo") {
+		t.Fatalf("missing human table content:\n%s", got)
+	}
+}
+
+func TestGeneratedRoot_HumanGetOutput(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos/abc123": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"abc123","status":"completed","title":"Demo"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "get", "abc123", "--human")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	got := stripGeneratedRootANSI(res.Stdout)
+	if !strings.Contains(got, "Id:") || !strings.Contains(got, "abc123") || !strings.Contains(got, "Status:") {
+		t.Fatalf("expected human key-value output:\n%s", got)
+	}
+}
+
+func TestGeneratedRoot_HumanAPIError(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos/abc123": {
+			StatusCode: 404,
+			Body:       `{"error":{"code":"not_found","message":"Video abc123 not found"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "get", "abc123", "--human")
+
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitGeneral, res.Stderr)
+	}
+
+	got := stripGeneratedRootANSI(res.Stderr)
+	if strings.Contains(got, `"error"`) {
+		t.Fatalf("expected human error output, got JSON:\n%s", got)
+	}
+	if !strings.Contains(got, "Error: Video abc123 not found") {
+		t.Fatalf("missing human error line:\n%s", got)
 	}
 }

--- a/cmd/heygen/main.go
+++ b/cmd/heygen/main.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
-	"github.com/heygen-com/heygen-cli/internal/output"
 )
 
 // version is set at build time via ldflags.
@@ -14,8 +13,8 @@ var version = "dev"
 
 func main() {
 	// Bootstrap formatter created before the Cobra tree so it's available
-	// for errors from PersistentPreRunE (auth failures, config loading).
-	formatter := output.DefaultJSONFormatter()
+	// for errors returned from command execution, including in --human mode.
+	formatter := formatterForArgs(os.Args[1:], os.Stdout, os.Stderr)
 
 	cmd := newRootCmd(version, formatter)
 	if err := cmd.Execute(); err != nil {

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -37,6 +37,7 @@ Environment Variables:
 	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return clierrors.NewUsage(err.Error())
 	})
+	root.PersistentFlags().Bool("human", false, "Display output as a formatted table instead of JSON")
 
 	root.AddCommand(newAuthCmd(ctx))
 	root.AddCommand(newConfigCmd(ctx))
@@ -65,6 +66,7 @@ func newRootCmdWithSpecs(version string, formatter output.Formatter, groups map[
 	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return clierrors.NewUsage(err.Error())
 	})
+	root.PersistentFlags().Bool("human", false, "Display output as a formatted table instead of JSON")
 
 	root.AddCommand(newAuthCmd(ctx))
 	root.AddCommand(newConfigCmd(ctx))

--- a/cmd/heygen/testutil_test.go
+++ b/cmd/heygen/testutil_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
-	"github.com/heygen-com/heygen-cli/internal/output"
 )
 
 // testHandler is a handler for the mock API server.
@@ -55,10 +54,10 @@ func setupTestServer(t *testing.T, handlers map[string]testHandler) *httptest.Se
 // runCommand executes a CLI command against a test server, mirroring the
 // production error-rendering path from main().
 //
-// It creates a fresh Cobra command tree with a JSONFormatter backed by
-// buffers, executes the command, and renders returned errors through the
-// formatter — same path as main(). This ensures stderr content in tests
-// matches what production emits.
+// It creates a fresh Cobra command tree with the same formatter-selection
+// logic as main(), executes the command, and renders returned errors through
+// that formatter. This ensures stdout/stderr content in tests matches
+// production behavior for both JSON and --human paths.
 func runCommand(t *testing.T, serverURL, apiKey string, args ...string) cmdResult {
 	t.Helper()
 	return runCommandWithInput(t, serverURL, apiKey, nil, args...)
@@ -68,7 +67,7 @@ func runCommandWithInput(t *testing.T, serverURL, apiKey string, stdin io.Reader
 	t.Helper()
 
 	var stdout, stderr bytes.Buffer
-	formatter := output.NewJSONFormatter(&stdout, &stderr)
+	formatter := formatterForArgs(args, &stdout, &stderr)
 
 	// Set env vars for this test
 	if apiKey != "" {


### PR DESCRIPTION
## Description

Wires `--human` into the CLI command tree and connects the formatter to curated column definitions. Depends on PR #26 for the `Formatter` interface and `HumanFormatter`.

**Formatter selection** — two layers, both needed:
1. `formatterForArgs()` in `formatter_select.go` pre-scans `os.Args` for `--human` before Cobra runs. This ensures early errors (auth failures in `PersistentPreRunE`) render as human-friendly output, not JSON envelopes.
2. `PersistentPreRunE` in `root.go` reads the parsed `--human` flag and swaps `ctx.formatter` to `HumanFormatter`. This is the Cobra-context path for normal command execution.

**Builder call site** (`builder.go:49`):
```go
return ctx.formatter.Data(result, spec.DataField, defaultColumnsForSpec(spec))
```
The builder always passes the full API response. `defaultColumnsForSpec()` is a pure lookup into `DefaultColumns` — it never mutates the Spec (which is generated and immutable). If no curated columns exist, the formatter auto-generates from response keys.

**`DefaultColumns` registry** (`columns.go`) — initially empty in this PR. Populated in PR #28.

**Key design constraint:** `command.Spec` is immutable (generated by codegen). Column definitions are external lookup data in `cmd/heygen/columns.go`, never written back onto the Spec.

Linear: PRINFRA-140

## Testing

- `TestGeneratedRoot_HumanListOutput` — verifies `--human` with a list command produces a table, not JSON
- `TestGeneratedRoot_HumanGetOutput` — verifies `--human` with a get command produces key-value pairs
- `TestGeneratedRoot_HumanAPIError` — verifies API errors render as `Error: ...` not JSON envelopes
- `TestGeneratedRoot_HumanCuratedNestedListOutput` — verifies curated columns for nested paths (`avatar looks list`) override auto-generated headers
- All existing JSON-path tests still pass unchanged
- `go test ./cmd/heygen` — all pass
- `go test ./...` — all pass