### PR TITLE
cmd: add auth status command

### DIFF
--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -4,10 +4,10 @@ import "github.com/spf13/cobra"
 
 func newAuthCmd(ctx *cmdContext) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "auth",
-		Short:       "Manage authentication",
-		Annotations: map[string]string{"skipAuth": "true"},
+		Use:   "auth",
+		Short: "Manage authentication",
 	}
 	cmd.AddCommand(newAuthLoginCmd(ctx))
+	cmd.AddCommand(newAuthStatusCmd(ctx))
 	return cmd
 }

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -16,8 +16,9 @@ import (
 
 func newAuthLoginCmd(ctx *cmdContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "login",
-		Short: "Store API key for CLI authentication",
+		Use:         "login",
+		Short:       "Store API key for CLI authentication",
+		Annotations: map[string]string{"skipAuth": "true"},
 		Long: `Reads an API key from stdin and stores it for future CLI use.
 
 Interactive:

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net/url"
+
+	"github.com/heygen-com/heygen-cli/gen"
+	"github.com/heygen-com/heygen-cli/internal/client"
+	"github.com/heygen-com/heygen-cli/internal/command"
+	"github.com/spf13/cobra"
+)
+
+func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
+	return &cobra.Command{
+		Use:     "status",
+		Short:   "Verify stored API key and show account info",
+		Example: "heygen auth status",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := ctx.client.Execute(gen.UserMeGet, &command.Invocation{
+				PathParams:  make(map[string]string),
+				QueryParams: make(url.Values),
+			})
+			if err != nil {
+				return err
+			}
+			return ctx.formatter.Data(result, client.APIDataField, nil)
+		},
+	}
+}

--- a/cmd/heygen/auth_status_test.go
+++ b/cmd/heygen/auth_status_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+func TestAuthStatus_Success(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/user/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"user@example.com","username":"demo"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if res.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty", res.Stderr)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, res.Stdout)
+	}
+	data, ok := parsed["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data field missing or not object: %v", parsed)
+	}
+	if data["email"] != "user@example.com" {
+		t.Fatalf("data.email = %v, want %q", data["email"], "user@example.com")
+	}
+}
+
+func TestAuthStatus_InvalidKey(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/user/me": {
+			StatusCode: 401,
+			Body:       `{"error":{"message":"invalid API key"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "invalid-key", "auth", "status")
+
+	if res.ExitCode != clierrors.ExitAuth {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitAuth, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"code":"auth_error"`) {
+		t.Fatalf("stderr = %s, want auth_error code", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"message":"invalid API key"`) {
+		t.Fatalf("stderr = %s, want invalid API key message", res.Stderr)
+	}
+}
+
+func TestAuthStatus_NoKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	res := runCommand(t, "http://example.invalid", "", "auth", "status")
+
+	if res.ExitCode != clierrors.ExitAuth {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitAuth, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"message":"no API key found"`) {
+		t.Fatalf("stderr = %s, want missing API key message", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"hint":"Set HEYGEN_API_KEY env var or run: heygen auth login"`) {
+		t.Fatalf("stderr = %s, want auth hint", res.Stderr)
+	}
+}


### PR DESCRIPTION
## Description

Adds `heygen auth status` — verifies the stored API key is valid by calling `GET /v3/user/me` and outputting account info.

```bash
# Valid key
$ heygen auth status
{"data":{"email":"user@example.com","username":"demo",...}}

# Invalid key → exit 3
$ heygen auth status
{"error":{"code":"auth_error","message":"invalid API key"}}

# No key configured → exit 3
$ heygen auth status
{"error":{"code":"auth_error","message":"no API key found","hint":"Set HEYGEN_API_KEY env var or run: heygen auth login"}}
```

**skipAuth restructured:** Moved `skipAuth` annotation from the `auth` group to `auth login` specifically. `auth status` intentionally resolves auth — if no key is configured, it fails with the standard auth error (exit 3) before the API call. `auth login` continues to skip auth as before.

**Reuses generated spec:** Calls `ctx.client.Execute(gen.UserMeGet, ...)` — same endpoint as `heygen user me get`. If the API path or response shape changes, both commands update together.

**Auth vs server errors:** Distinguishable by exit code. Invalid key → exit 3 (`auth_error`). Server down → exit 1 (`server_error`/`network_error`). Retry transport handles transient failures before surfacing.

Stacked on PR #43 (SKILL.md).

## Testing

3 tests: success (200 → exit 0, stdout has user email), invalid key (401 → exit 3, stderr has auth_error), no key (exit 3 with hint to set env var or run auth login).

Existing `TestAuthLogin_SkipsAuth` continues passing — skipAuth annotation moved to login, not removed.

All tests use `httptest.Server` — no real API calls.