### PR TITLE
cmd: increase default wait timeout (PRINFRA-125)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ Video creation is asynchronous. Two patterns:
 
 **Block until done (recommended):**
 ```bash
-heygen video-agent create --prompt "Demo video" --wait --timeout 5m
+heygen video-agent create --prompt "Demo video" --wait
 # stdout: final resource JSON with video_url when complete
 ```
 
@@ -92,7 +92,7 @@ Both output valid JSON Schema. Available on all create/update commands (`--reque
 
 ## Notes
 
-- `--wait` handles polling with exponential backoff (2s to 30s). Default timeout is 10 minutes.
+- `--wait` handles polling with exponential backoff (2s to 30s). Default timeout is 20 minutes.
 - The CLI retries transient errors (429, 5xx) automatically.
 - Video download writes to `{video-id}.mp4` by default. Override with `--output-path`.
 - For the full API reference (concepts, limits, pricing), see https://developers.heygen.com

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -168,7 +168,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 	}
 	if pollConfigs[spec.Group+"/"+spec.Name] != nil {
 		cmd.Flags().Bool("wait", false, "Poll until the operation completes or fails")
-		cmd.Flags().Duration("timeout", 10*time.Minute, "Max time to wait when using --wait")
+		cmd.Flags().Duration("timeout", 20*time.Minute, "Max time to wait when using --wait")
 	}
 	// Add -d/--data for commands with JSON request bodies
 	if spec.BodyEncoding == "json" {


### PR DESCRIPTION
## Description

Bumps the default `--timeout` for `--wait` from 10 minutes to 20 minutes. Internal testing showed video-agent videos routinely take 10-30 minutes, causing the default timeout to expire before completion. The internal video skill documentation already recommends 15-20 minute timeouts.

**Three changes:**
1. `builder.go` — `--timeout` flag default changed from `10*time.Minute` to `20*time.Minute`
2. `SKILL.md` — "Default timeout is 10 minutes" → "20 minutes"
3. `SKILL.md` — removed `--timeout 5m` from the example (misleadingly short; the default now works for most cases)

Users can still override with `--timeout 30m` or `--timeout 1h` for exceptionally long operations.

Stacked on PR #43 (SKILL.md).
Linear: PRINFRA-125

## Testing

Existing timeout tests use explicit `--timeout 20ms` overrides, so they are unaffected by the default change. Verified with `go test ./cmd/heygen/... -count=1`.