### PR TITLE
client: add retry with exponential backoff (PRINFRA-122)

### DIFF
--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -17,13 +17,15 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "heygen",
 		Short: "HeyGen CLI — create and manage videos, avatars, and more",
-		// NOTE: env var list is hardcoded. Keep in sync with envVarByKey in env_provider.go.
+		// NOTE: env var list is hardcoded. Keep config-related entries in sync with
+		// envVarByKey in env_provider.go and update operational settings here too.
 		Long: `HeyGen CLI — create and manage videos, avatars, and more.
 
 Environment Variables:
   HEYGEN_API_KEY            API key for authentication (overrides stored credentials)
   HEYGEN_OUTPUT             Output format: json, human (default: json)
   HEYGEN_NO_ANALYTICS       Disable analytics when set (default: enabled)
+  HEYGEN_MAX_RETRIES        Max retries for transient errors (default: 2, 0 to disable)
   HEYGEN_CONFIG_DIR         Override config directory (default: ~/.heygen)`,
 		Version:       version,
 		SilenceUsage:  true, // we handle usage errors ourselves

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -17,16 +17,16 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "heygen",
 		Short: "HeyGen CLI — create and manage videos, avatars, and more",
-		// NOTE: env var list is hardcoded. Keep config-related entries in sync with
-		// envVarByKey in env_provider.go and update operational settings here too.
+		// NOTE: Only user-facing env vars are listed here. Internal/operational
+		// vars (HEYGEN_MAX_RETRIES, HEYGEN_NO_ANALYTICS, HEYGEN_CONFIG_DIR) are
+		// intentionally hidden. Use "heygen config list" to see all settings.
 		Long: `HeyGen CLI — create and manage videos, avatars, and more.
 
 Environment Variables:
-  HEYGEN_API_KEY            API key for authentication (overrides stored credentials)
-  HEYGEN_OUTPUT             Output format: json, human (default: json)
-  HEYGEN_NO_ANALYTICS       Disable analytics when set (default: enabled)
-  HEYGEN_MAX_RETRIES        Max retries for transient errors (default: 2, 0 to disable)
-  HEYGEN_CONFIG_DIR         Override config directory (default: ~/.heygen)`,
+  HEYGEN_API_KEY     API key for authentication (overrides stored credentials)
+  HEYGEN_OUTPUT      Output format: json, human (default: json)
+
+Use "heygen config list" to see all configuration settings and their sources.`,
 		Version:       version,
 		SilenceUsage:  true, // we handle usage errors ourselves
 		SilenceErrors: true, // we handle error output ourselves

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -35,25 +35,10 @@ func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) { c.httpClient = hc }
 }
 
-// WithRetry merges the given config into the default retry configuration.
-// MaxRetries is always applied (0 is valid — means no retries).
-// BaseDelay and MaxDelay are only applied if positive, so
-// WithRetry(RetryConfig{MaxRetries: 1}) keeps the default delays.
-func WithRetry(config RetryConfig) Option {
-	return func(c *Client) {
-		c.retry.MaxRetries = config.MaxRetries
-		if config.BaseDelay > 0 {
-			c.retry.BaseDelay = config.BaseDelay
-		}
-		if config.MaxDelay > 0 {
-			c.retry.MaxDelay = config.MaxDelay
-		}
-	}
-}
-
-// WithNoRetry disables retries entirely.
-func WithNoRetry() Option {
-	return func(c *Client) { c.retry.MaxRetries = 0 }
+// WithMaxRetries sets the maximum number of retries for transient failures.
+// 0 disables retries. Delays remain at their defaults.
+func WithMaxRetries(n int) Option {
+	return func(c *Client) { c.retry.MaxRetries = n }
 }
 
 // WithUserAgent overrides the default User-Agent header.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -19,6 +19,7 @@ type Client struct {
 	baseURL    string
 	apiKey     string
 	userAgent  string
+	retry      RetryConfig
 }
 
 // Option configures the Client.
@@ -34,6 +35,16 @@ func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) { c.httpClient = hc }
 }
 
+// WithRetry overrides the default retry configuration.
+func WithRetry(config RetryConfig) Option {
+	return func(c *Client) { c.retry = config }
+}
+
+// WithNoRetry disables retries entirely.
+func WithNoRetry() Option {
+	return func(c *Client) { c.retry.MaxRetries = 0 }
+}
+
 // WithUserAgent overrides the default User-Agent header.
 func WithUserAgent(ua string) Option {
 	return func(c *Client) { c.userAgent = ua }
@@ -46,10 +57,23 @@ func New(apiKey string, opts ...Option) *Client {
 		baseURL:    DefaultBaseURL,
 		apiKey:     apiKey,
 		userAgent:  DefaultUserAgent,
+		retry:      DefaultRetryConfig(),
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
+
+	copied := *c.httpClient
+	transport := copied.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	copied.Transport = &retryTransport{
+		base:   transport,
+		config: c.retry,
+	}
+	c.httpClient = &copied
+
 	return c
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -35,9 +35,20 @@ func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) { c.httpClient = hc }
 }
 
-// WithRetry overrides the default retry configuration.
+// WithRetry merges the given config into the default retry configuration.
+// MaxRetries is always applied (0 is valid — means no retries).
+// BaseDelay and MaxDelay are only applied if positive, so
+// WithRetry(RetryConfig{MaxRetries: 1}) keeps the default delays.
 func WithRetry(config RetryConfig) Option {
-	return func(c *Client) { c.retry = config }
+	return func(c *Client) {
+		c.retry.MaxRetries = config.MaxRetries
+		if config.BaseDelay > 0 {
+			c.retry.BaseDelay = config.BaseDelay
+		}
+		if config.MaxDelay > 0 {
+			c.retry.MaxDelay = config.MaxDelay
+		}
+	}
 }
 
 // WithNoRetry disables retries entirely.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestClient_Do_InjectsHeaders(t *testing.T) {
@@ -65,4 +66,92 @@ func TestClient_Defaults(t *testing.T) {
 	if c.userAgent != DefaultUserAgent {
 		t.Errorf("userAgent = %q, want %q", c.userAgent, DefaultUserAgent)
 	}
+	if c.retry.MaxRetries != 2 {
+		t.Errorf("retry.MaxRetries = %d, want %d", c.retry.MaxRetries, 2)
+	}
+	if c.retry.BaseDelay != time.Second {
+		t.Errorf("retry.BaseDelay = %v, want %v", c.retry.BaseDelay, time.Second)
+	}
+	if c.retry.MaxDelay != 30*time.Second {
+		t.Errorf("retry.MaxDelay = %v, want %v", c.retry.MaxDelay, 30*time.Second)
+	}
+	if _, ok := c.httpClient.Transport.(*retryTransport); !ok {
+		t.Fatalf("httpClient.Transport = %T, want *retryTransport", c.httpClient.Transport)
+	}
+}
+
+func TestClient_WithNoRetry(t *testing.T) {
+	c := New("key", WithNoRetry())
+	if c.retry.MaxRetries != 0 {
+		t.Errorf("retry.MaxRetries = %d, want %d", c.retry.MaxRetries, 0)
+	}
+}
+
+func TestClient_WithHTTPClientPreservesTimeout(t *testing.T) {
+	custom := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &stubTransport{},
+	}
+
+	c := New("key", WithHTTPClient(custom))
+	if c.httpClient.Timeout != 5*time.Second {
+		t.Errorf("httpClient.Timeout = %v, want %v", c.httpClient.Timeout, 5*time.Second)
+	}
+	rt, ok := c.httpClient.Transport.(*retryTransport)
+	if !ok {
+		t.Fatalf("httpClient.Transport = %T, want *retryTransport", c.httpClient.Transport)
+	}
+	if _, ok := rt.base.(*stubTransport); !ok {
+		t.Fatalf("retryTransport.base = %T, want *stubTransport", rt.base)
+	}
+}
+
+func TestClient_WithHTTPClientNoMutation(t *testing.T) {
+	base := &stubTransport{}
+	custom := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: base,
+	}
+
+	c1 := New("key", WithHTTPClient(custom))
+	c2 := New("key", WithHTTPClient(custom))
+
+	if custom.Transport != base {
+		t.Fatalf("custom.Transport mutated to %T, want original transport", custom.Transport)
+	}
+
+	rt1, ok := c1.httpClient.Transport.(*retryTransport)
+	if !ok {
+		t.Fatalf("c1.httpClient.Transport = %T, want *retryTransport", c1.httpClient.Transport)
+	}
+	rt2, ok := c2.httpClient.Transport.(*retryTransport)
+	if !ok {
+		t.Fatalf("c2.httpClient.Transport = %T, want *retryTransport", c2.httpClient.Transport)
+	}
+	if rt1.base != base {
+		t.Fatalf("c1 retry base = %T, want original transport", rt1.base)
+	}
+	if rt2.base != base {
+		t.Fatalf("c2 retry base = %T, want original transport", rt2.base)
+	}
+}
+
+func TestDefaultRetryConfig_FromEnv(t *testing.T) {
+	t.Setenv("HEYGEN_MAX_RETRIES", "5")
+
+	cfg := DefaultRetryConfig()
+	if cfg.MaxRetries != 5 {
+		t.Errorf("cfg.MaxRetries = %d, want %d", cfg.MaxRetries, 5)
+	}
+}
+
+type stubTransport struct{}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -80,8 +80,19 @@ func TestClient_Defaults(t *testing.T) {
 	}
 }
 
-func TestClient_WithNoRetry(t *testing.T) {
-	c := New("key", WithNoRetry())
+func TestClient_WithMaxRetries(t *testing.T) {
+	c := New("key", WithMaxRetries(5))
+	if c.retry.MaxRetries != 5 {
+		t.Errorf("retry.MaxRetries = %d, want %d", c.retry.MaxRetries, 5)
+	}
+	// Delays stay at defaults
+	if c.retry.BaseDelay != time.Second {
+		t.Errorf("retry.BaseDelay = %v, want %v", c.retry.BaseDelay, time.Second)
+	}
+}
+
+func TestClient_WithMaxRetries_Zero(t *testing.T) {
+	c := New("key", WithMaxRetries(0))
 	if c.retry.MaxRetries != 0 {
 		t.Errorf("retry.MaxRetries = %d, want %d", c.retry.MaxRetries, 0)
 	}

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -260,7 +260,7 @@ func TestExecute_RetryOn429(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(1))
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), withFastRetries(1))
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
@@ -295,7 +295,7 @@ func TestExecute_RetryPreservesBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(1))
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), withFastRetries(1))
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "POST", BodyEncoding: "json"}
 	inv := &command.Invocation{

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -229,7 +229,7 @@ func TestExecute_NetworkError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
@@ -242,6 +242,80 @@ func TestExecute_NetworkError(t *testing.T) {
 	}
 	if cliErr.Code != "network_error" {
 		t.Errorf("Code = %q, want %q", cliErr.Code, "network_error")
+	}
+}
+
+func TestExecute_RetryOn429(t *testing.T) {
+	var calls int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"code":"rate_limited","message":"too many requests"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+
+	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	result, err := c.Execute(spec, inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want %d", calls, 2)
+	}
+	if string(result) != `{"data":[]}` {
+		t.Fatalf("result = %s, want %s", result, `{"data":[]}`)
+	}
+}
+
+func TestExecute_RetryPreservesBody(t *testing.T) {
+	var calls int
+	var bodies []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"code":"rate_limited","message":"too many requests"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"new123"}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+
+	spec := &command.Spec{Endpoint: "/v3/videos", Method: "POST", BodyEncoding: "json"}
+	inv := &command.Invocation{
+		PathParams:  make(map[string]string),
+		QueryParams: make(url.Values),
+		Body:        map[string]any{"title": "My Video", "draft": true},
+	}
+
+	result, err := c.Execute(spec, inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want %d", calls, 2)
+	}
+	if len(bodies) != 2 || bodies[0] != bodies[1] {
+		t.Fatalf("bodies = %#v, want two identical request bodies", bodies)
+	}
+	if string(result) != `{"id":"new123"}` {
+		t.Fatalf("result = %s, want %s", result, `{"id":"new123"}`)
 	}
 }
 

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -229,7 +229,7 @@ func TestExecute_NetworkError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
@@ -260,7 +260,7 @@ func TestExecute_RetryOn429(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(1))
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
@@ -295,7 +295,7 @@ func TestExecute_RetryPreservesBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(1))
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "POST", BodyEncoding: "json"}
 	inv := &command.Invocation{

--- a/internal/client/retry.go
+++ b/internal/client/retry.go
@@ -64,6 +64,11 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		delay := backoffDelay(attempt, t.config)
 		if resp != nil {
 			if retryAfter := parseRetryAfter(resp.Header.Get("Retry-After")); retryAfter > delay {
+				// Clamp Retry-After to MaxDelay — a server sending Retry-After: 86400
+				// shouldn't block the CLI for 24 hours.
+				if t.config.MaxDelay > 0 && retryAfter > t.config.MaxDelay {
+					retryAfter = t.config.MaxDelay
+				}
 				delay = retryAfter
 			}
 			drainAndClose(resp.Body)
@@ -97,13 +102,16 @@ func shouldRetry(req *http.Request, resp *http.Response, err error) bool {
 	if resp.StatusCode == http.StatusTooManyRequests {
 		return true
 	}
-	return isRetryableStatus(resp.StatusCode) && isIdempotent(req.Method)
+	// 5xx server errors — only retry for idempotent methods.
+	return isRetryableServerError(resp.StatusCode) && isIdempotent(req.Method)
 }
 
-func isRetryableStatus(code int) bool {
+// isRetryableServerError returns true for server-side errors worth retrying.
+// 429 (rate limited) is handled separately in shouldRetry — it's always retried
+// regardless of method because the server explicitly rejected without processing.
+func isRetryableServerError(code int) bool {
 	switch code {
-	case http.StatusTooManyRequests,
-		http.StatusInternalServerError,
+	case http.StatusInternalServerError,
 		http.StatusBadGateway,
 		http.StatusServiceUnavailable,
 		http.StatusGatewayTimeout:
@@ -209,6 +217,8 @@ func drainAndClose(body io.ReadCloser) {
 	if body == nil {
 		return
 	}
-	_, _ = io.Copy(io.Discard, body)
+	// Cap the drain to 4KB — response bodies on 429/5xx should be tiny.
+	// A misbehaving server sending a large body won't block the retry loop.
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, 4096))
 	_ = body.Close()
 }

--- a/internal/client/retry.go
+++ b/internal/client/retry.go
@@ -1,0 +1,214 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+// RetryConfig controls retry behavior for transient HTTP failures.
+type RetryConfig struct {
+	MaxRetries int
+	BaseDelay  time.Duration
+	MaxDelay   time.Duration
+}
+
+// DefaultRetryConfig returns the default retry policy, optionally overridden by
+// the HEYGEN_MAX_RETRIES environment variable.
+func DefaultRetryConfig() RetryConfig {
+	cfg := RetryConfig{
+		MaxRetries: 2,
+		BaseDelay:  time.Second,
+		MaxDelay:   30 * time.Second,
+	}
+
+	if raw, ok := os.LookupEnv("HEYGEN_MAX_RETRIES"); ok {
+		if maxRetries, err := strconv.Atoi(raw); err == nil && maxRetries >= 0 {
+			cfg.MaxRetries = maxRetries
+		}
+	}
+
+	return cfg
+}
+
+// retryTransport wraps an http.RoundTripper with automatic retries for
+// transient failures.
+type retryTransport struct {
+	base   http.RoundTripper
+	config RetryConfig
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	currentReq := req
+	for attempt := 0; ; attempt++ {
+		resp, err := base.RoundTrip(currentReq)
+		if attempt >= t.config.MaxRetries || !shouldRetry(currentReq, resp, err) {
+			return resp, err
+		}
+
+		if !canReplayBody(currentReq) {
+			return resp, err
+		}
+
+		delay := backoffDelay(attempt, t.config)
+		if resp != nil {
+			if retryAfter := parseRetryAfter(resp.Header.Get("Retry-After")); retryAfter > delay {
+				delay = retryAfter
+			}
+			drainAndClose(resp.Body)
+		}
+
+		if err := waitForRetry(currentReq.Context(), delay); err != nil {
+			return nil, err
+		}
+
+		nextReq, err := cloneRequestForRetry(currentReq)
+		if err != nil {
+			return nil, err
+		}
+		currentReq = nextReq
+	}
+}
+
+func shouldRetry(req *http.Request, resp *http.Response, err error) bool {
+	if err != nil {
+		if req.Context().Err() != nil ||
+			errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
+			return false
+		}
+		return isIdempotent(req.Method)
+	}
+
+	if resp == nil {
+		return false
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	return isRetryableStatus(resp.StatusCode) && isIdempotent(req.Method)
+}
+
+func isRetryableStatus(code int) bool {
+	switch code {
+	case http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func isIdempotent(method string) bool {
+	switch method {
+	case http.MethodGet,
+		http.MethodHead,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+func canReplayBody(req *http.Request) bool {
+	return req.Body == nil || req.GetBody != nil
+}
+
+func parseRetryAfter(header string) time.Duration {
+	if header == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(header); err == nil {
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		return 0
+	}
+
+	retryAt, err := http.ParseTime(header)
+	if err != nil {
+		return 0
+	}
+	if delay := time.Until(retryAt); delay > 0 {
+		return delay
+	}
+	return 0
+}
+
+func backoffDelay(attempt int, config RetryConfig) time.Duration {
+	if config.BaseDelay <= 0 {
+		return 0
+	}
+
+	delay := float64(config.BaseDelay) * math.Pow(2, float64(attempt))
+	if config.MaxDelay > 0 && time.Duration(delay) > config.MaxDelay {
+		delay = float64(config.MaxDelay)
+	}
+
+	jitter := 0.75 + rand.Float64()*0.5
+	return time.Duration(delay * jitter)
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func cloneRequestForRetry(req *http.Request) (*http.Request, error) {
+	clone := req.Clone(req.Context())
+	clone.GetBody = req.GetBody
+	clone.ContentLength = req.ContentLength
+
+	if req.Body == nil {
+		clone.Body = nil
+		return clone, nil
+	}
+
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	clone.Body = body
+	return clone, nil
+}
+
+func drainAndClose(body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
+}

--- a/internal/client/retry_test.go
+++ b/internal/client/retry_test.go
@@ -26,7 +26,7 @@ func TestRetry_429ThenSuccess_GET(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestRetry_429ThenSuccess_POST(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
 	req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"title":"demo"}`))
 	resp, err := c.Do(req)
 	if err != nil {
@@ -85,7 +85,7 @@ func TestRetry_500ThenSuccess_GET(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestRetry_500NoRetry_POST(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(2))
 	req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"title":"demo"}`))
 	resp, err := c.Do(req)
 	if err != nil {
@@ -133,7 +133,7 @@ func TestRetry_400NoRetry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(2))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -154,7 +154,7 @@ func TestRetry_401NoRetry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(2))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -175,7 +175,7 @@ func TestRetry_ExhaustedRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(2))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -206,7 +206,7 @@ func TestRetry_NetworkErrorThenSuccess_GET(t *testing.T) {
 				base: srv.Client().Transport,
 			},
 		}),
-		WithRetry(RetryConfig{MaxRetries: 1}),
+		WithMaxRetries(1),
 	)
 
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
@@ -226,7 +226,7 @@ func TestRetry_NetworkErrorNoRetry_POST(t *testing.T) {
 		WithHTTPClient(&http.Client{
 			Transport: &failOnceTransport{err: errors.New("temporary network error")},
 		}),
-		WithRetry(RetryConfig{MaxRetries: 2}),
+		WithMaxRetries(2),
 	)
 
 	req, _ := http.NewRequest(http.MethodPost, "http://example.invalid", strings.NewReader(`{"title":"demo"}`))
@@ -261,7 +261,7 @@ func TestRetry_RetryAfterSeconds(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 
 	start := time.Now()
@@ -291,7 +291,7 @@ func TestRetry_RetryAfterHTTPDate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 
 	start := time.Now()
@@ -315,7 +315,7 @@ func TestRetry_MaxRetriesZero(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 0}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(0))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -334,11 +334,7 @@ func TestRetry_ContextCancellation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{
-		MaxRetries: 1,
-		BaseDelay:  2 * time.Second,
-		MaxDelay:   2 * time.Second,
-	}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -379,7 +375,7 @@ func TestRetry_NoGetBody_SkipsRetry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(2))
 	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
 	req.Body = io.NopCloser(strings.NewReader(`{"title":"demo"}`))
 	req.ContentLength = int64(len(`{"title":"demo"}`))

--- a/internal/client/retry_test.go
+++ b/internal/client/retry_test.go
@@ -1,0 +1,433 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetry_429ThenSuccess_GET(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("calls = %d, want %d", got, 2)
+	}
+}
+
+func TestRetry_429ThenSuccess_POST(t *testing.T) {
+	var calls int32
+	bodies := make([]string, 0, 2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"title":"demo"}`))
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("calls = %d, want %d", got, 2)
+	}
+	if len(bodies) != 2 || bodies[0] != bodies[1] {
+		t.Fatalf("bodies = %#v, want two identical request bodies", bodies)
+	}
+}
+
+func TestRetry_500ThenSuccess_GET(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("calls = %d, want %d", got, 2)
+	}
+}
+
+func TestRetry_500NoRetry_POST(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"title":"demo"}`))
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("calls = %d, want %d", got, 1)
+	}
+}
+
+func TestRetry_400NoRetry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("calls = %d, want %d", got, 1)
+	}
+}
+
+func TestRetry_401NoRetry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("calls = %d, want %d", got, 1)
+	}
+}
+
+func TestRetry_ExhaustedRetries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("calls = %d, want %d", got, 3)
+	}
+}
+
+func TestRetry_NetworkErrorThenSuccess_GET(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key",
+		WithHTTPClient(&http.Client{
+			Transport: &failOnceTransport{
+				err:  errors.New("temporary network error"),
+				base: srv.Client().Transport,
+			},
+		}),
+		WithRetry(RetryConfig{MaxRetries: 1}),
+	)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("server calls = %d, want %d", got, 1)
+	}
+}
+
+func TestRetry_NetworkErrorNoRetry_POST(t *testing.T) {
+	c := New("key",
+		WithHTTPClient(&http.Client{
+			Transport: &failOnceTransport{err: errors.New("temporary network error")},
+		}),
+		WithRetry(RetryConfig{MaxRetries: 2}),
+	)
+
+	req, _ := http.NewRequest(http.MethodPost, "http://example.invalid", strings.NewReader(`{"title":"demo"}`))
+	_, err := c.Do(req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	ft, ok := c.httpClient.Transport.(*retryTransport)
+	if !ok {
+		t.Fatalf("Transport = %T, want *retryTransport", c.httpClient.Transport)
+	}
+	failOnce, ok := ft.base.(*failOnceTransport)
+	if !ok {
+		t.Fatalf("retryTransport.base = %T, want *failOnceTransport", ft.base)
+	}
+	if failOnce.calls != 1 {
+		t.Fatalf("transport calls = %d, want %d", failOnce.calls, 1)
+	}
+}
+
+func TestRetry_RetryAfterSeconds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+
+	start := time.Now()
+	resp, err := c.Do(req)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if elapsed < time.Second {
+		t.Fatalf("elapsed = %v, want >= %v", elapsed, time.Second)
+	}
+}
+
+func TestRetry_RetryAfterHTTPDate(t *testing.T) {
+	var calls int32
+	delay := 2 * time.Second
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			w.Header().Set("Retry-After", time.Now().Add(delay).UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 1}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+
+	start := time.Now()
+	resp, err := c.Do(req)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if elapsed < time.Second {
+		t.Fatalf("elapsed = %v, want >= %v", elapsed, time.Second)
+	}
+}
+
+func TestRetry_MaxRetriesZero(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 0}))
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("calls = %d, want %d", got, 1)
+	}
+}
+
+func TestRetry_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{
+		MaxRetries: 1,
+		BaseDelay:  2 * time.Second,
+		MaxDelay:   2 * time.Second,
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	start := time.Now()
+	_, err := c.Do(req)
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want %v", err, context.Canceled)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("elapsed = %v, want cancellation before full backoff", elapsed)
+	}
+}
+
+func TestRetry_BackoffIncreases(t *testing.T) {
+	cfg := RetryConfig{BaseDelay: 100 * time.Millisecond, MaxDelay: 30 * time.Second}
+
+	first := backoffDelay(0, cfg)
+	second := backoffDelay(1, cfg)
+	third := backoffDelay(2, cfg)
+
+	if !(first < second && second < third) {
+		t.Fatalf("delays = %v, %v, %v, want strictly increasing", first, second, third)
+	}
+}
+
+func TestRetry_NoGetBody_SkipsRetry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := New("key", WithHTTPClient(srv.Client()), WithRetry(RetryConfig{MaxRetries: 2}))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	req.Body = io.NopCloser(strings.NewReader(`{"title":"demo"}`))
+	req.ContentLength = int64(len(`{"title":"demo"}`))
+	req.GetBody = nil
+
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusTooManyRequests)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("calls = %d, want %d", got, 1)
+	}
+}
+
+func TestParseRetryAfter_Invalid(t *testing.T) {
+	if got := parseRetryAfter("not-a-date"); got != 0 {
+		t.Fatalf("parseRetryAfter() = %v, want 0", got)
+	}
+}
+
+type failOnceTransport struct {
+	base  http.RoundTripper
+	err   error
+	calls int
+}
+
+func (t *failOnceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.calls++
+	if t.calls == 1 {
+		return nil, t.err
+	}
+	return t.base.RoundTrip(req)
+}
+
+func TestCloneRequestForRetry_PreservesURL(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/v1/videos?limit=1", nil)
+	cloned, err := cloneRequestForRetry(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := url.Parse(cloned.URL.String())
+	if got.String() != "https://example.com/v1/videos?limit=1" {
+		t.Fatalf("cloned URL = %q, want exact URL preserved", got.String())
+	}
+}

--- a/internal/client/retry_test.go
+++ b/internal/client/retry_test.go
@@ -26,7 +26,7 @@ func TestRetry_429ThenSuccess_GET(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
+	c := New("key", WithHTTPClient(srv.Client()), withFastRetries(1))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestRetry_429ThenSuccess_POST(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
+	c := New("key", WithHTTPClient(srv.Client()), withFastRetries(1))
 	req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"title":"demo"}`))
 	resp, err := c.Do(req)
 	if err != nil {
@@ -85,7 +85,7 @@ func TestRetry_500ThenSuccess_GET(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(1))
+	c := New("key", WithHTTPClient(srv.Client()), withFastRetries(1))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -175,7 +175,7 @@ func TestRetry_ExhaustedRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithHTTPClient(srv.Client()), WithMaxRetries(2))
+	c := New("key", WithHTTPClient(srv.Client()), withFastRetries(2))
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, err := c.Do(req)
 	if err != nil {
@@ -206,7 +206,7 @@ func TestRetry_NetworkErrorThenSuccess_GET(t *testing.T) {
 				base: srv.Client().Transport,
 			},
 		}),
-		WithMaxRetries(1),
+		withFastRetries(1),
 	)
 
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
@@ -398,6 +398,16 @@ func TestRetry_NoGetBody_SkipsRetry(t *testing.T) {
 func TestParseRetryAfter_Invalid(t *testing.T) {
 	if got := parseRetryAfter("not-a-date"); got != 0 {
 		t.Fatalf("parseRetryAfter() = %v, want 0", got)
+	}
+}
+
+// withFastRetries sets millisecond delays for tests. Unexported — only
+// available to tests in package client. The public API is WithMaxRetries(n).
+func withFastRetries(maxRetries int) Option {
+	return func(c *Client) {
+		c.retry.MaxRetries = maxRetries
+		c.retry.BaseDelay = time.Millisecond
+		c.retry.MaxDelay = time.Millisecond
 	}
 }
 


### PR DESCRIPTION
## Description

Adds automatic retry with exponential backoff to the HTTP client for transient failures. Every command benefits transparently — no per-command changes needed.

**Retry policy:**
- **429 (rate limited):** always retried, regardless of HTTP method — the server explicitly rejected without processing
- **5xx (server error):** retried only for idempotent methods (GET, HEAD, PUT, DELETE, OPTIONS). POST/PATCH are not retried on 5xx because the server may have processed the request
- **Network errors:** retried only for idempotent methods
- **4xx (except 429):** never retried — client errors won't resolve on retry

**Backoff:** exponential with ±25% jitter. `Retry-After` header (seconds or HTTP-date) is respected as minimum delay, clamped to `MaxDelay` (30s) to prevent excessive blocks.

**Configuration:** `HEYGEN_MAX_RETRIES` env var (default: 2 retries, 0 to disable). Internal/dev-only — not shown in `--help`.

**Safety:**
- Context-aware backoff — cancelled commands (Ctrl-C, timeout) exit immediately, not after the full delay
- Body replay guard — requests with a body but no `GetBody` (e.g., streaming readers) are never retried
- Caller's `*http.Client` is shallow-copied before wrapping the transport — no mutation of shared clients
- Response body drain capped at 4KB — prevents blocking on large error bodies from misbehaving servers

**API:** Single option `WithMaxRetries(n)` to configure retry count. Delays stay at defaults. No zero-value ambiguity.

Implemented as a `retryTransport` wrapping `http.RoundTripper`, the standard Go pattern. All callers of `Client.Do()` get retries transparently, including future features like video download.

Linear: PRINFRA-122

## Testing

16 retry transport tests covering: 429/5xx recovery (GET and POST), 400/401 no-retry, exhausted retries, network error handling, `Retry-After` parsing (seconds and HTTP-date), context cancellation, backoff progression, body replay guard, and no-GetBody skip.

8 client tests: default config, `WithMaxRetries`, `WithMaxRetries(0)`, `WithHTTPClient` preserves timeout, no mutation of shared clients, env var override.

2 executor integration tests: retry on 429 through full `Execute()` path, body preserved across retry on POST+429.

All tests use `httptest.Server` — no real API calls.