### PR TITLE
output: format timestamps and durations in --human

### DIFF
--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/heygen-com/heygen-cli/internal/command"
@@ -98,7 +99,7 @@ func (f *HumanFormatter) renderTable(rows []map[string]any, columns []command.Co
 
 	for _, row := range rows {
 		for i, col := range columns {
-			cell := formatValue(fieldValue(row, col.Field))
+			cell := formatCell(fieldValue(row, col.Field), col.Field)
 			if w := lipgloss.Width(cell); w > widths[i] {
 				widths[i] = w
 			}
@@ -111,7 +112,7 @@ func (f *HumanFormatter) renderTable(rows []map[string]any, columns []command.Co
 	for _, row := range rows {
 		values := make([]string, len(columns))
 		for i, col := range columns {
-			values[i] = formatValue(fieldValue(row, col.Field))
+			values[i] = formatCell(fieldValue(row, col.Field), col.Field)
 		}
 		if _, err := fmt.Fprintln(f.out, renderTableLine(values, widths, true)); err != nil {
 			return err
@@ -159,7 +160,7 @@ func (f *HumanFormatter) renderKeyValue(obj map[string]any) error {
 	for _, key := range keys {
 		label := humanizeKey(key)
 		padding := strings.Repeat(" ", max(0, maxLabelWidth-lipgloss.Width(label)))
-		if _, err := fmt.Fprintf(f.out, "%s:%s  %s\n", label, padding, formatValue(obj[key])); err != nil {
+		if _, err := fmt.Fprintf(f.out, "%s:%s  %s\n", label, padding, formatCell(obj[key], key)); err != nil {
 			return err
 		}
 	}
@@ -232,6 +233,18 @@ func fieldValue(row map[string]any, path string) any {
 	return current
 }
 
+func formatCell(v any, fieldName string) string {
+	if value, ok := v.(float64); ok {
+		if isUnixTimestamp(value) {
+			return time.Unix(int64(value), 0).UTC().Format("2006-01-02 15:04")
+		}
+		if strings.Contains(strings.ToLower(fieldName), "duration") {
+			return formatDuration(value)
+		}
+	}
+	return formatValue(v)
+}
+
 func formatValue(v any) string {
 	switch value := v.(type) {
 	case nil:
@@ -261,6 +274,24 @@ func formatValue(v any) string {
 	}
 }
 
+func isUnixTimestamp(value float64) bool {
+	if value != float64(int64(value)) {
+		return false
+	}
+	return value > 1.5e9 && value < 2.2e9
+}
+
+func formatDuration(seconds float64) string {
+	d := time.Duration(seconds * float64(time.Second))
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("%dh %dm %ds", int(d.Hours()), int(d.Minutes())%60, int(d.Seconds())%60)
+}
+
 func humanizeKey(key string) string {
 	parts := strings.FieldsFunc(key, func(r rune) bool {
 		return r == '_' || r == '-' || r == '.'
@@ -273,4 +304,3 @@ func humanizeKey(key string) string {
 	}
 	return strings.Join(parts, " ")
 }
-

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -79,6 +79,56 @@ func TestHumanFormatter_Data_KeyValue(t *testing.T) {
 	}
 }
 
+func TestHumanFormatter_Data_TimestampFormatting(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":[{"id":"vid_123","created_at":1774712936}]}`)
+	columns := []command.Column{
+		{Header: "ID", Field: "id"},
+		{Header: "Created", Field: "created_at"},
+	}
+
+	if err := f.Data(input, "data", columns); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "2026-03-28 15:48") {
+		t.Fatalf("timestamp was not formatted as UTC date/time:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_DurationFormatting(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"duration":18.9649,"status":"completed"}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Duration:  18s") {
+		t.Fatalf("duration was not formatted as seconds:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_RegularFloatUnaffected(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"score":3.14}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Score:  3.14") {
+		t.Fatalf("regular float should remain unchanged:\n%s", got)
+	}
+}
+
 func TestHumanFormatter_Data_PrimitiveArray(t *testing.T) {
 	var out bytes.Buffer
 	f := NewHumanFormatter(&out, &bytes.Buffer{})


### PR DESCRIPTION
## Description

Formats timestamps and durations in `--human` mode so they're actually human-readable.

**Before:**
```
ID                                Title                 Status     Created
4621f8ba1a8f4811b32f669c37be53a2  HeyGen in 20 Seconds  completed  1774712936
```

**After:**
```
ID                                Title                 Status     Created
4621f8ba1a8f4811b32f669c37be53a2  HeyGen in 20 Seconds  completed  2026-03-28 15:48
```

**Timestamp formatting:**
- Detects unix timestamps by heuristic: integer-valued floats between 1.5e9 and 2.2e9 (covers 2017–2039)
- Formats as UTC: `2006-01-02 15:04`
- Won't false-positive on durations (small floats), IDs (strings), or counts (integers outside range)

**Duration formatting:**
- Detects by field name: any field containing "duration" (case-insensitive)
- `18.9649` → `18s`, `62.5` → `1m 2s`, `3661.0` → `1h 1m 1s`

**Implementation:**
- New `formatCell(v, fieldName)` function wraps `formatValue` with context-aware formatting
- Called from `renderTable` and `renderKeyValue` (both paths get formatting)
- `formatValue` unchanged — JSON mode is unaffected

Stacked on PR #40 (help text fixes).

## Testing

3 new tests:
- `TestHumanFormatter_Data_TimestampFormatting` — unix epoch `1774712936` renders as `2026-03-28 15:48`
- `TestHumanFormatter_Data_DurationFormatting` — float `18.9649` with field name "duration" renders as `18s`
- `TestHumanFormatter_Data_RegularFloatUnaffected` — float `3.14` with field name "score" stays `3.14`