### PR TITLE
client: add pagination with --all flag (PRINFRA-125)

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -58,15 +57,6 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 					cols := defaultColumnsForSpec(spec)
 					result, err := ctx.client.ExecuteAll(spec, inv)
 					if err != nil {
-						var truncErr *client.ErrPaginationTruncated
-						if errors.As(err, &truncErr) {
-							// Output partial data, then signal truncation via CLIError.
-							// The error goes through formatter.Error() — no raw stderr writes.
-							if fmtErr := ctx.formatter.Data(truncErr.Data, "", cols); fmtErr != nil {
-								return fmtErr
-							}
-							return clierrors.New(truncErr.Error())
-						}
 						return err
 					}
 
@@ -79,7 +69,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
-			return ctx.formatter.Data(result, "data", defaultColumnsForSpec(spec))
+			return ctx.formatter.Data(result, client.APIDataField, defaultColumnsForSpec(spec))
 		},
 	}
 
@@ -89,7 +79,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 	}
 
 	if spec.Paginated {
-		cmd.Flags().Bool("all", false, "Fetch all pages (returns flat JSON array instead of API envelope)")
+		cmd.Flags().Bool("all", false, "Fetch all pages into a single JSON array. For datasets over 10,000 items, consider paginating manually with --token.")
 	}
 
 	// Add -d/--data for commands with JSON request bodies

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 
+	"github.com/heygen-com/heygen-cli/internal/client"
 	"github.com/heygen-com/heygen-cli/internal/command"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 	"github.com/spf13/cobra"
@@ -41,6 +43,33 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
+			if spec.Paginated {
+				allPages, _ := cmd.Flags().GetBool("all")
+				cursorFlagName := cursorFlagForSpec(spec)
+				cursorSet := cursorFlagName != "" && cmd.Flags().Changed(cursorFlagName)
+
+				if allPages && cursorSet {
+					return clierrors.NewUsage(fmt.Sprintf("--all and --%s are mutually exclusive", cursorFlagName))
+				}
+
+				if allPages {
+					result, err := ctx.client.ExecuteAll(spec, inv)
+					if err != nil {
+						var truncErr *client.ErrPaginationTruncated
+						if errors.As(err, &truncErr) {
+							fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", truncErr.Error())
+							if fmtErr := ctx.formatter.Data(truncErr.Data); fmtErr != nil {
+								return fmtErr
+							}
+							return clierrors.New(truncErr.Error())
+						}
+						return err
+					}
+
+					return ctx.formatter.Data(result)
+				}
+			}
+
 			result, err := ctx.client.Execute(spec, inv)
 			if err != nil {
 				return err
@@ -53,6 +82,10 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 	// Register flags from spec
 	for _, flag := range spec.Flags {
 		registerFlag(cmd, flag)
+	}
+
+	if spec.Paginated {
+		cmd.Flags().Bool("all", false, "Fetch all pages (returns flat JSON array instead of API envelope)")
 	}
 
 	// Add -d/--data for commands with JSON request bodies
@@ -84,6 +117,15 @@ func buildUseLine(spec *command.Spec) string {
 		parts = append(parts, "<"+arg.Name+">")
 	}
 	return strings.Join(parts, " ")
+}
+
+func cursorFlagForSpec(spec *command.Spec) string {
+	for _, flag := range spec.Flags {
+		if flag.JSONName == spec.TokenParam {
+			return flag.Name
+		}
+	}
+	return ""
 }
 
 // registerFlag adds a typed flag to the Cobra command based on the FlagSpec.

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -79,7 +79,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
-			return ctx.formatter.Data(result, spec.DataField, defaultColumnsForSpec(spec))
+			return ctx.formatter.Data(result, "data", defaultColumnsForSpec(spec))
 		},
 	}
 
@@ -125,7 +125,7 @@ func buildUseLine(spec *command.Spec) string {
 
 func cursorFlagForSpec(spec *command.Spec) string {
 	for _, flag := range spec.Flags {
-		if flag.JSONName == spec.TokenParam {
+		if flag.JSONName == "token" {
 			return flag.Name
 		}
 	}

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -53,12 +53,16 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				}
 
 				if allPages {
+					// --all returns a flat array (no envelope), so dataField is empty.
+					// Columns are still passed so --human renders a curated table.
+					cols := defaultColumnsForSpec(spec)
 					result, err := ctx.client.ExecuteAll(spec, inv)
 					if err != nil {
 						var truncErr *client.ErrPaginationTruncated
 						if errors.As(err, &truncErr) {
-							fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", truncErr.Error())
-							if fmtErr := ctx.formatter.Data(truncErr.Data, "", nil); fmtErr != nil {
+							// Output partial data, then signal truncation via CLIError.
+							// The error goes through formatter.Error() — no raw stderr writes.
+							if fmtErr := ctx.formatter.Data(truncErr.Data, "", cols); fmtErr != nil {
 								return fmtErr
 							}
 							return clierrors.New(truncErr.Error())
@@ -66,7 +70,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 						return err
 					}
 
-					return ctx.formatter.Data(result, "", nil)
+					return ctx.formatter.Data(result, "", cols)
 				}
 			}
 

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -58,7 +58,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 						var truncErr *client.ErrPaginationTruncated
 						if errors.As(err, &truncErr) {
 							fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", truncErr.Error())
-							if fmtErr := ctx.formatter.Data(truncErr.Data); fmtErr != nil {
+							if fmtErr := ctx.formatter.Data(truncErr.Data, "", nil); fmtErr != nil {
 								return fmtErr
 							}
 							return clierrors.New(truncErr.Error())
@@ -66,7 +66,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 						return err
 					}
 
-					return ctx.formatter.Data(result)
+					return ctx.formatter.Data(result, "", nil)
 				}
 			}
 

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -249,8 +249,8 @@ func TestGenBuilder_VideoList_AllPages_Truncated(t *testing.T) {
 	if res.ExitCode != 1 {
 		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, "Warning: pagination stopped at 10000 items") {
-		t.Fatalf("stderr = %s, want truncation warning", res.Stderr)
+	if !strings.Contains(res.Stderr, "pagination stopped at 10000 items") {
+		t.Fatalf("stderr = %s, want truncation message", res.Stderr)
 	}
 
 	var parsed []map[string]any

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -204,60 +203,6 @@ func TestGenBuilder_VideoList_NoAllFlag_NonPaginated(t *testing.T) {
 	}
 }
 
-func TestGenBuilder_VideoList_AllPages_Truncated(t *testing.T) {
-	var calls int
-	srv := setupTestServer(t, map[string]testHandler{
-		"GET /v3/videos": {
-			StatusCode: 200,
-			ValidateRequest: func(t *testing.T, r *http.Request) {
-				t.Helper()
-				calls++
-			},
-			Body: truncatedPageBody(0, 2500, "cursor_1"),
-		},
-	})
-	defer srv.Close()
-
-	originalHandler := srv.Config.Handler
-	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := r.URL.Query().Get("token")
-		switch token {
-		case "":
-			originalHandler.ServeHTTP(w, r)
-		case "cursor_1":
-			calls++
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(truncatedPageBody(2500, 2500, "cursor_2")))
-		case "cursor_2":
-			calls++
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(truncatedPageBody(5000, 2500, "cursor_3")))
-		case "cursor_3":
-			calls++
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(truncatedPageBody(7500, 2500, "cursor_4")))
-		default:
-			t.Fatalf("unexpected token %q", token)
-		}
-	})
-
-	res := runGenCommand(t, srv.URL, "test-key", videoListSpec, "list", "--all")
-
-	if res.ExitCode != 1 {
-		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
-	}
-	if !strings.Contains(res.Stderr, "pagination stopped at 10000 items") {
-		t.Fatalf("stderr = %s, want truncation message", res.Stderr)
-	}
-
-	var parsed []map[string]any
-	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
-		t.Fatalf("stdout is not valid JSON array: %v\nstdout: %s", err, res.Stdout)
-	}
-	if len(parsed) != 10000 {
-		t.Fatalf("len(parsed) = %d, want 10000", len(parsed))
-	}
-}
 
 func TestGenBuilder_PostWithBodyFlags(t *testing.T) {
 	var gotBody map[string]any
@@ -604,19 +549,3 @@ func runGeneratedRootCommand(t *testing.T, serverURL, apiKey string, groups map[
 	}
 }
 
-func truncatedPageBody(start, count int, nextToken string) string {
-	items := make([]map[string]any, 0, count)
-	for i := 0; i < count; i++ {
-		items = append(items, map[string]any{"id": fmt.Sprintf("v%d", start+i)})
-	}
-	body := map[string]any{
-		"data": items,
-	}
-	if nextToken == "" {
-		body["next_token"] = nil
-	} else {
-		body["next_token"] = nextToken
-	}
-	raw, _ := json.Marshal(body)
-	return string(raw)
-}

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -18,15 +18,12 @@ import (
 // videoListSpec mirrors the hand-written video list command as a Spec,
 // proving the generic builder produces identical behavior.
 var videoListSpec = &command.Spec{
-	Group:      "video",
-	Name:       "list",
-	Summary:    "List videos",
-	Endpoint:   "/v3/videos",
-	Method:     "GET",
-	Paginated:  true,
-	TokenField: "next_token",
-	TokenParam: "token",
-	DataField:  "data",
+	Group:     "video",
+	Name:      "list",
+	Summary:   "List videos",
+	Endpoint:  "/v3/videos",
+	Method:    "GET",
+	Paginated: true,
 	Flags: []command.FlagSpec{
 		{Name: "limit", Type: "int", Source: "query", JSONName: "limit"},
 		{Name: "token", Type: "string", Source: "query", JSONName: "token"},

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -17,13 +18,14 @@ import (
 // videoListSpec mirrors the hand-written video list command as a Spec,
 // proving the generic builder produces identical behavior.
 var videoListSpec = &command.Spec{
-	Group:    "video",
-	Name:     "list",
-	Summary:  "List videos",
-	Endpoint: "/v3/videos",
-	Method:   "GET",
-	// TokenField/DataField for pagination (used by paginator, not tested here)
+	Group:      "video",
+	Name:       "list",
+	Summary:    "List videos",
+	Endpoint:   "/v3/videos",
+	Method:     "GET",
+	Paginated:  true,
 	TokenField: "next_token",
+	TokenParam: "token",
 	DataField:  "data",
 	Flags: []command.FlagSpec{
 		{Name: "limit", Type: "int", Source: "query", JSONName: "limit"},
@@ -89,6 +91,174 @@ func TestGenBuilder_VideoList_Flags(t *testing.T) {
 
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestGenBuilder_VideoList_AllPages(t *testing.T) {
+	var calls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 200,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				calls++
+				switch calls {
+				case 1:
+					if got := r.URL.Query().Get("token"); got != "" {
+						t.Fatalf("first page token = %q, want empty", got)
+					}
+				case 2:
+					if got := r.URL.Query().Get("token"); got != "cursor_2" {
+						t.Fatalf("second page token = %q, want %q", got, "cursor_2")
+					}
+				default:
+					t.Fatalf("unexpected request count %d", calls)
+				}
+			},
+			Body: `{"data":[{"id":"v1"},{"id":"v2"}],"next_token":"cursor_2"}`,
+		},
+	})
+	defer srv.Close()
+
+	originalHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("token") == "cursor_2" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":"v3"}],"next_token":null}`))
+			return
+		}
+		originalHandler.ServeHTTP(w, r)
+	})
+
+	res := runGenCommand(t, srv.URL, "test-key", videoListSpec, "list", "--all")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON array: %v\nstdout: %s", err, res.Stdout)
+	}
+	if len(parsed) != 3 {
+		t.Fatalf("len(parsed) = %d, want 3", len(parsed))
+	}
+}
+
+func TestGenBuilder_VideoList_AllPages_SinglePage(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":[{"id":"v1"}],"next_token":null}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", videoListSpec, "list", "--all")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON array: %v\nstdout: %s", err, res.Stdout)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("len(parsed) = %d, want 1", len(parsed))
+	}
+}
+
+func TestGenBuilder_VideoList_AllAndTokenConflict(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", videoListSpec, "list", "--all", "--token", "cursor_abc")
+
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "--all and --token are mutually exclusive") {
+		t.Fatalf("stderr = %s, want conflict message", res.Stderr)
+	}
+}
+
+func TestGenBuilder_VideoList_NoAllFlag_NonPaginated(t *testing.T) {
+	nonPaginated := &command.Spec{
+		Group:    "video",
+		Name:     "get",
+		Summary:  "Get video",
+		Endpoint: "/v3/videos/{video_id}",
+		Method:   "GET",
+		Args: []command.ArgSpec{
+			{Name: "video-id", Param: "video_id"},
+		},
+		Examples: []string{"heygen video get <video-id>"},
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", nonPaginated, "get", "vid_123", "--all")
+
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "unknown flag: --all") {
+		t.Fatalf("stderr = %s, want unknown flag error", res.Stderr)
+	}
+}
+
+func TestGenBuilder_VideoList_AllPages_Truncated(t *testing.T) {
+	var calls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos": {
+			StatusCode: 200,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				calls++
+			},
+			Body: truncatedPageBody(0, 2500, "cursor_1"),
+		},
+	})
+	defer srv.Close()
+
+	originalHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		switch token {
+		case "":
+			originalHandler.ServeHTTP(w, r)
+		case "cursor_1":
+			calls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(truncatedPageBody(2500, 2500, "cursor_2")))
+		case "cursor_2":
+			calls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(truncatedPageBody(5000, 2500, "cursor_3")))
+		case "cursor_3":
+			calls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(truncatedPageBody(7500, 2500, "cursor_4")))
+		default:
+			t.Fatalf("unexpected token %q", token)
+		}
+	})
+
+	res := runGenCommand(t, srv.URL, "test-key", videoListSpec, "list", "--all")
+
+	if res.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "Warning: pagination stopped at 10000 items") {
+		t.Fatalf("stderr = %s, want truncation warning", res.Stderr)
+	}
+
+	var parsed []map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON array: %v\nstdout: %s", err, res.Stdout)
+	}
+	if len(parsed) != 10000 {
+		t.Fatalf("len(parsed) = %d, want 10000", len(parsed))
 	}
 }
 
@@ -435,4 +605,21 @@ func runGeneratedRootCommand(t *testing.T, serverURL, apiKey string, groups map[
 		Stderr:   stderr.String(),
 		ExitCode: exitCode,
 	}
+}
+
+func truncatedPageBody(start, count int, nextToken string) string {
+	items := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		items = append(items, map[string]any{"id": fmt.Sprintf("v%d", start+i)})
+	}
+	body := map[string]any{
+		"data": items,
+	}
+	if nextToken == "" {
+		body["next_token"] = nil
+	} else {
+		body["next_token"] = nextToken
+	}
+	raw, _ := json.Marshal(body)
+	return string(raw)
 }

--- a/cmd/heygen/testutil_test.go
+++ b/cmd/heygen/testutil_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
@@ -70,10 +71,11 @@ func runCommandWithInput(t *testing.T, serverURL, apiKey string, stdin io.Reader
 	formatter := formatterForArgs(args, &stdout, &stderr)
 
 	// Set env vars for this test
-	if apiKey != "" {
-		t.Setenv("HEYGEN_API_KEY", apiKey)
-	}
+	t.Setenv("HEYGEN_API_KEY", apiKey)
 	t.Setenv("HEYGEN_API_BASE", serverURL)
+	if _, ok := os.LookupEnv("HEYGEN_CONFIG_DIR"); !ok {
+		t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	}
 
 	cmd := newRootCmd("test", formatter)
 	cmd.SetOut(&stdout)

--- a/codegen/grouper.go
+++ b/codegen/grouper.go
@@ -53,6 +53,7 @@ import (
 //	  → sessions → sub-group, {session_id} → arg, stop → sub-group
 //	  → x-cli-action: true → no terminal verb appended
 //	  → result: heygen video-agent sessions stop <session-id>
+//
 // GroupDescriptions maps group name → description from the OpenAPI tag.
 // Used by the builder for group command help text.
 type GroupDescriptions map[string]string
@@ -157,7 +158,7 @@ func buildSpec(
 	}
 
 	// Pagination
-	_, spec.TokenField, spec.DataField = detectPagination(op)
+	spec.Paginated, spec.TokenField, spec.TokenParam, spec.DataField = detectPagination(op, pathItem)
 
 	// Flags from query params
 	for _, paramRef := range collectParams(pathItem, op) {
@@ -439,7 +440,7 @@ func isComplexField(s *openapi3.Schema) bool {
 
 // --- Response analysis ---
 
-func detectPagination(op *openapi3.Operation) (hasMore bool, tokenField, dataField string) {
+func detectPagination(op *openapi3.Operation, pathItem *openapi3.PathItem) (paginated bool, tokenField, tokenParam, dataField string) {
 	respSchema := successResponseSchema(op)
 	if respSchema == nil {
 		return
@@ -455,11 +456,39 @@ func detectPagination(op *openapi3.Operation) (hasMore bool, tokenField, dataFie
 	for _, schema := range schemasToCheck {
 		for _, candidate := range []string{"next_token", "token", "cursor"} {
 			if _, ok := schema.Properties[candidate]; ok {
-				return true, candidate, dataField
+				tokenField = candidate
+				break
 			}
 		}
+		if tokenField != "" {
+			break
+		}
 	}
-	return
+	if tokenField == "" {
+		return false, "", "", dataField
+	}
+
+	tokenParam = detectCursorParam(pathItem, op)
+	if tokenParam == "" {
+		return false, tokenField, "", dataField
+	}
+
+	return true, tokenField, tokenParam, dataField
+}
+
+func detectCursorParam(pathItem *openapi3.PathItem, op *openapi3.Operation) string {
+	params := collectParams(pathItem, op)
+	for _, paramRef := range params {
+		param := paramRef.Value
+		if param == nil || param.In != "query" {
+			continue
+		}
+		switch param.Name {
+		case "token", "cursor", "page_token":
+			return param.Name
+		}
+	}
+	return ""
 }
 
 func successResponseSchema(op *openapi3.Operation) *openapi3.Schema {

--- a/codegen/grouper.go
+++ b/codegen/grouper.go
@@ -157,8 +157,9 @@ func buildSpec(
 		spec.BodyEncoding = "multipart"
 	}
 
-	// Pagination
-	spec.Paginated, spec.TokenField, spec.TokenParam, spec.DataField = detectPagination(op, pathItem)
+	// Pagination — only sets Paginated bool. The cursor field names and data
+	// field are API conventions hardcoded in the client package.
+	spec.Paginated = detectPagination(op, pathItem)
 
 	// Flags from query params
 	for _, paramRef := range collectParams(pathItem, op) {
@@ -440,42 +441,38 @@ func isComplexField(s *openapi3.Schema) bool {
 
 // --- Response analysis ---
 
-func detectPagination(op *openapi3.Operation, pathItem *openapi3.PathItem) (paginated bool, tokenField, tokenParam, dataField string) {
+// detectPagination returns true if the endpoint supports cursor-based pagination.
+// An endpoint is paginated when both: (1) the response has a cursor field
+// (next_token, token, or cursor), and (2) the request has a cursor query param
+// (token, cursor, or page_token).
+func detectPagination(op *openapi3.Operation, pathItem *openapi3.PathItem) bool {
 	respSchema := successResponseSchema(op)
 	if respSchema == nil {
-		return
+		return false
 	}
-	if dataProp := respSchema.Properties["data"]; dataProp != nil && dataProp.Value != nil {
-		dataField = "data"
-	}
-	// Check for token at root level and inside data wrapper
+
+	// Check for cursor field in response (at root or inside data wrapper)
+	hasCursorField := false
 	schemasToCheck := []*openapi3.Schema{respSchema}
-	if dataField != "" {
-		schemasToCheck = append(schemasToCheck, respSchema.Properties["data"].Value)
+	if dataProp := respSchema.Properties["data"]; dataProp != nil && dataProp.Value != nil {
+		schemasToCheck = append(schemasToCheck, dataProp.Value)
 	}
 	for _, schema := range schemasToCheck {
 		for _, candidate := range []string{"next_token", "token", "cursor"} {
 			if _, ok := schema.Properties[candidate]; ok {
-				tokenField = candidate
+				hasCursorField = true
 				break
 			}
 		}
-		if tokenField != "" {
+		if hasCursorField {
 			break
 		}
 	}
-	if tokenField == "" {
-		return false, "", "", dataField
+	if !hasCursorField {
+		return false
 	}
 
-	tokenParam = detectCursorParam(pathItem, op)
-	if tokenParam == "" {
-		// Response has a token field but no cursor query param — not paginated.
-		// Clear tokenField to avoid inconsistency.
-		return false, "", "", dataField
-	}
-
-	return true, tokenField, tokenParam, dataField
+	return detectCursorParam(pathItem, op) != ""
 }
 
 func detectCursorParam(pathItem *openapi3.PathItem, op *openapi3.Operation) string {

--- a/codegen/grouper.go
+++ b/codegen/grouper.go
@@ -470,7 +470,9 @@ func detectPagination(op *openapi3.Operation, pathItem *openapi3.PathItem) (pagi
 
 	tokenParam = detectCursorParam(pathItem, op)
 	if tokenParam == "" {
-		return false, tokenField, "", dataField
+		// Response has a token field but no cursor query param — not paginated.
+		// Clear tokenField to avoid inconsistency.
+		return false, "", "", dataField
 	}
 
 	return true, tokenField, tokenParam, dataField

--- a/codegen/grouper.go
+++ b/codegen/grouper.go
@@ -458,13 +458,8 @@ func detectPagination(op *openapi3.Operation, pathItem *openapi3.PathItem) bool 
 		schemasToCheck = append(schemasToCheck, dataProp.Value)
 	}
 	for _, schema := range schemasToCheck {
-		for _, candidate := range []string{"next_token", "token", "cursor"} {
-			if _, ok := schema.Properties[candidate]; ok {
-				hasCursorField = true
-				break
-			}
-		}
-		if hasCursorField {
+		if _, ok := schema.Properties["next_token"]; ok {
+			hasCursorField = true
 			break
 		}
 	}
@@ -482,8 +477,7 @@ func detectCursorParam(pathItem *openapi3.PathItem, op *openapi3.Operation) stri
 		if param == nil || param.In != "query" {
 			continue
 		}
-		switch param.Name {
-		case "token", "cursor", "page_token":
+		if param.Name == "token" {
 			return param.Name
 		}
 	}

--- a/codegen/grouper_test.go
+++ b/codegen/grouper_test.go
@@ -156,8 +156,14 @@ func TestGroupEndpoints_Pagination(t *testing.T) {
 		if s.Name != "list" {
 			continue
 		}
+		if !s.Paginated {
+			t.Error("Paginated = false, want true")
+		}
 		if s.TokenField != "token" {
 			t.Errorf("TokenField = %q, want 'token'", s.TokenField)
+		}
+		if s.TokenParam != "token" {
+			t.Errorf("TokenParam = %q, want 'token'", s.TokenParam)
 		}
 		if s.DataField != "data" {
 			t.Errorf("DataField = %q, want 'data'", s.DataField)

--- a/codegen/grouper_test.go
+++ b/codegen/grouper_test.go
@@ -159,15 +159,6 @@ func TestGroupEndpoints_Pagination(t *testing.T) {
 		if !s.Paginated {
 			t.Error("Paginated = false, want true")
 		}
-		if s.TokenField != "token" {
-			t.Errorf("TokenField = %q, want 'token'", s.TokenField)
-		}
-		if s.TokenParam != "token" {
-			t.Errorf("TokenParam = %q, want 'token'", s.TokenParam)
-		}
-		if s.DataField != "data" {
-			t.Errorf("DataField = %q, want 'data'", s.DataField)
-		}
 		return
 	}
 	t.Error("video list not found")

--- a/codegen/templates/command.go.tmpl
+++ b/codegen/templates/command.go.tmpl
@@ -14,8 +14,14 @@ var {{pascalCase .Group}}{{pascalCase .Name}} = &command.Spec{
 	Endpoint:    {{quote .Endpoint}},
 	Method:      {{quote .Method}},
 	BodyEncoding: {{quote .BodyEncoding}},
+{{- if .Paginated}}
+	Paginated:   true,
+{{- end}}
 {{- if .TokenField}}
 	TokenField:  {{quote .TokenField}},
+{{- end}}
+{{- if .TokenParam}}
+	TokenParam:  {{quote .TokenParam}},
 {{- end}}
 {{- if .DataField}}
 	DataField:   {{quote .DataField}},

--- a/codegen/templates/command.go.tmpl
+++ b/codegen/templates/command.go.tmpl
@@ -17,15 +17,6 @@ var {{pascalCase .Group}}{{pascalCase .Name}} = &command.Spec{
 {{- if .Paginated}}
 	Paginated:   true,
 {{- end}}
-{{- if .TokenField}}
-	TokenField:  {{quote .TokenField}},
-{{- end}}
-{{- if .TokenParam}}
-	TokenParam:  {{quote .TokenParam}},
-{{- end}}
-{{- if .DataField}}
-	DataField:   {{quote .DataField}},
-{{- end}}
 {{- if .Examples}}
 	Examples: []string{
 {{- range .Examples}}

--- a/codegen/testdata/golden/upload.go
+++ b/codegen/testdata/golden/upload.go
@@ -12,7 +12,6 @@ var UploadCreate = &command.Spec{
 	Endpoint:     "/v3/uploads",
 	Method:       "POST",
 	BodyEncoding: "multipart",
-	DataField:    "data",
 	Flags: []command.FlagSpec{
 		{
 			Name:     "file",

--- a/codegen/testdata/golden/widget.go
+++ b/codegen/testdata/golden/widget.go
@@ -12,7 +12,6 @@ var WidgetActivateCreate = &command.Spec{
 	Endpoint:     "/v3/widgets/{widget_id}/activate",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Args: []command.ArgSpec{
 		{Name: "widget-id", Param: "widget_id", Help: ""},
 	},
@@ -40,7 +39,6 @@ var WidgetCreate = &command.Spec{
 	Endpoint:     "/v3/widgets",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Flags: []command.FlagSpec{
 		{
 			Name:     "count",
@@ -89,7 +87,6 @@ var WidgetDelete = &command.Spec{
 	Endpoint:     "/v3/widgets/{widget_id}",
 	Method:       "DELETE",
 	BodyEncoding: "",
-	DataField:    "data",
 	Args: []command.ArgSpec{
 		{Name: "widget-id", Param: "widget_id", Help: ""},
 	},
@@ -103,7 +100,6 @@ var WidgetGet = &command.Spec{
 	Endpoint:     "/v3/widgets/{widget_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Args: []command.ArgSpec{
 		{Name: "widget-id", Param: "widget_id", Help: ""},
 	},
@@ -118,9 +114,6 @@ var WidgetList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Flags: []command.FlagSpec{
 		{
 			Name:     "limit",

--- a/codegen/testdata/golden/widget.go
+++ b/codegen/testdata/golden/widget.go
@@ -117,7 +117,9 @@ var WidgetList = &command.Spec{
 	Endpoint:     "/v3/widgets",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Flags: []command.FlagSpec{
 		{

--- a/codegen/testdata/test_spec.yaml
+++ b/codegen/testdata/test_spec.yaml
@@ -37,7 +37,7 @@ paths:
                         type: array
                         items:
                           type: object
-                      token:
+                      next_token:
                         type: string
     post:
       tags: [Videos]

--- a/gen/asset.go
+++ b/gen/asset.go
@@ -12,7 +12,6 @@ var AssetCreate = &command.Spec{
 	Endpoint:     "/v3/assets",
 	Method:       "POST",
 	BodyEncoding: "multipart",
-	DataField:    "data",
 	Examples: []string{
 		"heygen asset create --file ./video.mp4",
 	},

--- a/gen/avatar.go
+++ b/gen/avatar.go
@@ -12,7 +12,6 @@ var AvatarConsentCreate = &command.Spec{
 	Endpoint:     "/v3/avatars/{group_id}/consent",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen avatar consent create <group-id>",
 	},
@@ -29,7 +28,6 @@ var AvatarCreate = &command.Spec{
 	Endpoint:     "/v3/avatars",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen avatar create",
 	},
@@ -43,7 +41,6 @@ var AvatarGet = &command.Spec{
 	Endpoint:     "/v3/avatars/{group_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen avatar get <group-id>",
 	},
@@ -61,9 +58,6 @@ var AvatarList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen avatar list --limit 10",
 	},
@@ -115,7 +109,6 @@ var AvatarLooksGet = &command.Spec{
 	Endpoint:     "/v3/avatars/looks/{look_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen avatar looks get <look-id>",
 	},
@@ -133,9 +126,6 @@ var AvatarLooksList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen avatar looks list --limit 10",
 	},

--- a/gen/avatar.go
+++ b/gen/avatar.go
@@ -60,7 +60,9 @@ var AvatarList = &command.Spec{
 	Endpoint:     "/v3/avatars",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen avatar list --limit 10",
@@ -130,7 +132,9 @@ var AvatarLooksList = &command.Spec{
 	Endpoint:     "/v3/avatars/looks",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen avatar looks list --limit 10",

--- a/gen/overdub.go
+++ b/gen/overdub.go
@@ -12,7 +12,6 @@ var OverdubCreate = &command.Spec{
 	Endpoint:     "/v3/overdubs",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"cat request.json | heygen overdub create -d -",
 	},
@@ -100,7 +99,6 @@ var OverdubDelete = &command.Spec{
 	Endpoint:     "/v3/overdubs/{overdub_id}",
 	Method:       "DELETE",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen overdub delete <overdub-id>",
 	},
@@ -117,7 +115,6 @@ var OverdubGet = &command.Spec{
 	Endpoint:     "/v3/overdubs/{overdub_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen overdub get <overdub-id>",
 	},
@@ -135,9 +132,6 @@ var OverdubList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen overdub list --limit 10",
 	},
@@ -177,7 +171,6 @@ var OverdubUpdate = &command.Spec{
 	Endpoint:     "/v3/overdubs/{overdub_id}",
 	Method:       "PATCH",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen overdub update <overdub-id> --title 'Updated title'",
 	},

--- a/gen/overdub.go
+++ b/gen/overdub.go
@@ -134,7 +134,9 @@ var OverdubList = &command.Spec{
 	Endpoint:     "/v3/overdubs",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen overdub list --limit 10",

--- a/gen/user.go
+++ b/gen/user.go
@@ -12,7 +12,6 @@ var UserMeGet = &command.Spec{
 	Endpoint:     "/v3/user/me",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen user me get",
 	},

--- a/gen/video-agent.go
+++ b/gen/video-agent.go
@@ -260,7 +260,9 @@ var VideoAgentStylesList = &command.Spec{
 	Endpoint:     "/v3/video-agents/styles",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent styles list",

--- a/gen/video-agent.go
+++ b/gen/video-agent.go
@@ -12,7 +12,6 @@ var VideoAgentCreate = &command.Spec{
 	Endpoint:     "/v3/video-agents",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent create --prompt 'Make a product demo' --style-id modern",
 	},
@@ -52,7 +51,6 @@ var VideoAgentSessionsCreate = &command.Spec{
 	Endpoint:     "/v3/video-agents/sessions",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent sessions create --prompt 'Interview video'",
 	},
@@ -104,7 +102,6 @@ var VideoAgentSessionsGet = &command.Spec{
 	Endpoint:     "/v3/video-agents/sessions/{session_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent sessions get <session-id>",
 	},
@@ -121,7 +118,6 @@ var VideoAgentSessionsMessagesCreate = &command.Spec{
 	Endpoint:     "/v3/video-agents/sessions/{session_id}/messages",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent sessions messages create <session-id> --message 'Add intro'",
 	},
@@ -164,7 +160,6 @@ var VideoAgentSessionsResourcesGet = &command.Spec{
 	Endpoint:     "/v3/video-agents/sessions/{session_id}/resources",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent sessions resources list <session-id>",
 	},
@@ -243,7 +238,6 @@ var VideoAgentSessionsStop = &command.Spec{
 	Endpoint:     "/v3/video-agents/sessions/{session_id}/stop",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent sessions stop <session-id>",
 	},
@@ -261,9 +255,6 @@ var VideoAgentStylesList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-agent styles list",
 	},

--- a/gen/video-translate.go
+++ b/gen/video-translate.go
@@ -12,7 +12,6 @@ var VideoTranslateCaptionGet = &command.Spec{
 	Endpoint:     "/v3/video-translations/{video_translation_id}/caption",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate caption get <video-translation-id> --format srt",
 	},
@@ -43,7 +42,6 @@ var VideoTranslateCreate = &command.Spec{
 	Endpoint:     "/v3/video-translations",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"cat request.json | heygen video-translate create -d -",
 	},
@@ -155,7 +153,6 @@ var VideoTranslateDelete = &command.Spec{
 	Endpoint:     "/v3/video-translations/{video_translation_id}",
 	Method:       "DELETE",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate delete <video-translation-id>",
 	},
@@ -172,7 +169,6 @@ var VideoTranslateGet = &command.Spec{
 	Endpoint:     "/v3/video-translations/{video_translation_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate get <video-translation-id>",
 	},
@@ -189,7 +185,6 @@ var VideoTranslateLanguagesList = &command.Spec{
 	Endpoint:     "/v3/video-translations/languages",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate languages list",
 	},
@@ -204,9 +199,6 @@ var VideoTranslateList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate list --limit 10",
 	},
@@ -246,7 +238,6 @@ var VideoTranslateProofreadsCreate = &command.Spec{
 	Endpoint:     "/v3/video-translations/proofreads",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"cat request.json | heygen video-translate proofreads create -d -",
 	},
@@ -346,7 +337,6 @@ var VideoTranslateProofreadsGenerate = &command.Spec{
 	Endpoint:     "/v3/video-translations/proofreads/{proofread_id}/generate",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate proofreads generate <proofread-id>",
 	},
@@ -389,7 +379,6 @@ var VideoTranslateProofreadsGet = &command.Spec{
 	Endpoint:     "/v3/video-translations/proofreads/{proofread_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate proofreads get <proofread-id>",
 	},
@@ -406,7 +395,6 @@ var VideoTranslateProofreadsSrtGet = &command.Spec{
 	Endpoint:     "/v3/video-translations/proofreads/{proofread_id}/srt",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate proofreads srt get <proofread-id>",
 	},
@@ -423,7 +411,6 @@ var VideoTranslateProofreadsSrtUpdate = &command.Spec{
 	Endpoint:     "/v3/video-translations/proofreads/{proofread_id}/srt",
 	Method:       "PUT",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate proofreads srt update <proofread-id>",
 	},
@@ -440,7 +427,6 @@ var VideoTranslateUpdate = &command.Spec{
 	Endpoint:     "/v3/video-translations/{video_translation_id}",
 	Method:       "PATCH",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate update <video-translation-id> --title 'New title'",
 	},

--- a/gen/video-translate.go
+++ b/gen/video-translate.go
@@ -203,7 +203,9 @@ var VideoTranslateList = &command.Spec{
 	Endpoint:     "/v3/video-translations",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen video-translate list --limit 10",

--- a/gen/video.go
+++ b/gen/video.go
@@ -60,7 +60,9 @@ var VideoList = &command.Spec{
 	Endpoint:     "/v3/videos",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen video list --limit 10",

--- a/gen/video.go
+++ b/gen/video.go
@@ -12,7 +12,6 @@ var VideoCreate = &command.Spec{
 	Endpoint:     "/v3/videos",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video create --avatar-id josh_lite --script 'Hello world' --voice-id en_male",
 	},
@@ -26,7 +25,6 @@ var VideoDelete = &command.Spec{
 	Endpoint:     "/v3/videos/{video_id}",
 	Method:       "DELETE",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video delete <video-id>",
 	},
@@ -43,7 +41,6 @@ var VideoGet = &command.Spec{
 	Endpoint:     "/v3/videos/{video_id}",
 	Method:       "GET",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video get <video-id>",
 	},
@@ -61,9 +58,6 @@ var VideoList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen video list --limit 10",
 		"heygen video list --folder-id abc123",

--- a/gen/voice.go
+++ b/gen/voice.go
@@ -13,9 +13,6 @@ var VoiceList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen voice list --type public",
 	},
@@ -103,7 +100,6 @@ var VoiceSpeechCreate = &command.Spec{
 	Endpoint:     "/v3/voices/speech",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen voice speech create --text 'Hello world' --voice-id en_male",
 	},

--- a/gen/voice.go
+++ b/gen/voice.go
@@ -12,7 +12,9 @@ var VoiceList = &command.Spec{
 	Endpoint:     "/v3/voices",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen voice list --type public",

--- a/gen/webhook.go
+++ b/gen/webhook.go
@@ -57,7 +57,9 @@ var WebhookEndpointsList = &command.Spec{
 	Endpoint:     "/v3/webhooks/endpoints",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen webhook endpoints list",
@@ -147,7 +149,9 @@ var WebhookEventsList = &command.Spec{
 	Endpoint:     "/v3/webhooks/events",
 	Method:       "GET",
 	BodyEncoding: "",
+	Paginated:    true,
 	TokenField:   "next_token",
+	TokenParam:   "token",
 	DataField:    "data",
 	Examples: []string{
 		"heygen webhook events list --event-type avatar_video.success",

--- a/gen/webhook.go
+++ b/gen/webhook.go
@@ -12,7 +12,6 @@ var WebhookEndpointsCreate = &command.Spec{
 	Endpoint:     "/v3/webhooks/endpoints",
 	Method:       "POST",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen webhook endpoints create --url https://example.com/hook",
 	},
@@ -40,7 +39,6 @@ var WebhookEndpointsDelete = &command.Spec{
 	Endpoint:     "/v3/webhooks/endpoints/{endpoint_id}",
 	Method:       "DELETE",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen webhook endpoints delete <endpoint-id>",
 	},
@@ -58,9 +56,6 @@ var WebhookEndpointsList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen webhook endpoints list",
 	},
@@ -100,7 +95,6 @@ var WebhookEndpointsRotateSecret = &command.Spec{
 	Endpoint:     "/v3/webhooks/endpoints/{endpoint_id}/rotate-secret",
 	Method:       "POST",
 	BodyEncoding: "",
-	DataField:    "data",
 	Examples: []string{
 		"heygen webhook endpoints rotate-secret <endpoint-id>",
 	},
@@ -117,7 +111,6 @@ var WebhookEndpointsUpdate = &command.Spec{
 	Endpoint:     "/v3/webhooks/endpoints/{endpoint_id}",
 	Method:       "PATCH",
 	BodyEncoding: "json",
-	DataField:    "data",
 	Examples: []string{
 		"heygen webhook endpoints update <endpoint-id> --url https://new.example.com/hook",
 	},
@@ -134,8 +127,6 @@ var WebhookEventTypesList = &command.Spec{
 	Endpoint:     "/v3/webhooks/event-types",
 	Method:       "GET",
 	BodyEncoding: "",
-	TokenField:   "next_token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen webhook event-types list",
 	},
@@ -150,9 +141,6 @@ var WebhookEventsList = &command.Spec{
 	Method:       "GET",
 	BodyEncoding: "",
 	Paginated:    true,
-	TokenField:   "next_token",
-	TokenParam:   "token",
-	DataField:    "data",
 	Examples: []string{
 		"heygen webhook events list --event-type avatar_video.success",
 	},

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -228,6 +228,8 @@ func cloneInvocation(inv *command.Invocation) *command.Invocation {
 		cloned.QueryParams[key] = copied
 	}
 	if inv.Body != nil {
+		// Shallow copy — nested maps/slices are shared. Safe because pagination
+		// only mutates QueryParams, never Body values.
 		cloned.Body = make(map[string]any, len(inv.Body))
 		for key, value := range inv.Body {
 			cloned.Body[key] = value

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -16,7 +16,15 @@ import (
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 )
 
-const paginationHardLimit = 10000
+const (
+	paginationHardLimit = 10000
+
+	// HeyGen API conventions — consistent across all v3 endpoints.
+	// Hardcoded rather than per-Spec because no endpoint deviates.
+	apiDataField      = "data"       // response envelope field containing the payload
+	apiCursorField    = "next_token" // response field with the next page cursor
+	apiCursorParam    = "token"      // request query parameter for the cursor
+)
 
 // ErrPaginationTruncated is returned when ExecuteAll stops early at the hard
 // item limit. It carries the partial data so callers can still render it.
@@ -83,7 +91,7 @@ func (c *Client) Execute(spec *command.Spec, inv *command.Invocation) (json.RawM
 // ExecuteAll fetches all pages of a paginated endpoint and returns a flat JSON
 // array containing all accumulated items.
 func (c *Client) ExecuteAll(spec *command.Spec, inv *command.Invocation) (json.RawMessage, error) {
-	if !spec.Paginated || spec.TokenField == "" || spec.TokenParam == "" || spec.DataField == "" {
+	if !spec.Paginated {
 		return nil, clierrors.New("spec is not configured for pagination")
 	}
 
@@ -96,7 +104,7 @@ func (c *Client) ExecuteAll(spec *command.Spec, inv *command.Invocation) (json.R
 			return nil, err
 		}
 
-		items, nextToken, err := extractPage(page, spec.DataField, spec.TokenField)
+		items, nextToken, err := extractPage(page, apiDataField, apiCursorField)
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +134,7 @@ func (c *Client) ExecuteAll(spec *command.Spec, inv *command.Invocation) (json.R
 			return nil, &ErrPaginationTruncated{Data: data, Count: len(accumulated)}
 		}
 
-		workingInv.QueryParams.Set(spec.TokenParam, nextToken)
+		workingInv.QueryParams.Set(apiCursorParam, nextToken)
 	}
 }
 

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -16,6 +16,19 @@ import (
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 )
 
+const paginationHardLimit = 10000
+
+// ErrPaginationTruncated is returned when ExecuteAll stops early at the hard
+// item limit. It carries the partial data so callers can still render it.
+type ErrPaginationTruncated struct {
+	Data  json.RawMessage
+	Count int
+}
+
+func (e *ErrPaginationTruncated) Error() string {
+	return fmt.Sprintf("pagination stopped at %d items (hard limit); results may be incomplete", e.Count)
+}
+
 // Execute sends an HTTP request described by the Spec (static metadata)
 // and Invocation (resolved user values). Returns the raw JSON response.
 //
@@ -65,6 +78,56 @@ func (c *Client) Execute(spec *command.Spec, inv *command.Invocation) (json.RawM
 	}
 
 	return json.RawMessage(respBody), nil
+}
+
+// ExecuteAll fetches all pages of a paginated endpoint and returns a flat JSON
+// array containing all accumulated items.
+func (c *Client) ExecuteAll(spec *command.Spec, inv *command.Invocation) (json.RawMessage, error) {
+	if !spec.Paginated || spec.TokenField == "" || spec.TokenParam == "" || spec.DataField == "" {
+		return nil, clierrors.New("spec is not configured for pagination")
+	}
+
+	workingInv := cloneInvocation(inv)
+	accumulated := make([]json.RawMessage, 0)
+
+	for {
+		page, err := c.Execute(spec, workingInv)
+		if err != nil {
+			return nil, err
+		}
+
+		items, nextToken, err := extractPage(page, spec.DataField, spec.TokenField)
+		if err != nil {
+			return nil, err
+		}
+
+		remaining := paginationHardLimit - len(accumulated)
+		if remaining <= 0 {
+			data, err := marshalItems(accumulated)
+			if err != nil {
+				return nil, err
+			}
+			return nil, &ErrPaginationTruncated{Data: data, Count: len(accumulated)}
+		}
+
+		if len(items) > remaining {
+			items = items[:remaining]
+		}
+		accumulated = append(accumulated, items...)
+
+		if nextToken == "" {
+			return marshalItems(accumulated)
+		}
+		if len(accumulated) >= paginationHardLimit {
+			data, err := marshalItems(accumulated)
+			if err != nil {
+				return nil, err
+			}
+			return nil, &ErrPaginationTruncated{Data: data, Count: len(accumulated)}
+		}
+
+		workingInv.QueryParams.Set(spec.TokenParam, nextToken)
+	}
 }
 
 // buildURL constructs the full URL with path param substitution and query params.
@@ -147,6 +210,70 @@ func buildMultipartRequest(method, reqURL, filePath string) (*http.Request, erro
 	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
 
 	return req, nil
+}
+
+func cloneInvocation(inv *command.Invocation) *command.Invocation {
+	cloned := &command.Invocation{
+		PathParams:  make(map[string]string, len(inv.PathParams)),
+		QueryParams: make(url.Values, len(inv.QueryParams)),
+		FilePath:    inv.FilePath,
+	}
+
+	for key, value := range inv.PathParams {
+		cloned.PathParams[key] = value
+	}
+	for key, values := range inv.QueryParams {
+		copied := make([]string, len(values))
+		copy(copied, values)
+		cloned.QueryParams[key] = copied
+	}
+	if inv.Body != nil {
+		cloned.Body = make(map[string]any, len(inv.Body))
+		for key, value := range inv.Body {
+			cloned.Body[key] = value
+		}
+	}
+
+	return cloned
+}
+
+func extractPage(raw json.RawMessage, dataField, tokenField string) ([]json.RawMessage, string, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, "", clierrors.New(fmt.Sprintf("failed to parse paginated response: %v", err))
+	}
+
+	dataRaw, ok := envelope[dataField]
+	if !ok {
+		return nil, "", clierrors.New(fmt.Sprintf("response missing %q field", dataField))
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(dataRaw, &items); err != nil {
+		return nil, "", clierrors.New(fmt.Sprintf("response field %q is not an array: %v", dataField, err))
+	}
+
+	tokenRaw, ok := envelope[tokenField]
+	if !ok {
+		return items, "", nil
+	}
+	if string(tokenRaw) == "null" {
+		return items, "", nil
+	}
+
+	var token string
+	if err := json.Unmarshal(tokenRaw, &token); err != nil {
+		return nil, "", clierrors.New(fmt.Sprintf("response field %q is not a string: %v", tokenField, err))
+	}
+	return items, token, nil
+}
+
+func marshalItems(items []json.RawMessage) (json.RawMessage, error) {
+	data, err := json.Marshal(items)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf("failed to marshal paginated results: %v", err))
+	}
+	return json.RawMessage(data), nil
 }
 
 // parseErrorResponse parses an API error response into a CLIError.

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -17,25 +17,15 @@ import (
 )
 
 const (
-	paginationHardLimit = 10000
+	// APIDataField is the response envelope field containing the payload.
+	// Exported so the builder can pass it to the formatter for --human rendering.
+	APIDataField = "data"
 
-	// HeyGen API conventions — consistent across all v3 endpoints.
-	// Hardcoded rather than per-Spec because no endpoint deviates.
-	apiDataField      = "data"       // response envelope field containing the payload
-	apiCursorField    = "next_token" // response field with the next page cursor
-	apiCursorParam    = "token"      // request query parameter for the cursor
+	// HeyGen API pagination conventions — consistent across all v3 endpoints.
+	apiCursorField = "next_token" // response field with the next page cursor
+	apiCursorParam = "token"      // request query parameter for the cursor
 )
 
-// ErrPaginationTruncated is returned when ExecuteAll stops early at the hard
-// item limit. It carries the partial data so callers can still render it.
-type ErrPaginationTruncated struct {
-	Data  json.RawMessage
-	Count int
-}
-
-func (e *ErrPaginationTruncated) Error() string {
-	return fmt.Sprintf("pagination stopped at %d items (hard limit); results may be incomplete", e.Count)
-}
 
 // Execute sends an HTTP request described by the Spec (static metadata)
 // and Invocation (resolved user values). Returns the raw JSON response.
@@ -104,34 +94,15 @@ func (c *Client) ExecuteAll(spec *command.Spec, inv *command.Invocation) (json.R
 			return nil, err
 		}
 
-		items, nextToken, err := extractPage(page, apiDataField, apiCursorField)
+		items, nextToken, err := extractPage(page, APIDataField, apiCursorField)
 		if err != nil {
 			return nil, err
 		}
 
-		remaining := paginationHardLimit - len(accumulated)
-		if remaining <= 0 {
-			data, err := marshalItems(accumulated)
-			if err != nil {
-				return nil, err
-			}
-			return nil, &ErrPaginationTruncated{Data: data, Count: len(accumulated)}
-		}
-
-		if len(items) > remaining {
-			items = items[:remaining]
-		}
 		accumulated = append(accumulated, items...)
 
 		if nextToken == "" {
 			return marshalItems(accumulated)
-		}
-		if len(accumulated) >= paginationHardLimit {
-			data, err := marshalItems(accumulated)
-			if err != nil {
-				return nil, err
-			}
-			return nil, &ErrPaginationTruncated{Data: data, Count: len(accumulated)}
 		}
 
 		workingInv.QueryParams.Set(apiCursorParam, nextToken)

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -471,98 +470,6 @@ func TestExecuteAll_MissingDataField(t *testing.T) {
 	}
 }
 
-func TestExecuteAll_Truncated(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := r.URL.Query().Get("token")
-		switch token {
-		case "":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(0, 2500, "cursor_1")))
-		case "cursor_1":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(2500, 2500, "cursor_2")))
-		case "cursor_2":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(5000, 2500, "cursor_3")))
-		case "cursor_3":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(7500, 2500, "cursor_4")))
-		default:
-			t.Fatalf("unexpected token %q", token)
-		}
-	}))
-	defer srv.Close()
-
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
-	spec := &command.Spec{
-		Endpoint:   "/v3/videos",
-		Method:     "GET",
-		Paginated:  true,
-	}
-	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
-
-	_, err := c.ExecuteAll(spec, inv)
-	var truncErr *ErrPaginationTruncated
-	if !errors.As(err, &truncErr) {
-		t.Fatalf("err = %T, want *ErrPaginationTruncated", err)
-	}
-	if truncErr.Count != 10000 {
-		t.Fatalf("Count = %d, want 10000", truncErr.Count)
-	}
-	var parsed []map[string]any
-	if err := json.Unmarshal(truncErr.Data, &parsed); err != nil {
-		t.Fatalf("truncErr.Data is not valid JSON array: %v", err)
-	}
-	if len(parsed) != 10000 {
-		t.Fatalf("len(parsed) = %d, want 10000", len(parsed))
-	}
-}
-
-func TestExecuteAll_ExactlyAtLimit(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := r.URL.Query().Get("token")
-		switch token {
-		case "":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(0, 2000, "cursor_1")))
-		case "cursor_1":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(2000, 2000, "cursor_2")))
-		case "cursor_2":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(4000, 2000, "cursor_3")))
-		case "cursor_3":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(6000, 2000, "cursor_4")))
-		case "cursor_4":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(paginationPageBody(8000, 2000, "")))
-		default:
-			t.Fatalf("unexpected token %q", token)
-		}
-	}))
-	defer srv.Close()
-
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
-	spec := &command.Spec{
-		Endpoint:   "/v3/videos",
-		Method:     "GET",
-		Paginated:  true,
-	}
-	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
-
-	result, err := c.ExecuteAll(spec, inv)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	var parsed []map[string]any
-	if err := json.Unmarshal(result, &parsed); err != nil {
-		t.Fatalf("result is not valid JSON array: %v", err)
-	}
-	if len(parsed) != 10000 {
-		t.Fatalf("len(parsed) = %d, want 10000", len(parsed))
-	}
-}
 
 func TestExecute_MultipartUpload(t *testing.T) {
 	var gotContentType string
@@ -629,24 +536,6 @@ func TestExecute_MultipartUpload(t *testing.T) {
 	if jsonErr := json.Unmarshal(result, &parsed); jsonErr != nil {
 		t.Errorf("response is not valid JSON: %v", jsonErr)
 	}
-}
-
-func paginationPageBody(start, count int, nextToken string) string {
-	items := make([]map[string]any, 0, count)
-	for i := 0; i < count; i++ {
-		items = append(items, map[string]any{"id": fmt.Sprintf("v%d", start+i)})
-	}
-
-	body := map[string]any{
-		"data": items,
-	}
-	if nextToken == "" {
-		body["next_token"] = nil
-	} else {
-		body["next_token"] = nextToken
-	}
-	raw, _ := json.Marshal(body)
-	return string(raw)
 }
 
 func TestExecute_MultipartMissingFilePath(t *testing.T) {

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -26,7 +27,7 @@ func TestExecute_GETWithQueryParams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{
@@ -61,7 +62,7 @@ func TestExecute_RepeatedQueryParams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{
@@ -319,6 +320,271 @@ func TestExecute_RetryPreservesBody(t *testing.T) {
 	}
 }
 
+func TestExecuteAll_SinglePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[{"id":"v1"}],"next_token":null}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	spec := &command.Spec{
+		Endpoint:   "/v3/videos",
+		Method:     "GET",
+		Paginated:  true,
+		TokenField: "next_token",
+		TokenParam: "token",
+		DataField:  "data",
+	}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	result, err := c.ExecuteAll(spec, inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON array: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("len(parsed) = %d, want 1", len(parsed))
+	}
+	if parsed[0]["id"] != "v1" {
+		t.Fatalf("parsed[0].id = %v, want %q", parsed[0]["id"], "v1")
+	}
+}
+
+func TestExecuteAll_MultiplePages(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		switch r.URL.Query().Get("token") {
+		case "":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":"v1"},{"id":"v2"}],"next_token":"cursor_2"}`))
+		case "cursor_2":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":"v3"},{"id":"v4"}],"next_token":"cursor_3"}`))
+		case "cursor_3":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":"v5"},{"id":"v6"}],"next_token":""}`))
+		default:
+			t.Fatalf("unexpected token %q", r.URL.Query().Get("token"))
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	spec := &command.Spec{
+		Endpoint:   "/v3/videos",
+		Method:     "GET",
+		Paginated:  true,
+		TokenField: "next_token",
+		TokenParam: "token",
+		DataField:  "data",
+	}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	result, err := c.ExecuteAll(spec, inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON array: %v", err)
+	}
+	if len(parsed) != 6 {
+		t.Fatalf("len(parsed) = %d, want 6", len(parsed))
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+}
+
+func TestExecuteAll_EmptyFirstPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[],"next_token":null}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	spec := &command.Spec{
+		Endpoint:   "/v3/videos",
+		Method:     "GET",
+		Paginated:  true,
+		TokenField: "next_token",
+		TokenParam: "token",
+		DataField:  "data",
+	}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	result, err := c.ExecuteAll(spec, inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != "[]" {
+		t.Fatalf("result = %s, want []", result)
+	}
+}
+
+func TestExecuteAll_ErrorOnSecondPage(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Query().Get("token") == "" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":"v1"}],"next_token":"cursor_2"}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":"server_error","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
+	spec := &command.Spec{
+		Endpoint:   "/v3/videos",
+		Method:     "GET",
+		Paginated:  true,
+		TokenField: "next_token",
+		TokenParam: "token",
+		DataField:  "data",
+	}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	_, err := c.ExecuteAll(spec, inv)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}
+
+func TestExecuteAll_MissingDataField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"next_token":null}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	spec := &command.Spec{
+		Endpoint:   "/v3/videos",
+		Method:     "GET",
+		Paginated:  true,
+		TokenField: "next_token",
+		TokenParam: "token",
+		DataField:  "data",
+	}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	_, err := c.ExecuteAll(spec, inv)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestExecuteAll_Truncated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		switch token {
+		case "":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(0, 2500, "cursor_1")))
+		case "cursor_1":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(2500, 2500, "cursor_2")))
+		case "cursor_2":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(5000, 2500, "cursor_3")))
+		case "cursor_3":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(7500, 2500, "cursor_4")))
+		default:
+			t.Fatalf("unexpected token %q", token)
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	spec := &command.Spec{
+		Endpoint:   "/v3/videos",
+		Method:     "GET",
+		Paginated:  true,
+		TokenField: "next_token",
+		TokenParam: "token",
+		DataField:  "data",
+	}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	_, err := c.ExecuteAll(spec, inv)
+	var truncErr *ErrPaginationTruncated
+	if !errors.As(err, &truncErr) {
+		t.Fatalf("err = %T, want *ErrPaginationTruncated", err)
+	}
+	if truncErr.Count != 10000 {
+		t.Fatalf("Count = %d, want 10000", truncErr.Count)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal(truncErr.Data, &parsed); err != nil {
+		t.Fatalf("truncErr.Data is not valid JSON array: %v", err)
+	}
+	if len(parsed) != 10000 {
+		t.Fatalf("len(parsed) = %d, want 10000", len(parsed))
+	}
+}
+
+func TestExecuteAll_ExactlyAtLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		switch token {
+		case "":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(0, 2000, "cursor_1")))
+		case "cursor_1":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(2000, 2000, "cursor_2")))
+		case "cursor_2":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(4000, 2000, "cursor_3")))
+		case "cursor_3":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(6000, 2000, "cursor_4")))
+		case "cursor_4":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(paginationPageBody(8000, 2000, "")))
+		default:
+			t.Fatalf("unexpected token %q", token)
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	spec := &command.Spec{
+		Endpoint:   "/v3/videos",
+		Method:     "GET",
+		Paginated:  true,
+		TokenField: "next_token",
+		TokenParam: "token",
+		DataField:  "data",
+	}
+	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
+
+	result, err := c.ExecuteAll(spec, inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON array: %v", err)
+	}
+	if len(parsed) != 10000 {
+		t.Fatalf("len(parsed) = %d, want 10000", len(parsed))
+	}
+}
+
 func TestExecute_MultipartUpload(t *testing.T) {
 	var gotContentType string
 	var gotFileContent string
@@ -384,6 +650,24 @@ func TestExecute_MultipartUpload(t *testing.T) {
 	if jsonErr := json.Unmarshal(result, &parsed); jsonErr != nil {
 		t.Errorf("response is not valid JSON: %v", jsonErr)
 	}
+}
+
+func paginationPageBody(start, count int, nextToken string) string {
+	items := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		items = append(items, map[string]any{"id": fmt.Sprintf("v%d", start+i)})
+	}
+
+	body := map[string]any{
+		"data": items,
+	}
+	if nextToken == "" {
+		body["next_token"] = nil
+	} else {
+		body["next_token"] = nextToken
+	}
+	raw, _ := json.Marshal(body)
+	return string(raw)
 }
 
 func TestExecute_MultipartMissingFilePath(t *testing.T) {

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -27,7 +27,7 @@ func TestExecute_GETWithQueryParams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{
@@ -62,7 +62,7 @@ func TestExecute_RepeatedQueryParams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
 
 	spec := &command.Spec{Endpoint: "/v3/videos", Method: "GET"}
 	inv := &command.Invocation{
@@ -442,7 +442,7 @@ func TestExecuteAll_ErrorOnSecondPage(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithNoRetry())
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
 	spec := &command.Spec{
 		Endpoint:   "/v3/videos",
 		Method:     "GET",

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -332,9 +332,6 @@ func TestExecuteAll_SinglePage(t *testing.T) {
 		Endpoint:   "/v3/videos",
 		Method:     "GET",
 		Paginated:  true,
-		TokenField: "next_token",
-		TokenParam: "token",
-		DataField:  "data",
 	}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 
@@ -379,9 +376,6 @@ func TestExecuteAll_MultiplePages(t *testing.T) {
 		Endpoint:   "/v3/videos",
 		Method:     "GET",
 		Paginated:  true,
-		TokenField: "next_token",
-		TokenParam: "token",
-		DataField:  "data",
 	}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 
@@ -413,9 +407,6 @@ func TestExecuteAll_EmptyFirstPage(t *testing.T) {
 		Endpoint:   "/v3/videos",
 		Method:     "GET",
 		Paginated:  true,
-		TokenField: "next_token",
-		TokenParam: "token",
-		DataField:  "data",
 	}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 
@@ -447,9 +438,6 @@ func TestExecuteAll_ErrorOnSecondPage(t *testing.T) {
 		Endpoint:   "/v3/videos",
 		Method:     "GET",
 		Paginated:  true,
-		TokenField: "next_token",
-		TokenParam: "token",
-		DataField:  "data",
 	}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 
@@ -474,9 +462,6 @@ func TestExecuteAll_MissingDataField(t *testing.T) {
 		Endpoint:   "/v3/videos",
 		Method:     "GET",
 		Paginated:  true,
-		TokenField: "next_token",
-		TokenParam: "token",
-		DataField:  "data",
 	}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 
@@ -513,9 +498,6 @@ func TestExecuteAll_Truncated(t *testing.T) {
 		Endpoint:   "/v3/videos",
 		Method:     "GET",
 		Paginated:  true,
-		TokenField: "next_token",
-		TokenParam: "token",
-		DataField:  "data",
 	}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 
@@ -566,9 +548,6 @@ func TestExecuteAll_ExactlyAtLimit(t *testing.T) {
 		Endpoint:   "/v3/videos",
 		Method:     "GET",
 		Paginated:  true,
-		TokenField: "next_token",
-		TokenParam: "token",
-		DataField:  "data",
 	}
 	inv := &command.Invocation{PathParams: make(map[string]string), QueryParams: make(url.Values)}
 

--- a/internal/command/spec.go
+++ b/internal/command/spec.go
@@ -37,7 +37,7 @@ func (g Groups) SortedNames() []string {
 //	var VideoList = &command.Spec{
 //	    Group: "video", Name: "list", Summary: "List videos",
 //	    Endpoint: "/v3/videos", Method: "GET",
-//	    TokenField: "next_token", DataField: "data",
+//	    Paginated: true, TokenField: "next_token", TokenParam: "token", DataField: "data",
 //	    Flags: []command.FlagSpec{{Name: "limit", Type: "int", Source: "query", JSONName: "limit"}},
 //	}
 type Spec struct {
@@ -56,7 +56,9 @@ type Spec struct {
 	BodyEncoding string // "json", "multipart", or "" (no body). Builder adds -d/--data when "json".
 
 	// Execution behavior (used by executor)
-	TokenField  string      // non-empty → paginated; response field with next cursor
+	Paginated   bool        // true → supports cursor pagination and the builder adds --all
+	TokenField  string      // response field with next cursor (e.g., "next_token")
+	TokenParam  string      // request query parameter carrying the cursor (e.g., "token")
 	DataField   string      // response field containing the result array (e.g., "data")
 	PollConfig  *PollConfig // non-nil → pollable; defines polling behavior for --wait (future)
 	Destructive bool        // triggers --force confirmation prompt (future)

--- a/internal/command/spec.go
+++ b/internal/command/spec.go
@@ -37,7 +37,7 @@ func (g Groups) SortedNames() []string {
 //	var VideoList = &command.Spec{
 //	    Group: "video", Name: "list", Summary: "List videos",
 //	    Endpoint: "/v3/videos", Method: "GET",
-//	    Paginated: true, TokenField: "next_token", TokenParam: "token", DataField: "data",
+//	    Paginated: true,
 //	    Flags: []command.FlagSpec{{Name: "limit", Type: "int", Source: "query", JSONName: "limit"}},
 //	}
 type Spec struct {
@@ -56,11 +56,8 @@ type Spec struct {
 	BodyEncoding string // "json", "multipart", or "" (no body). Builder adds -d/--data when "json".
 
 	// Execution behavior (used by executor)
-	Paginated   bool        // true → supports cursor pagination and the builder adds --all
-	TokenField  string      // response field with next cursor (e.g., "next_token")
-	TokenParam  string      // request query parameter carrying the cursor (e.g., "token")
-	DataField   string      // response field containing the result array (e.g., "data")
-	PollConfig  *PollConfig // non-nil → pollable; defines polling behavior for --wait (future)
+	Paginated  bool        // true → supports cursor pagination and the builder adds --all
+	PollConfig *PollConfig // non-nil → pollable; defines polling behavior for --wait (future)
 	Destructive bool        // triggers --force confirmation prompt (future)
 	Columns     []Column    // TUI table column definitions (future)
 }


### PR DESCRIPTION
## Description

Adds `--all` flag to paginated list commands, automatically fetching all pages and returning a flat JSON array. Without `--all`, behavior is unchanged (raw API envelope with `next_token`).

**How it works:**
- `ExecuteAll()` on `Client` loops through pages using `Execute()` (retries from PR #29 apply to each page request)
- Accumulates `json.RawMessage` items across pages — no deserialization overhead
- Returns flat `[{item1}, {item2}, ...]` array instead of the API envelope

**Pagination field names** (`next_token`, `token`, `data`) are hardcoded as constants in the client package — they're HeyGen API conventions consistent across all v3 endpoints, not per-command configuration. The only Spec field is `Paginated bool`, set by codegen.

**Codegen changes:**
- `Paginated bool` field on `command.Spec` — explicitly marks commands that support cursor pagination
- `detectPagination()` checks for both a cursor query param AND a cursor response field — endpoints like `webhook event-types list` that have a cursor response field but no cursor query param are correctly excluded

**No hard limit** on accumulated items. `--all` fetches everything. For very large datasets, the help text recommends manual pagination with `--token`.

**`--human` support:** The `--all` path passes curated columns to the formatter, so `--all --human` renders the same table columns as the single-page path.

**Mutual exclusion:** `--all` and the cursor flag (e.g., `--token`) cannot be used together — exit 2. The cursor flag name is resolved from the Spec's flag list (not hardcoded).

| Command | `--all` | Notes |
|---|---|---|
| `video list` | Yes | |
| `avatar list` | Yes | |
| `avatar looks list` | Yes | |
| `voice list` | Yes | |
| `webhook endpoints list` | Yes | |
| `webhook events list` | Yes | |
| `video-translate list` | Yes | |
| `overdub list` | Yes | |
| `video-agent styles list` | Yes | |
| `webhook event-types list` | **No** | Single-response endpoint, correctly excluded by `Paginated: false` |

Stacked on PR #29 (retries).

Linear: PRINFRA-125

## Testing

5 executor tests: single page, multiple pages (3 pages / 6 items), empty first page, error on second page, missing data field.

4 builder integration tests: multi-page `--all`, single-page `--all`, `--all`+`--token` conflict, `--all` on non-paginated command (unknown flag).

Codegen: golden file updated, grouper test verifies `Paginated` field.

All tests use `httptest.Server` — no real API calls.