### PR TITLE
docs: add internal release process docs (PRINFRA-138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,135 @@
+# HeyGen CLI
+
+A Go CLI wrapping HeyGen's v3 API. Auto-generated from our OpenAPI spec. Single
+binary, JSON-first output.
+
+## Install
+
+### Internal dev build (recommended for internal users)
+
+If `gh` is installed and authenticated:
+
+```bash
+gh api repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  --jq '.content' | base64 -d | bash
+```
+
+If you want to use a token directly:
+
+```bash
+curl -fsSL \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.raw" \
+  https://api.github.com/repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  | bash
+```
+
+This installs the latest internal dev build from the rolling `dev` prerelease
+into `~/.local/bin` by default.
+
+### From source (contributors)
+
+Requires Go 1.23+.
+
+```bash
+git clone git@github.com:heygen-com/heygen-cli.git
+cd heygen-cli
+make install
+```
+
+This installs `heygen` to your `$GOPATH/bin` (typically `~/go/bin`).
+
+### Manual release download
+
+Download the binary for your platform from
+[Releases](https://github.com/heygen-com/heygen-cli/releases) and put it in
+your `PATH`.
+
+For this internal repository, users still need GitHub read access to download
+release assets. See [RELEASE.md](./RELEASE.md) for the maintainer release
+process and internal dev-release workflow.
+
+## Setup
+
+Authenticate with your HeyGen API key:
+
+```bash
+heygen auth login
+
+# Or non-interactively
+echo "$HEYGEN_API_KEY" | heygen auth login
+```
+
+The key is stored in `~/.heygen/credentials`. You can also use the
+`HEYGEN_API_KEY` environment variable (takes precedence over the stored key).
+
+## Usage
+
+```bash
+heygen video list --limit 10
+heygen video get <video-id>
+heygen video create --avatar-id josh_lite --script "Hello world" --voice-id en_male
+heygen avatar list
+heygen voice list --type public
+heygen video list --limit 10 --human
+```
+
+Every command supports `--help`:
+
+```bash
+heygen --help                      # show all groups
+heygen video --help                # show video commands
+heygen video-agent --help          # show flattened nested task help
+heygen webhook --help              # show flattened endpoint/event help
+```
+
+### Complex request bodies
+
+For endpoints with complex input (nested objects, unions), use `-d` to pass raw
+JSON:
+
+```bash
+heygen video-translate create -d '{"video": {"type": "url", "url": "https://..."}, "output_languages": ["es"]}'
+
+# Or from a file
+heygen video-translate create -d request.json
+
+# Or from stdin
+cat request.json | heygen video-translate create -d -
+```
+
+Flags and `-d` can be combined. Flags override fields in the JSON body.
+
+## Output modes
+
+The CLI defaults to JSON output, which is the best mode for scripts and agents:
+
+```bash
+heygen video get <video-id>
+```
+
+For human-readable tables and key/value views, add `--human`:
+
+```bash
+heygen video list --limit 10 --human
+heygen webhook --help
+```
+
+## Build & Test
+
+```bash
+make build    # build to bin/heygen
+make install  # install to $GOPATH/bin/heygen
+make test     # run all tests (mocked, no API key needed)
+make lint     # golangci-lint
+make clean    # remove build artifacts
+```
+
+## Regenerate commands from OpenAPI spec
+
+```bash
+make generate SPEC=/path/to/external-api.json
+```
+
+This reads the OpenAPI spec, generates command definitions in `gen/`, and
+formats the output. Generated files should be committed.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,91 @@
+# Release Process
+
+## Install the CLI
+
+### Internal dev build
+
+Recommended for internal users who do not want to build from source.
+
+If `gh` is installed and authenticated:
+
+```bash
+gh api repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  --jq '.content' | base64 -d | bash
+```
+
+If you want to use a token directly:
+
+```bash
+curl -fsSL \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.raw" \
+  https://api.github.com/repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  | bash
+```
+
+The installer downloads the latest internal dev build from the rolling `dev`
+prerelease and installs `heygen` into `~/.local/bin` by default.
+
+### Manual download
+
+1. Open the repo's Releases page.
+2. Find the `Internal Dev Build` prerelease.
+3. Download the archive for your platform.
+4. Extract the archive and move `heygen` into your `PATH`.
+
+### From source
+
+For contributors with Go installed:
+
+```bash
+git clone git@github.com:heygen-com/heygen-cli.git
+cd heygen-cli
+make install
+```
+
+## Release Types
+
+### Dev builds
+
+- Rolling prerelease tagged `dev`
+- Built from `main`
+- Version format: `dev-<sha>`
+- Intended for internal users and fast feedback
+
+### Stable releases
+
+- Immutable tagged releases like `v0.1.0`
+- Built from a tagged commit via GoReleaser
+- Intended for milestone cuts and broader distribution later
+
+## How to Cut a Dev Release
+
+1. Make sure `main` is in a good state.
+2. Trigger the GitHub Actions workflow:
+
+```bash
+gh workflow run dev-release.yml
+```
+
+3. Wait for the workflow to finish.
+4. Verify the `Internal Dev Build` prerelease was updated with the latest commit
+   SHA.
+5. Share the installer command or release link with internal users as needed.
+
+## How to Cut a Stable Release
+
+1. Make sure `main` is ready for a stable cut.
+2. Tag and push:
+
+```bash
+git tag v0.1.0
+git push --tags
+```
+
+3. The tag-based release workflow publishes the stable release artifacts.
+
+## Version Scheme
+
+- `dev-<sha>` for rolling internal builds
+- `v0.x.y` for pre-1.0 stable releases
+- `v1.x.y` and beyond once the CLI surface is considered stable


### PR DESCRIPTION
## Description
This adds the release-facing documentation for the new internal distribution flow.

It introduces:
- `README.md` with the current CLI install, auth, usage, and `--human` guidance
- `RELEASE.md` with maintainer-facing instructions for cutting the rolling internal dev release and future stable tagged releases

The README now points internal users toward the install script / release path instead of implying that source builds are the only first-class install route. The release guide keeps the operational details for maintainers out of the main README.

This is the top docs layer of the new release stack and is intended to make the workflow and installer from the lower PRs usable immediately.

## Testing
- Reviewed the docs against the implemented workflow and install script in the lower stack PRs.
- Verified the documented install commands match the private-repo auth constraints (`gh` or `GITHUB_TOKEN`).
- Verified the README examples match the current generated CLI surface and auth behavior on `main`.
