### PR TITLE
scripts: add internal install script (PRINFRA-138)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -75,26 +75,23 @@ jobs:
       - name: Write release notes
         shell: bash
         run: |
-          set -euo pipefail
-
           short_sha="$(git rev-parse --short HEAD)"
           commit_date="$(git show -s --format=%ci HEAD)"
           commit_subject="$(git show -s --format=%s HEAD)"
-          actor="@${GITHUB_ACTOR}"
 
-          cat > /tmp/dev-release-notes.md <<EOF
-## Internal Dev Build
-
-Latest CLI build from \`main\`. Manually triggered.
-
-- **Commit:** ${short_sha}
-- **Date:** ${commit_date}
-- **Source:** \`main\`
-- **Commit message:** ${commit_subject}
-- **Triggered by:** ${actor}
-
-Download the archive for your platform from the assets below and add \`heygen\` to your \`PATH\`.
-EOF
+          {
+            echo "## Internal Dev Build"
+            echo ""
+            echo "Latest CLI build from \`main\`. Manually triggered."
+            echo ""
+            echo "- **Commit:** ${short_sha}"
+            echo "- **Date:** ${commit_date}"
+            echo "- **Source:** \`main\`"
+            echo "- **Commit message:** ${commit_subject}"
+            echo "- **Triggered by:** @${GITHUB_ACTOR}"
+            echo ""
+            echo "Download the archive for your platform from the assets below and add \`heygen\` to your \`PATH\`."
+          } > /tmp/dev-release-notes.md
 
       - name: Recreate dev prerelease
         env:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO="${HEYGEN_REPO:-heygen-com/heygen-cli}"
+RELEASE_TAG="${HEYGEN_RELEASE_TAG:-dev}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux) printf 'linux\n' ;;
+    Darwin) printf 'darwin\n' ;;
+    *)
+      fail "unsupported OS: $(uname -s). Install manually from the release assets."
+      ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64 | amd64) printf 'amd64\n' ;;
+    arm64 | aarch64) printf 'arm64\n' ;;
+    *)
+      fail "unsupported architecture: $(uname -m). Install manually from the release assets."
+      ;;
+  esac
+}
+
+checksum_cmd() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf 'sha256sum\n'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    printf 'shasum -a 256\n'
+    return
+  fi
+  fail "missing sha256 tool (need sha256sum or shasum)"
+}
+
+github_token() {
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    printf '%s\n' "$GITHUB_TOKEN"
+    return
+  fi
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    printf '%s\n' "$GH_TOKEN"
+    return
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    local token
+    token="$(gh auth token 2>/dev/null || true)"
+    if [[ -n "$token" ]]; then
+      printf '%s\n' "$token"
+      return
+    fi
+  fi
+  fail "set GITHUB_TOKEN or authenticate gh before running this installer"
+}
+
+download_with_gh() {
+  local asset_name="$1"
+  local checksums_name="$2"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  if ! gh auth token >/dev/null 2>&1; then
+    return 1
+  fi
+
+  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$asset_name" --dir "$TMPDIR"; then
+    return 1
+  fi
+  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$checksums_name" --dir "$TMPDIR"; then
+    return 1
+  fi
+  if [[ ! -f "${TMPDIR}/${asset_name}" || ! -f "${TMPDIR}/${checksums_name}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+download_with_curl() {
+  local asset_name="$1"
+  local checksums_name="$2"
+  local token="$3"
+  local base_url
+
+  if [[ -n "${HEYGEN_RELEASE_BASE_URL:-}" ]]; then
+    base_url="${HEYGEN_RELEASE_BASE_URL%/}"
+  else
+    base_url="https://github.com/${REPO}/releases/download/${RELEASE_TAG}"
+  fi
+
+  curl -fsSL -H "Authorization: Bearer ${token}" \
+    "${base_url}/${asset_name}" -o "${TMPDIR}/${asset_name}"
+  curl -fsSL -H "Authorization: Bearer ${token}" \
+    "${base_url}/${checksums_name}" -o "${TMPDIR}/${checksums_name}"
+}
+
+verify_checksum() {
+  local asset_name="$1"
+  local checksums_name="$2"
+  local checksum_tool
+  local expected actual
+
+  checksum_tool="$(checksum_cmd)"
+  expected="$(grep " ${asset_name}\$" "${TMPDIR}/${checksums_name}" | awk '{print $1}')"
+  if [[ -z "$expected" ]]; then
+    fail "could not find checksum for ${asset_name}"
+  fi
+
+  actual="$($checksum_tool "${TMPDIR}/${asset_name}" | awk '{print $1}')"
+  if [[ "$expected" != "$actual" ]]; then
+    fail "checksum verification failed for ${asset_name}"
+  fi
+}
+
+install_archive() {
+  local archive="$1"
+  local os="$2"
+  local extracted_bin="$TMPDIR/heygen"
+
+  if [[ "$os" == "darwin" || "$os" == "linux" ]]; then
+    tar -C "$TMPDIR" -xzf "$archive" heygen
+  else
+    fail "unsupported OS for automatic install: ${os}"
+  fi
+
+  mkdir -p "$INSTALL_DIR"
+  install -m 0755 "$extracted_bin" "${INSTALL_DIR}/heygen"
+}
+
+main() {
+  local os arch asset_name checksums_name token version_output
+
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  asset_name="heygen_${os}_${arch}.tar.gz"
+  checksums_name="checksums.txt"
+
+  log "Detected: ${os} ${arch}"
+  log "Installing heygen from ${REPO} release tag '${RELEASE_TAG}'"
+
+  if download_with_gh "$asset_name" "$checksums_name"; then
+    log "Downloaded release assets with gh"
+  else
+    token="$(github_token)"
+    download_with_curl "$asset_name" "$checksums_name" "$token"
+    log "Downloaded release assets with curl"
+  fi
+
+  verify_checksum "$asset_name" "$checksums_name"
+  install_archive "${TMPDIR}/${asset_name}" "$os"
+
+  version_output="$("${INSTALL_DIR}/heygen" --version 2>/dev/null || true)"
+  if [[ -z "$version_output" ]]; then
+    fail "installed binary but version check failed"
+  fi
+
+  log "Installed: ${INSTALL_DIR}/heygen"
+  log "${version_output}"
+
+  case ":$PATH:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+      log ""
+      log "Add ${INSTALL_DIR} to your PATH if it is not already included."
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,10 +80,10 @@ download_with_gh() {
     return 1
   fi
 
-  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$asset_name" --dir "$TMPDIR"; then
+  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$asset_name" --dir "$TMPDIR" >/dev/null 2>&1; then
     return 1
   fi
-  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$checksums_name" --dir "$TMPDIR"; then
+  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$checksums_name" --dir "$TMPDIR" >/dev/null 2>&1; then
     return 1
   fi
   if [[ ! -f "${TMPDIR}/${asset_name}" || ! -f "${TMPDIR}/${checksums_name}" ]]; then


### PR DESCRIPTION
## Description

Adds `scripts/install.sh` — a one-command installer for internal users who don't have Go. Downloads the latest dev build from the rolling `dev` prerelease (PR #35) and installs to `~/.local/bin`.

**Install or update (same command):**
```bash
# If you have gh CLI authenticated:
bash <(gh api repos/heygen-com/heygen-cli/contents/scripts/install.sh --jq '.content' | base64 -d)

# Or with a GitHub token:
export GITHUB_TOKEN=<token>
curl -fsSL -H "Authorization: token $GITHUB_TOKEN" \
  https://raw.githubusercontent.com/heygen-com/heygen-cli/main/scripts/install.sh | bash
```

**What the script does:**
1. Detects OS (`darwin`/`linux`) and architecture (`amd64`/`arm64`)
2. Downloads the matching archive from the `dev` prerelease
3. Downloads `checksums.txt` and verifies the archive SHA256 hash
4. Extracts the `heygen` binary
5. Installs to `~/.local/bin` with `0755` permissions
6. Runs `heygen --version` to verify the install
7. Warns if `~/.local/bin` is not in PATH

**Auth handling** (private repo requires authentication):
- Primary path: `gh release download` — works if user has `gh` CLI installed and authenticated (most internal devs do)
- Fallback: `curl` with `GITHUB_TOKEN` or `GH_TOKEN` environment variable
- Fails with a clear message if neither auth method is available

**Safety:**
- Checksum verification catches corrupted or tampered downloads
- `set -euo pipefail` — strict bash mode, fails fast on errors
- Temp directory with cleanup trap — no leftover files on failure
- SHA256 tool detection: `sha256sum` (Linux) or `shasum -a 256` (Mac)

**Testing overrides:**
- `HEYGEN_RELEASE_BASE_URL` — point downloads at a local directory for testing
- `INSTALL_DIR` — install to a custom directory
- `HEYGEN_RELEASE_TAG` — download a specific release tag instead of `dev`

**What the user sees:**
```
Detected: linux amd64
Installing heygen from heygen-com/heygen-cli release tag 'dev'
Downloaded release assets with gh
Installed: /home/user/.local/bin/heygen
heygen version dev-08bd87d
```

Depends on PR #35 for the dev release workflow that produces the artifacts this script downloads.

Linear: PRINFRA-138

## Testing

- `bash -n scripts/install.sh` — syntax check passes
- Tested end-to-end against a real `dev` prerelease on GitHub — download, checksum verify, install, version check all pass
- Tested `gh` download path (primary) — clean output, no stderr leaks
- Tested `curl` fallback with `HEYGEN_RELEASE_BASE_URL=file:///tmp/...` — works for local testing
- Tested checksum failure detection — corrupted archive correctly rejected with clear error
- Tested PATH hint — shown when `~/.local/bin` is not in PATH