### PR TITLE
cmd: add --wait polling framework (PRINFRA-125)

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -2,15 +2,18 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/client"
 	"github.com/heygen-com/heygen-cli/internal/command"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+	"github.com/heygen-com/heygen-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -42,6 +45,57 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
+			// Poll config is looked up at call time, not attached to Spec.
+			// Spec is immutable (generated); poll configs are hand-written in cmd/.
+			pc := pollConfigs[spec.Group+"/"+spec.Name]
+			if pc != nil {
+				wait, _ := cmd.Flags().GetBool("wait")
+				if wait {
+					timeout, _ := cmd.Flags().GetDuration("timeout")
+
+					// Let ExecuteAndPoll own the timeout via ensurePollContext.
+					// Don't wrap cmd.Context() with WithTimeout here.
+					pollSpec := *spec
+					pollSpec.PollConfig = pc
+
+					opts := client.PollOptions{
+						Timeout:   timeout,
+						BaseDelay: 2 * time.Second,
+						MaxDelay:  30 * time.Second,
+					}
+					// Only emit progress in human mode. JSON mode keeps stderr
+					// clean for machine consumption (structured errors only).
+					if _, ok := ctx.formatter.(*output.HumanFormatter); ok {
+						var lastStatus string
+						opts.OnStatus = func(status string, elapsed time.Duration) {
+							if status == lastStatus {
+								return
+							}
+							fmt.Fprintf(cmd.ErrOrStderr(), "Polling: status=%s (elapsed %s)\n", status, elapsed.Round(time.Second))
+							lastStatus = status
+						}
+					}
+
+					result, err := ctx.client.ExecuteAndPoll(cmd.Context(), &pollSpec, inv, opts)
+					if err != nil {
+						var failErr *client.ErrPollFailed
+						if errors.As(err, &failErr) {
+							// Output the failure response (contains error details),
+							// then signal failure via CLIError for exit code 1.
+							if fmtErr := ctx.formatter.Data(failErr.Data, "data", nil); fmtErr != nil {
+								return fmtErr
+							}
+							return clierrors.New(failErr.Error())
+						}
+						return err
+					}
+
+					// --wait result is a single resource from the GET endpoint.
+					// Columns are nil — HumanFormatter renders single objects as
+					// key-value pairs, not tables. This matches `heygen video get`.
+					return ctx.formatter.Data(result, "data", nil)
+				}
+			}
 			result, err := ctx.client.Execute(spec, inv)
 			if err != nil {
 				return err
@@ -56,6 +110,10 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 		registerFlag(cmd, flag)
 	}
 
+	if pollConfigs[spec.Group+"/"+spec.Name] != nil {
+		cmd.Flags().Bool("wait", false, "Poll until the operation completes or fails")
+		cmd.Flags().Duration("timeout", 10*time.Minute, "Max time to wait when using --wait")
+	}
 	// Add -d/--data for commands with JSON request bodies
 	if spec.BodyEncoding == "json" {
 		cmd.Flags().StringVarP(&rawData, "data", "d", "",

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -31,6 +31,18 @@ var videoListSpec = &command.Spec{
 	Examples: []string{"heygen video list --limit 10"},
 }
 
+// videoCreateWaitSpec has Group/Name matching pollConfigs["video/create"],
+// so the builder picks up PollConfig at call time — no need to set it here.
+var videoCreateWaitSpec = &command.Spec{
+	Group:        "video",
+	Name:         "create",
+	Summary:      "Create a video",
+	Endpoint:     "/v3/videos",
+	Method:       "POST",
+	BodyEncoding: "json",
+	Examples:     []string{"heygen video create --wait"},
+}
+
 func TestGenBuilder_VideoList_Success(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
 		"GET /v3/videos": {
@@ -87,6 +99,177 @@ func TestGenBuilder_VideoList_Flags(t *testing.T) {
 
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestGenBuilder_VideoCreate_Wait_Success(t *testing.T) {
+	var statusCalls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":{"video_id":"vid_123"}}`,
+		},
+		"GET /v3/videos/vid_123": {
+			StatusCode: 200,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				statusCalls++
+			},
+			Body: `{"data":{"video_id":"vid_123","status":"processing"}}`,
+		},
+	})
+	defer srv.Close()
+
+	originalHandler := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v3/videos/vid_123" {
+			statusCalls++
+			w.WriteHeader(http.StatusOK)
+			if statusCalls < 2 {
+				_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"processing"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"completed","video_url":"https://cdn.test/video.mp4"}}`))
+			return
+		}
+		originalHandler.ServeHTTP(w, r)
+	})
+
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, res.Stdout)
+	}
+	data := parsed["data"].(map[string]any)
+	if data["status"] != "completed" {
+		t.Fatalf("status = %v, want completed", data["status"])
+	}
+	// JSON mode: no progress on stderr (keeps it machine-readable).
+	// Progress is only emitted in --human mode.
+	if strings.Contains(res.Stderr, "Polling:") {
+		t.Fatalf("stderr should not contain progress in JSON mode: %s", res.Stderr)
+	}
+}
+
+func TestGenBuilder_VideoCreate_Wait_Failure(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":{"video_id":"vid_123"}}`,
+		},
+		"GET /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"video_id":"vid_123","status":"failed"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait")
+
+	if res.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "operation reached terminal failure state: failed") {
+		t.Fatalf("stderr = %s, want failure message", res.Stderr)
+	}
+	// Failure response should be output to stdout so users can see error details
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout should contain failure response: %v\nstdout: %s", err, res.Stdout)
+	}
+	data := parsed["data"].(map[string]any)
+	if data["status"] != "failed" {
+		t.Fatalf("status = %v, want failed", data["status"])
+	}
+}
+
+func TestGenBuilder_VideoCreate_Wait_Timeout(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":{"video_id":"vid_123"}}`,
+		},
+		"GET /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"video_id":"vid_123","status":"processing"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--timeout", "20ms")
+
+	if res.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "polling timed out before the operation completed") {
+		t.Fatalf("stderr = %s, want timeout message", res.Stderr)
+	}
+}
+
+func TestGenBuilder_VideoCreate_NoWait(t *testing.T) {
+	var statusCalled bool
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/videos": {
+			StatusCode: 200,
+			Body:       `{"data":{"video_id":"vid_123","status":"pending"}}`,
+		},
+		"GET /v3/videos/vid_123": {
+			StatusCode: 200,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				statusCalled = true
+			},
+			Body: `{"data":{"video_id":"vid_123","status":"completed"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if statusCalled {
+		t.Fatal("status endpoint should not be called without --wait")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, res.Stdout)
+	}
+	data := parsed["data"].(map[string]any)
+	if data["status"] != "pending" {
+		t.Fatalf("status = %v, want pending", data["status"])
+	}
+}
+
+func TestGenBuilder_VideoCreate_WaitNotAvailable(t *testing.T) {
+	nonPollable := &command.Spec{
+		Group:    "video",
+		Name:     "get",
+		Summary:  "Get video",
+		Endpoint: "/v3/videos/{video_id}",
+		Method:   "GET",
+		Args: []command.ArgSpec{
+			{Name: "video-id", Param: "video_id"},
+		},
+		Examples: []string{"heygen video get <video-id>"},
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", nonPollable, "get", "vid_123", "--wait")
+
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "unknown flag: --wait") {
+		t.Fatalf("stderr = %s, want unknown flag error", res.Stderr)
 	}
 }
 
@@ -407,6 +590,9 @@ func runGeneratedRootCommand(t *testing.T, serverURL, apiKey string, groups map[
 
 	t.Setenv("HEYGEN_API_KEY", apiKey)
 	t.Setenv("HEYGEN_API_BASE", serverURL)
+	if _, ok := os.LookupEnv("HEYGEN_CONFIG_DIR"); !ok {
+		t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	}
 
 	root := newRootCmdWithSpecs("test", formatter, groups)
 	root.SetOut(&stdout)

--- a/cmd/heygen/poll_configs.go
+++ b/cmd/heygen/poll_configs.go
@@ -1,0 +1,35 @@
+package main
+
+import "github.com/heygen-com/heygen-cli/internal/command"
+
+// pollConfigs maps "group/spec.Name" to PollConfig for async commands.
+// Keys use the full spec name to avoid collisions within a group.
+var pollConfigs = map[string]*command.PollConfig{
+	"video/create": {
+		StatusEndpoint: "/v3/videos/{video_id}",
+		StatusField:    "data.status",
+		TerminalOK:     []string{"completed"},
+		TerminalFail:   []string{"failed"},
+		IDField:        "data.video_id",
+	},
+	// The create response returns video_translation_ids (plural, always a list
+	// even for single-language requests). We extract the first element with ".0".
+	// Batch mode (multiple languages) is not supported by --wait.
+	"video-translate/create": {
+		StatusEndpoint: "/v3/video-translations/{video_translation_id}",
+		StatusField:    "data.status",
+		TerminalOK:     []string{"completed"},
+		TerminalFail:   []string{"failed"},
+		IDField:        "data.video_translation_ids.0",
+	},
+	// video-agent returns session_id + video_id. We poll the video status.
+	// video_id can be null in future multi-turn flows — extractJSONPath
+	// will return an error, which is correct (can't poll without an ID).
+	"video-agent/create": {
+		StatusEndpoint: "/v3/videos/{video_id}",
+		StatusField:    "data.status",
+		TerminalOK:     []string{"completed"},
+		TerminalFail:   []string{"failed"},
+		IDField:        "data.video_id",
+	},
+}

--- a/cmd/heygen/poll_configs_test.go
+++ b/cmd/heygen/poll_configs_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/heygen-com/heygen-cli/gen"
+)
+
+func TestPollConfigs_AllReferencedCommandsExist(t *testing.T) {
+	for key := range pollConfigs {
+		found := false
+		for group, specs := range gen.Groups {
+			for _, spec := range specs {
+				if key == group+"/"+spec.Name {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("poll config key %q does not match any generated spec", key)
+		}
+	}
+}

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -2,7 +2,9 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -10,7 +12,10 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/command"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
@@ -22,6 +27,117 @@ const (
 	APIDataField = "data"
 )
 
+// PollOptions controls ExecuteAndPoll behavior.
+type PollOptions struct {
+	Timeout   time.Duration
+	BaseDelay time.Duration
+	MaxDelay  time.Duration
+	OnStatus  func(status string, elapsed time.Duration)
+}
+
+// ErrPollFailed is returned when polling reaches a terminal failure state.
+// It carries the full status response so callers can output it (the response
+// often contains error details the user needs to diagnose the failure).
+type ErrPollFailed struct {
+	Data   json.RawMessage
+	Status string
+}
+
+func (e *ErrPollFailed) Error() string {
+	return fmt.Sprintf("operation reached terminal failure state: %s", e.Status)
+}
+
+// ExecuteAndPoll executes a create request, then polls a status endpoint until
+// the resource reaches a terminal state or the context is canceled.
+func (c *Client) ExecuteAndPoll(
+	ctx context.Context,
+	spec *command.Spec,
+	inv *command.Invocation,
+	opts PollOptions,
+) (json.RawMessage, error) {
+	if spec.PollConfig == nil {
+		return nil, clierrors.New("spec is not configured for polling")
+	}
+
+	opts = defaultPollOptions(opts)
+	pollCtx, cancel := ensurePollContext(ctx, opts.Timeout)
+	defer cancel()
+
+	createResp, err := c.executeWithContext(pollCtx, spec, inv)
+	if err != nil {
+		return nil, translatePollContextError(pollCtx, err)
+	}
+
+	resourceID, err := extractJSONPath(createResp, spec.PollConfig.IDField)
+	if err != nil {
+		return nil, clierrors.New(fmt.Sprintf(
+			"failed to extract resource ID from %q: %v. This command may require manual polling for batch responses",
+			spec.PollConfig.IDField, err,
+		))
+	}
+
+	// If IDField uses an array index (e.g., "data.ids.0"), reject batch
+	// responses with multiple IDs. --wait only supports single-resource polling.
+	if arrayLen, ok := extractArrayLen(createResp, spec.PollConfig.IDField); ok && arrayLen > 1 {
+		return nil, &clierrors.CLIError{
+			Code:     "batch_not_supported",
+			Message:  fmt.Sprintf("--wait does not support batch operations (got %d resources)", arrayLen),
+			Hint:     "Poll each resource individually with the corresponding get command",
+			ExitCode: clierrors.ExitGeneral,
+		}
+	}
+
+	pathParams, err := statusPathParams(spec.PollConfig.StatusEndpoint, resourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	statusSpec := buildStatusSpec(spec.PollConfig.StatusEndpoint)
+	statusInv := &command.Invocation{
+		PathParams:  pathParams,
+		QueryParams: make(url.Values),
+	}
+	pollBackoff := RetryConfig{
+		BaseDelay: opts.BaseDelay,
+		MaxDelay:  opts.MaxDelay,
+	}
+	start := time.Now()
+
+	for attempt := 0; ; attempt++ {
+		if err := pollCtx.Err(); err != nil {
+			return nil, newPollContextError(err)
+		}
+
+		statusResp, err := c.executeWithContext(pollCtx, statusSpec, statusInv)
+		if err != nil {
+			return nil, translatePollContextError(pollCtx, err)
+		}
+
+		status, err := extractJSONPath(statusResp, spec.PollConfig.StatusField)
+		if err != nil {
+			return nil, clierrors.New(fmt.Sprintf(
+				"failed to extract status from %q: %v",
+				spec.PollConfig.StatusField, err,
+			))
+		}
+
+		if slices.Contains(spec.PollConfig.TerminalOK, status) {
+			return statusResp, nil
+		}
+		if slices.Contains(spec.PollConfig.TerminalFail, status) {
+			return nil, &ErrPollFailed{Data: statusResp, Status: status}
+		}
+		if opts.OnStatus != nil {
+			opts.OnStatus(status, time.Since(start))
+		}
+
+		delay := backoffDelay(attempt, pollBackoff)
+		if err := waitForRetry(pollCtx, delay); err != nil {
+			return nil, newPollContextError(err)
+		}
+	}
+}
+
 // Execute sends an HTTP request described by the Spec (static metadata)
 // and Invocation (resolved user values). Returns the raw JSON response.
 //
@@ -29,6 +145,10 @@ const (
 // and behavioral flags (pagination, polling). The Invocation provides
 // the concrete path params, query params, body, and file path.
 func (c *Client) Execute(spec *command.Spec, inv *command.Invocation) (json.RawMessage, error) {
+	return c.executeWithContext(context.Background(), spec, inv)
+}
+
+func (c *Client) executeWithContext(ctx context.Context, spec *command.Spec, inv *command.Invocation) (json.RawMessage, error) {
 	if spec.Method == "" {
 		return nil, clierrors.New("Spec.Method must be set")
 	}
@@ -50,6 +170,7 @@ func (c *Client) Execute(spec *command.Spec, inv *command.Invocation) (json.RawM
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := c.Do(req)
 	if err != nil {
@@ -153,6 +274,181 @@ func buildMultipartRequest(method, reqURL, filePath string) (*http.Request, erro
 	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
 
 	return req, nil
+}
+
+func defaultPollOptions(opts PollOptions) PollOptions {
+	if opts.Timeout <= 0 {
+		opts.Timeout = 10 * time.Minute
+	}
+	if opts.BaseDelay <= 0 {
+		opts.BaseDelay = 2 * time.Second
+	}
+	if opts.MaxDelay <= 0 {
+		opts.MaxDelay = 30 * time.Second
+	}
+	return opts
+}
+
+func ensurePollContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok || timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func buildStatusSpec(endpoint string) *command.Spec {
+	return &command.Spec{
+		Endpoint: endpoint,
+		Method:   http.MethodGet,
+	}
+}
+
+func statusPathParams(endpoint, resourceID string) (map[string]string, error) {
+	params := make(map[string]string)
+	start := strings.Index(endpoint, "{")
+	end := strings.Index(endpoint, "}")
+	if start == -1 || end == -1 || end <= start+1 {
+		return nil, clierrors.New(fmt.Sprintf("status endpoint %q must contain exactly one path parameter", endpoint))
+	}
+	if strings.Contains(endpoint[end+1:], "{") {
+		return nil, clierrors.New(fmt.Sprintf("status endpoint %q must contain exactly one path parameter", endpoint))
+	}
+	params[endpoint[start+1:end]] = resourceID
+	return params, nil
+}
+
+// extractArrayLen checks if a dot-notation path ends with a numeric index
+// (e.g., "data.ids.0"), and if so, returns the length of that array.
+// Returns (0, false) if the path doesn't end with an array index.
+func extractArrayLen(raw json.RawMessage, path string) (int, bool) {
+	parts := strings.Split(path, ".")
+	if len(parts) < 2 {
+		return 0, false
+	}
+	// Check if the last segment is a numeric index
+	if _, err := strconv.Atoi(parts[len(parts)-1]); err != nil {
+		return 0, false
+	}
+	// Walk to the parent array
+	arrayPath := strings.Join(parts[:len(parts)-1], ".")
+
+	var current any
+	if err := json.Unmarshal(raw, &current); err != nil {
+		return 0, false
+	}
+	for _, part := range strings.Split(arrayPath, ".") {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return 0, false
+		}
+		next, ok := obj[part]
+		if !ok {
+			return 0, false
+		}
+		current = next
+	}
+	arr, ok := current.([]any)
+	if !ok {
+		return 0, false
+	}
+	return len(arr), true
+}
+
+// extractJSONPath extracts a string value from JSON using dot-notation.
+// Supports object fields ("data.status") and array indices ("data.ids.0").
+func extractJSONPath(raw json.RawMessage, path string) (string, error) {
+	if path == "" {
+		return "", clierrors.New("JSON path is required")
+	}
+
+	var current any
+	if err := json.Unmarshal(raw, &current); err != nil {
+		return "", clierrors.New(fmt.Sprintf("failed to parse JSON response: %v", err))
+	}
+
+	for _, part := range strings.Split(path, ".") {
+		// Try numeric index for arrays
+		if idx, err := strconv.Atoi(part); err == nil {
+			arr, ok := current.([]any)
+			if !ok {
+				return "", clierrors.New(fmt.Sprintf("field at %q is not an array", part))
+			}
+			if idx < 0 || idx >= len(arr) {
+				return "", clierrors.New(fmt.Sprintf("array index %d out of bounds (length %d)", idx, len(arr)))
+			}
+			current = arr[idx]
+			continue
+		}
+
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return "", clierrors.New(fmt.Sprintf("field %q is not an object", part))
+		}
+
+		next, ok := obj[part]
+		if !ok {
+			return "", clierrors.New(fmt.Sprintf("field %q not found", part))
+		}
+		current = next
+	}
+
+	value, ok := current.(string)
+	if !ok || value == "" {
+		return "", clierrors.New(fmt.Sprintf("field %q is not a string", path))
+	}
+	return value, nil
+}
+
+// translatePollContextError converts context deadline/cancellation errors into
+// user-friendly CLIErrors. This includes unwrapping context errors that were
+// stringified into CLIError.Message by executeWithContext — CLIError doesn't
+// preserve the error chain, so string matching is the fallback. If the message
+// format in executeWithContext changes, this degrades to returning the original
+// error (generic network failure), which is safe but less user-friendly.
+func translatePollContextError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return newPollContextError(ctxErr)
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return newPollContextError(err)
+	}
+
+	var cliErr *clierrors.CLIError
+	if errors.As(err, &cliErr) && cliErr.Code == "network_error" {
+		msg := strings.ToLower(cliErr.Message)
+		switch {
+		case strings.Contains(msg, "context deadline exceeded"):
+			return newPollContextError(context.DeadlineExceeded)
+		case strings.Contains(msg, "context canceled"), strings.Contains(msg, "context cancelled"):
+			return newPollContextError(context.Canceled)
+		}
+	}
+
+	return err
+}
+
+func newPollContextError(err error) error {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return &clierrors.CLIError{
+			Code:     "timeout",
+			Message:  "polling timed out before the operation completed",
+			Hint:     "Re-run the corresponding get command to check the current status manually",
+			ExitCode: clierrors.ExitGeneral,
+		}
+	case errors.Is(err, context.Canceled):
+		return &clierrors.CLIError{
+			Code:     "canceled",
+			Message:  "polling was canceled before the operation completed",
+			Hint:     "Re-run the corresponding get command to check the current status manually",
+			ExitCode: clierrors.ExitGeneral,
+		}
+	default:
+		return clierrors.New(err.Error())
+	}
 }
 
 // parseErrorResponse parses an API error response into a CLIError.

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/command"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
@@ -433,5 +435,405 @@ func TestExecute_MethodRequired(t *testing.T) {
 	_, err := c.Execute(spec, inv)
 	if err == nil {
 		t.Fatal("expected error for empty Method, got nil")
+	}
+}
+
+func TestExecuteAndPoll_ImmediateSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123"}}`))
+		case "/v3/videos/vid_123":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"completed"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	result, err := c.ExecuteAndPoll(context.Background(), pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != `{"data":{"video_id":"vid_123","status":"completed"}}` {
+		t.Fatalf("result = %s", result)
+	}
+}
+
+func TestExecuteAndPoll_PollsUntilComplete(t *testing.T) {
+	var statusCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123"}}`))
+		case "/v3/videos/vid_123":
+			statusCalls++
+			w.WriteHeader(http.StatusOK)
+			switch statusCalls {
+			case 1, 2:
+				_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"processing"}}`))
+			case 3:
+				_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"completed"}}`))
+			default:
+				t.Fatalf("unexpected status call %d", statusCalls)
+			}
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	result, err := c.ExecuteAndPoll(context.Background(), pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if statusCalls != 3 {
+		t.Fatalf("statusCalls = %d, want 3", statusCalls)
+	}
+	if string(result) != `{"data":{"video_id":"vid_123","status":"completed"}}` {
+		t.Fatalf("result = %s", result)
+	}
+}
+
+func TestExecuteAndPoll_FailureState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123"}}`))
+		case "/v3/videos/vid_123":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"failed"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	_, err := c.ExecuteAndPoll(context.Background(), pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var failErr *ErrPollFailed
+	if !errors.As(err, &failErr) {
+		t.Fatalf("expected *ErrPollFailed, got %T: %v", err, err)
+	}
+	if failErr.Status != "failed" {
+		t.Fatalf("status = %q, want %q", failErr.Status, "failed")
+	}
+	// Verify the full response is preserved
+	if !strings.Contains(string(failErr.Data), `"status":"failed"`) {
+		t.Fatalf("data = %s, want failure response", failErr.Data)
+	}
+}
+
+func TestExecuteAndPoll_TimeoutWhileWaiting(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123"}}`))
+		case "/v3/videos/vid_123":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"processing"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	_, err := c.ExecuteAndPoll(ctx, pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: 50 * time.Millisecond,
+		MaxDelay:  50 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T", err)
+	}
+	if cliErr.Code != "timeout" {
+		t.Fatalf("code = %q, want timeout", cliErr.Code)
+	}
+}
+
+func TestExecuteAndPoll_TimeoutDuringRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123"}}`))
+		case "/v3/videos/vid_123":
+			<-r.Context().Done()
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	_, err := c.ExecuteAndPoll(ctx, pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T", err)
+	}
+	if cliErr.Code != "timeout" {
+		t.Fatalf("code = %q, want timeout", cliErr.Code)
+	}
+}
+
+func TestExecuteAndPoll_CreateFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":"invalid_parameter","message":"bad request"}}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	_, err := c.ExecuteAndPoll(context.Background(), pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T", err)
+	}
+	if cliErr.Code != "invalid_parameter" {
+		t.Fatalf("code = %q, want invalid_parameter", cliErr.Code)
+	}
+}
+
+func TestExecuteAndPoll_StatusCallbackCalled(t *testing.T) {
+	var statuses []string
+	var statusCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123"}}`))
+		case "/v3/videos/vid_123":
+			statusCalls++
+			w.WriteHeader(http.StatusOK)
+			if statusCalls == 1 {
+				_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"processing"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"video_id":"vid_123","status":"completed"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	_, err := c.ExecuteAndPoll(context.Background(), pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+		OnStatus: func(status string, elapsed time.Duration) {
+			statuses = append(statuses, status)
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0] != "processing" {
+		t.Fatalf("statuses = %v, want [processing]", statuses)
+	}
+}
+
+func TestExtractJSONPath_Nested(t *testing.T) {
+	value, err := extractJSONPath(json.RawMessage(`{"data":{"video_id":"abc123"}}`), "data.video_id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != "abc123" {
+		t.Fatalf("value = %q, want %q", value, "abc123")
+	}
+}
+
+func TestExtractJSONPath_Missing(t *testing.T) {
+	_, err := extractJSONPath(json.RawMessage(`{"data":{}}`), "data.video_id")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestExtractJSONPath_ArrayIndex(t *testing.T) {
+	value, err := extractJSONPath(json.RawMessage(`{"data":{"ids":["abc","def"]}}`), "data.ids.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != "abc" {
+		t.Fatalf("value = %q, want %q", value, "abc")
+	}
+}
+
+func TestExtractJSONPath_ArrayIndexOutOfBounds(t *testing.T) {
+	_, err := extractJSONPath(json.RawMessage(`{"data":{"ids":["abc"]}}`), "data.ids.5")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestExtractJSONPath_ArrayOnNonArray(t *testing.T) {
+	_, err := extractJSONPath(json.RawMessage(`{"data":{"id":"abc"}}`), "data.id.0")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestExecuteAndPoll_RejectsBatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Create response returns multiple IDs (batch translation)
+		_, _ = w.Write([]byte(`{"data":{"video_translation_ids":["id_1","id_2","id_3"]}}`))
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	spec := &command.Spec{
+		Endpoint:     "/v3/video-translations",
+		Method:       http.MethodPost,
+		BodyEncoding: "json",
+		PollConfig: &command.PollConfig{
+			StatusEndpoint: "/v3/video-translations/{video_translation_id}",
+			StatusField:    "data.status",
+			TerminalOK:     []string{"completed"},
+			TerminalFail:   []string{"failed"},
+			IDField:        "data.video_translation_ids.0",
+		},
+	}
+
+	_, err := c.ExecuteAndPoll(context.Background(), spec, emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Code != "batch_not_supported" {
+		t.Fatalf("code = %q, want %q", cliErr.Code, "batch_not_supported")
+	}
+	if !strings.Contains(cliErr.Message, "3 resources") {
+		t.Fatalf("message = %q, want mention of 3 resources", cliErr.Message)
+	}
+}
+
+func TestExecuteAndPoll_SingleArrayElement_OK(t *testing.T) {
+	var statusCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/video-translations":
+			w.WriteHeader(http.StatusOK)
+			// Single-language: array with 1 element
+			_, _ = w.Write([]byte(`{"data":{"video_translation_ids":["trans_123"]}}`))
+		case "/v3/video-translations/trans_123":
+			statusCalls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"id":"trans_123","status":"completed"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	spec := &command.Spec{
+		Endpoint:     "/v3/video-translations",
+		Method:       http.MethodPost,
+		BodyEncoding: "json",
+		PollConfig: &command.PollConfig{
+			StatusEndpoint: "/v3/video-translations/{video_translation_id}",
+			StatusField:    "data.status",
+			TerminalOK:     []string{"completed"},
+			TerminalFail:   []string{"failed"},
+			IDField:        "data.video_translation_ids.0",
+		},
+	}
+
+	result, err := c.ExecuteAndPoll(context.Background(), spec, emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if statusCalls != 1 {
+		t.Fatalf("statusCalls = %d, want 1", statusCalls)
+	}
+	if !strings.Contains(string(result), "completed") {
+		t.Fatalf("result = %s, want completed", result)
+	}
+}
+
+func pollableVideoCreateSpec() *command.Spec {
+	return &command.Spec{
+		Endpoint:     "/v3/videos",
+		Method:       http.MethodPost,
+		BodyEncoding: "json",
+		PollConfig: &command.PollConfig{
+			StatusEndpoint: "/v3/videos/{video_id}",
+			StatusField:    "data.status",
+			TerminalOK:     []string{"completed"},
+			TerminalFail:   []string{"failed", "error"},
+			IDField:        "data.video_id",
+		},
+	}
+}
+
+func emptyInvocation() *command.Invocation {
+	return &command.Invocation{
+		PathParams:  make(map[string]string),
+		QueryParams: make(url.Values),
 	}
 }


### PR DESCRIPTION
## Description

Adds `--wait` flag to async commands (video create, video-translate create, video-agent create). When set, the CLI polls the status endpoint with exponential backoff until the resource reaches a terminal state, then outputs the final resource JSON — same as running the corresponding `get` command after completion.

**How it works:**
1. Execute the create request, extract the resource ID from the response (via dot-notation `IDField`, e.g., `data.video_id`)
2. Poll the status endpoint (e.g., `GET /v3/videos/{video_id}`) with exponential backoff (2s initial, up to 30s, with jitter)
3. Check the status field (e.g., `data.status`) against terminal states
4. Success (`completed`) → stdout gets the final resource JSON, exit 0
5. Failure (`failed`) → stdout gets the failure response (contains error details), stderr gets structured error, exit 1
6. Timeout (`--timeout`, default 10m) → stderr gets timeout message with hint, exit 1

**PollConfig registrations** (hand-written in `cmd/heygen/poll_configs.go`):

| Command | Status Endpoint | ID Field | Terminal States |
|---|---|---|---|
| `video create` | `GET /v3/videos/{video_id}` | `data.video_id` | OK: `completed`, Fail: `failed` |
| `video-translate create` | `GET /v3/video-translations/{video_translation_id}` | `data.video_translation_ids.0` | OK: `completed`, Fail: `failed` |
| `video-agent create` | `GET /v3/videos/{video_id}` | `data.video_id` | OK: `completed`, Fail: `failed` |

PollConfigs are looked up at call time in the builder via `pollConfigs[spec.Group+"/"+spec.Name]` — Specs are never mutated. Adding polling for a new async command is one entry in `poll_configs.go`. Field names and terminal states verified against experiment-framework DTOs.

**Timeout:** Owned by `ensurePollContext` inside `ExecuteAndPoll`. The builder passes `cmd.Context()` and `Timeout` in `PollOptions`; `ensurePollContext` adds the deadline. Single timeout owner.

**Context-aware:** Ctrl-C cancellation and timeout both work. Context errors from `Execute()` (wrapped as `network_error` in CLIError) are unwrapped and translated to clean `timeout`/`canceled` CLIErrors.

**Progress:** Only emitted in `--human` mode — one line per status *change* (`Polling: status=processing (elapsed 12s)`). JSON mode keeps stderr clean for machine consumption (structured errors only).

**Failure response preserved:** `ErrPollFailed` carries the full status response. The builder outputs it to stdout (users see error details without a second API call) then returns exit 1.

**`--human` support:** The `--wait` path passes `client.APIDataField` and nil columns to the formatter — single objects render as key-value pairs, matching the corresponding `get` command.

**Batch rejection:** `video-translate create` returns a list of IDs (`video_translation_ids`). `--wait` extracts the first element via array index (`.0`). If the list has >1 element (multi-language batch), returns `batch_not_supported` error with hint to poll manually. Single-language requests work normally.

**`extractJSONPath` supports array indices:** Dot-notation paths like `data.ids.0` walk into arrays. Used for video-translate's list-based ID field.

Stacked on PR #31 (pagination) → PR #29 (retries).

Linear: PRINFRA-125

## Testing

10 executor tests: immediate success, polls-until-complete (3 status calls), failure state with response preserved, timeout during backoff, timeout during HTTP request (server blocks), create fails (no polling), status callback, extractJSONPath (nested, missing, array index, array out of bounds, non-array), batch rejection (3 IDs), single-array-element OK.

5 builder integration tests: wait success (no progress in JSON mode), wait failure (response on stdout), wait timeout, no-wait (create response only), wait on non-pollable command (unknown flag).

1 validation test: all PollConfig keys match generated Specs (catches orphaned configs).

All tests use `httptest.Server` — no real API calls. Polling delays set to 1ms in tests for fast execution.