### PR TITLE
scripts: rewrite installer for versioned releases

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -26,86 +26,37 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Build release archives
+      - name: Compute dev version
+        id: compute
         shell: bash
         run: |
           set -euo pipefail
 
-          mkdir -p dist
-          version="dev-$(git rev-parse --short HEAD)"
-          targets=(
-            "linux amd64"
-            "linux arm64"
-            "darwin amd64"
-            "darwin arm64"
-            "windows amd64"
-          )
-
-          for target in "${targets[@]}"; do
-            read -r goos goarch <<<"$target"
-            workdir="$(mktemp -d)"
-            binary="heygen"
-            if [[ "$goos" == "windows" ]]; then
-              binary="heygen.exe"
-            fi
-
-            GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 \
-              go build -ldflags "-s -w -X main.version=${version}" \
-              -o "${workdir}/${binary}" ./cmd/heygen/
-
-            if [[ "$goos" == "windows" ]]; then
-              archive="dist/heygen_${goos}_${goarch}.zip"
-              (
-                cd "$workdir"
-                zip -q "$GITHUB_WORKSPACE/$archive" "$binary"
-              )
-            else
-              archive="dist/heygen_${goos}_${goarch}.tar.gz"
-              tar -C "$workdir" -czf "$archive" "$binary"
-            fi
-
-            rm -rf "$workdir"
-          done
-
-          (
-            cd dist
-            sha256sum ./* > checksums.txt
-          )
-
-      - name: Write release notes
-        shell: bash
-        run: |
-          short_sha="$(git rev-parse --short HEAD)"
-          commit_date="$(git show -s --format=%ci HEAD)"
-          commit_subject="$(git show -s --format=%s HEAD)"
-
-          {
-            echo "## Internal Dev Build"
-            echo ""
-            echo "Latest CLI build from \`main\`. Manually triggered."
-            echo ""
-            echo "- **Commit:** ${short_sha}"
-            echo "- **Date:** ${commit_date}"
-            echo "- **Source:** \`main\`"
-            echo "- **Commit message:** ${commit_subject}"
-            echo "- **Triggered by:** @${GITHUB_ACTOR}"
-            echo ""
-            echo "Download the archive for your platform from the assets below and add \`heygen\` to your \`PATH\`."
-          } > /tmp/dev-release-notes.md
-
-      - name: Recreate dev prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if gh release view dev >/dev/null 2>&1; then
-            gh release delete dev --cleanup-tag --yes
+          latest_stable="$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)"
+          if [[ -z "$latest_stable" ]]; then
+            latest_stable="v0.0.0"
           fi
 
-          gh release create dev dist/* \
-            --target "$GITHUB_SHA" \
-            --title "Internal Dev Build" \
-            --prerelease \
-            --notes-file /tmp/dev-release-notes.md
+          base="$(echo "$latest_stable" | sed 's/^v//' | awk -F. '{printf "%d.%d.%d", $1, $2, $3 + 1}')"
+          short_sha="$(git rev-parse --short HEAD)"
+          version="v${base}-dev.$(date -u +%Y%m%d).${short_sha}"
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Create git tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ steps.compute.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$version"
+          git push origin "$version"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean --skip=validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ archives:
       - goos: windows
         formats:
           - zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
   version_template: "{{ .Tag }}-next"
 checksum:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ binary, JSON-first output.
 
 ## Install
 
-### Internal dev build (recommended for internal users)
+### Install script
 
 If `gh` is installed and authenticated:
 
@@ -24,8 +24,21 @@ curl -fsSL \
   | bash
 ```
 
-This installs the latest internal dev build from the rolling `dev` prerelease
-into `~/.local/bin` by default.
+This installs the latest stable release into `~/.local/bin` by default.
+
+Install the latest dev prerelease instead:
+
+```bash
+gh api repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  --jq '.content' | base64 -d | bash -s -- --dev
+```
+
+Install a specific version:
+
+```bash
+gh api repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  --jq '.content' | base64 -d | bash -s -- --version v0.1.0
+```
 
 ### From source (contributors)
 
@@ -47,7 +60,7 @@ your `PATH`.
 
 For this internal repository, users still need GitHub read access to download
 release assets. See [RELEASE.md](./RELEASE.md) for the maintainer release
-process and internal dev-release workflow.
+process and release workflows.
 
 ## Setup
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Install the CLI
 
-### Internal dev build
+### Install script
 
 Recommended for internal users who do not want to build from source.
 
@@ -23,8 +23,22 @@ curl -fsSL \
   | bash
 ```
 
-The installer downloads the latest internal dev build from the rolling `dev`
-prerelease and installs `heygen` into `~/.local/bin` by default.
+The installer downloads the latest stable release and installs `heygen` into
+`~/.local/bin` by default.
+
+Install the latest dev prerelease:
+
+```bash
+gh api repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  --jq '.content' | base64 -d | bash -s -- --dev
+```
+
+Install a specific version:
+
+```bash
+gh api repos/heygen-com/heygen-cli/contents/scripts/install.sh \
+  --jq '.content' | base64 -d | bash -s -- --version v0.1.0
+```
 
 ### Manual download
 
@@ -47,9 +61,8 @@ make install
 
 ### Dev builds
 
-- Rolling prerelease tagged `dev`
+- Immutable prereleases tagged `v{base}-dev.{YYYYMMDD}.{shorthash}`
 - Built from `main`
-- Version format: `dev-<sha>`
 - Intended for internal users and fast feedback
 
 ### Stable releases
@@ -68,8 +81,7 @@ gh workflow run dev-release.yml
 ```
 
 3. Wait for the workflow to finish.
-4. Verify the `Internal Dev Build` prerelease was updated with the latest commit
-   SHA.
+4. Verify a new prerelease was published for the computed dev tag.
 5. Share the installer command or release link with internal users as needed.
 
 ## How to Cut a Stable Release
@@ -86,6 +98,6 @@ gh workflow run release-stable.yml -f version=v0.1.0
 
 ## Version Scheme
 
-- `dev-<sha>` for rolling internal builds
+- `v{base}-dev.{YYYYMMDD}.{shorthash}` for dev prereleases
 - `v0.x.y` for pre-1.0 stable releases
 - `v1.x.y` and beyond once the CLI surface is considered stable

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -98,6 +98,48 @@ gh workflow run release-stable.yml -f version=v0.1.0
 
 ## Version Scheme
 
-- `v{base}-dev.{YYYYMMDD}.{shorthash}` for dev prereleases
-- `v0.x.y` for pre-1.0 stable releases
-- `v1.x.y` and beyond once the CLI surface is considered stable
+All versions use semver with a `v` prefix. The `v` prefix is required everywhere: git tags, `--version` output, `heygen update --version` input, JSON responses, and install script flags.
+
+### Format
+
+| Build type | Tag format | Example |
+|---|---|---|
+| Stable | `v{major}.{minor}.{patch}` | `v0.1.0` |
+| Dev | `v{base}-dev.{YYYYMMDD}.{shorthash}` | `v0.1.1-dev.20260406.abc1234` |
+| Local (no ldflags) | — | `dev` |
+
+### Ordering
+
+Semver ordering is guaranteed:
+
+```
+v0.2.0 > v0.1.1-dev.20260407.def > v0.1.1-dev.20260406.abc > v0.1.0
+```
+
+- Stable always beats prerelease of the same base version
+- Dev builds sort chronologically by date within the same base
+- Dev builds of the next version sort above the current stable
+
+### Dev version auto-derivation
+
+The dev release workflow auto-computes the version tag. No manual bumping or VERSION file:
+
+1. Reads the latest stable tag (e.g., `v0.1.0`)
+2. Bumps patch: `v0.1.0` → `v0.1.1`
+3. Appends `-dev.YYYYMMDD.SHORTHASH`: `v0.1.1-dev.20260406.abc1234`
+
+If no stable tag exists, starts from `v0.0.1-dev.*`.
+
+### Bumping rules
+
+- **Pre-1.0 (`v0.x.y`):** no stability guarantees. Minor = features, patch = fixes.
+- **Post-1.0 (`v1.0.0`+):** semver contract. Major = breaking changes to output format or flag behavior.
+
+### Update channels
+
+`heygen update` auto-detects the update channel from the current version:
+
+- Running a stable version (e.g., `v0.1.0`) → updates track stable releases only
+- Running a dev version (e.g., `v0.1.1-dev.*`) → updates track dev prereleases
+
+`heygen update --version v0.1.0` overrides channel detection and installs the exact version specified.

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,6 @@ Official CLI for the HeyGen video generation API. 30+ commands auto-generated fr
 
 - **API Docs**: https://developers.heygen.com
 - **Install**: `curl -fsSL https://heygen-cli.heygen.com/install.sh | bash`
-- **Install dev build**: `curl -fsSL https://heygen-cli.heygen.com/install.sh | bash -s -- --dev`
 - **Auth**: Requires `HEYGEN_API_KEY` environment variable. The key must be provisioned by a user from https://app.heygen.com/settings/api
 
 ## Key Commands

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,7 +18,7 @@ Official CLI for the HeyGen video generation API. 30+ commands auto-generated fr
 heygen video-agent create --prompt "Make a 30-second product demo" --wait
 
 # Create avatar video with full control
-heygen video create -d '{"video_inputs":[{"character":{"type":"avatar","avatar_id":"josh_lite"},"voice":{"type":"text","voice_id":"en_male","input_text":"Hello world"}}]}'
+heygen video create -d '{"type":"avatar","avatar_id":"josh_lite","script":"Hello world","voice_id":"en_male"}'
 
 # Check video status
 heygen video get <video-id>
@@ -35,7 +35,7 @@ heygen voice list
 heygen video-translate create -d '{"video":{"type":"url","url":"https://..."},"output_languages":["es"]}'
 ```
 
-## Async Operations
+## Async Workflow
 
 Video creation is asynchronous. Two patterns:
 
@@ -43,6 +43,7 @@ Video creation is asynchronous. Two patterns:
 ```bash
 heygen video-agent create --prompt "Demo video" --wait
 # stdout: final resource JSON with video_url when complete
+# exit 4 on timeout — stdout has partial resource, stderr has the get command to poll manually
 ```
 
 **Manual polling:**
@@ -52,47 +53,24 @@ heygen video get <video-id>           # stdout: JSON with status field
 heygen video download <video-id>      # downloads file, stdout: JSON with path
 ```
 
-## Request Bodies
+## Discovering API Fields
 
-Create/update commands accept JSON via `-d`/`--data`:
-- Inline: `-d '{"key": "value"}'`
-- From file: `-d request.json`
-- From stdin: `echo '{"...}' | heygen video create -d -`
+Use `--request-schema` and `--response-schema` on any command to see the full JSON Schema. No auth required.
 
-Flags override matching fields in the JSON when both are provided.
-
-To discover the expected JSON fields, use `--request-schema`:
 ```bash
-heygen video create --request-schema       # shows all request body fields with types and descriptions
+heygen video create --request-schema
 heygen video-agent create --request-schema
+heygen video get --response-schema
 ```
-
-To see what the API returns, use `--response-schema`:
-```bash
-heygen video get --response-schema         # shows all response fields
-```
-
-Both output valid JSON Schema. Available on all create/update commands (`--request-schema`) and all commands (`--response-schema`). No auth required.
 
 ## Output Contract
 
-- **stdout**: JSON (always). Parseable by `jq`. This is the only output agents should consume.
+- **stdout**: JSON (always). This is the only output agents should consume.
 - **stderr**: JSON error envelope on failure: `{"error":{"code":"...","message":"...","hint":"..."}}`
-- **Pagination**: Use `--limit` and `--token` for manual pagination. Read `next_token` from the response to fetch the next page.
 - Do not pass `--human`. It produces unstructured text that cannot be parsed.
-
-## Exit Codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | General error (API error, network failure) |
-| 2 | Usage error (invalid flags, missing arguments) |
-| 3 | Authentication error |
 
 ## Notes
 
-- `--wait` handles polling with exponential backoff (2s to 30s). Default timeout is 20 minutes.
 - The CLI retries transient errors (429, 5xx) automatically.
-- Video download writes to `{video-id}.mp4` by default. Override with `--output-path`.
+- Use `heygen update check` to see if a newer CLI release is available.
 - For the full API reference (concepts, limits, pricing), see https://developers.heygen.com

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,6 +9,7 @@ Official CLI for the HeyGen video generation API. 30+ commands auto-generated fr
 
 - **API Docs**: https://developers.heygen.com
 - **Install**: `curl -fsSL https://heygen-cli.heygen.com/install.sh | bash`
+- **Install dev build**: `curl -fsSL https://heygen-cli.heygen.com/install.sh | bash -s -- --dev`
 - **Auth**: Requires `HEYGEN_API_KEY` environment variable. The key must be provisioned by a user from https://app.heygen.com/settings/api
 
 ## Key Commands

--- a/cmd/heygen/testutil_test.go
+++ b/cmd/heygen/testutil_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
@@ -69,7 +70,15 @@ func runCommandWithInput(t *testing.T, serverURL, apiKey string, stdin io.Reader
 	var stdout, stderr bytes.Buffer
 	formatter := formatterForArgs(args, &stdout, &stderr)
 
-	// Set env vars for this test
+	// Set env vars for this test.
+	// Set HEYGEN_CONFIG_DIR to an empty temp dir so the
+	// FileCredentialResolver doesn't pick up real credentials
+	// from ~/.heygen/credentials on dev machines — but only if
+	// the test hasn't already set it (e.g., config tests that
+	// write a config file to a specific dir).
+	if os.Getenv("HEYGEN_CONFIG_DIR") == "" {
+		t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	}
 	if apiKey != "" {
 		t.Setenv("HEYGEN_API_KEY", apiKey)
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,10 +3,11 @@
 set -euo pipefail
 
 REPO="${HEYGEN_REPO:-heygen-com/heygen-cli}"
-RELEASE_TAG="${HEYGEN_RELEASE_TAG:-dev}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+MODE="stable"
+REQUESTED_VERSION=""
 
 log() {
   printf '%s\n' "$*"
@@ -66,12 +67,135 @@ github_token() {
       return
     fi
   fi
-  fail "set GITHUB_TOKEN or authenticate gh before running this installer"
+  return 1
+}
+
+json_get_string() {
+  local key="$1"
+  sed -n "s/.*\"${key}\":\"\\([^\"]*\\)\".*/\\1/p"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dev)
+        if [[ -n "$REQUESTED_VERSION" ]]; then
+          fail "--dev cannot be combined with --version"
+        fi
+        MODE="dev"
+        shift
+        ;;
+      --version)
+        if [[ $# -lt 2 ]]; then
+          fail "--version requires a value"
+        fi
+        if [[ "$MODE" == "dev" ]]; then
+          fail "--version cannot be combined with --dev"
+        fi
+        REQUESTED_VERSION="$2"
+        if [[ ! "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].+)?$ ]]; then
+          fail "--version must include the leading v (for example: v0.1.0)"
+        fi
+        MODE="version"
+        shift 2
+        ;;
+      -h | --help)
+        cat <<'EOF'
+Usage: install.sh [--dev] [--version <tag>]
+
+Install the HeyGen CLI release for the current platform.
+
+Options:
+  --dev              Install the latest dev prerelease
+  --version <tag>    Install a specific version tag (for example: v0.1.0)
+EOF
+        exit 0
+        ;;
+      *)
+        fail "unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+github_api() {
+  local path="$1"
+  local token
+  local url="https://api.github.com/repos/${REPO}${path}"
+
+  if token="$(github_token)"; then
+    curl -fsSL \
+      -H "Authorization: Bearer ${token}" \
+      -H "Accept: application/vnd.github+json" \
+      "$url"
+    return
+  fi
+
+  curl -fsSL \
+    -H "Accept: application/vnd.github+json" \
+    "$url"
+}
+
+latest_stable_tag() {
+  github_api "/releases/latest" | tr -d '\n' | json_get_string tag_name
+}
+
+latest_dev_tag() {
+  if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
+    gh release list --repo "$REPO" --exclude-drafts --limit 50 --json tagName,isPrerelease --jq 'map(select(.isPrerelease))[0].tagName'
+    return
+  fi
+
+  github_api "/releases?per_page=50" | tr -d '\n' | sed 's/[[:space:]]//g' | awk '
+    BEGIN { RS="\\{"; FS="," }
+    {
+      tag=""; prerelease=""; draft=""
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /"tag_name":"/) {
+          field=$i
+          sub(/.*"tag_name":"/, "", field)
+          sub(/".*/, "", field)
+          tag=field
+        }
+        if ($i ~ /"prerelease":/) {
+          field=$i
+          sub(/.*"prerelease":/, "", field)
+          sub(/[^a-z].*/, "", field)
+          prerelease=field
+        }
+        if ($i ~ /"draft":/) {
+          field=$i
+          sub(/.*"draft":/, "", field)
+          sub(/[^a-z].*/, "", field)
+          draft=field
+        }
+      }
+      if (tag != "" && prerelease == "true" && draft != "true") {
+        print tag
+        exit
+      }
+    }
+  '
+}
+
+resolve_release_tag() {
+  case "$MODE" in
+    stable)
+      latest_stable_tag
+      ;;
+    dev)
+      latest_dev_tag
+      ;;
+    version)
+      printf '%s\n' "$REQUESTED_VERSION"
+      ;;
+  esac
 }
 
 download_with_gh() {
-  local asset_name="$1"
-  local checksums_name="$2"
+  local release_tag="$1"
+  local asset_name="$2"
+  local checksums_name="$3"
 
   if ! command -v gh >/dev/null 2>&1; then
     return 1
@@ -80,10 +204,10 @@ download_with_gh() {
     return 1
   fi
 
-  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$asset_name" --dir "$TMPDIR" >/dev/null 2>&1; then
+  if ! gh release download "$release_tag" --repo "$REPO" --pattern "$asset_name" --dir "$TMPDIR" >/dev/null 2>&1; then
     return 1
   fi
-  if ! gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "$checksums_name" --dir "$TMPDIR" >/dev/null 2>&1; then
+  if ! gh release download "$release_tag" --repo "$REPO" --pattern "$checksums_name" --dir "$TMPDIR" >/dev/null 2>&1; then
     return 1
   fi
   if [[ ! -f "${TMPDIR}/${asset_name}" || ! -f "${TMPDIR}/${checksums_name}" ]]; then
@@ -93,21 +217,31 @@ download_with_gh() {
 }
 
 download_with_curl() {
-  local asset_name="$1"
-  local checksums_name="$2"
-  local token="$3"
+  local release_tag="$1"
+  local asset_name="$2"
+  local checksums_name="$3"
+  local token=""
   local base_url
 
-  if [[ -n "${HEYGEN_RELEASE_BASE_URL:-}" ]]; then
-    base_url="${HEYGEN_RELEASE_BASE_URL%/}"
+  if token="$(github_token)"; then
+    :
   else
-    base_url="https://github.com/${REPO}/releases/download/${RELEASE_TAG}"
+    token=""
   fi
 
-  curl -fsSL -H "Authorization: Bearer ${token}" \
-    "${base_url}/${asset_name}" -o "${TMPDIR}/${asset_name}"
-  curl -fsSL -H "Authorization: Bearer ${token}" \
-    "${base_url}/${checksums_name}" -o "${TMPDIR}/${checksums_name}"
+  base_url="https://github.com/${REPO}/releases/download/${release_tag}"
+  if [[ -n "${HEYGEN_RELEASE_BASE_URL:-}" ]]; then
+    base_url="${HEYGEN_RELEASE_BASE_URL%/}/${release_tag}"
+  fi
+
+  if [[ -n "$token" ]]; then
+    curl -fsSL -H "Authorization: Bearer ${token}" "${base_url}/${asset_name}" -o "${TMPDIR}/${asset_name}"
+    curl -fsSL -H "Authorization: Bearer ${token}" "${base_url}/${checksums_name}" -o "${TMPDIR}/${checksums_name}"
+    return
+  fi
+
+  curl -fsSL "${base_url}/${asset_name}" -o "${TMPDIR}/${asset_name}"
+  curl -fsSL "${base_url}/${checksums_name}" -o "${TMPDIR}/${checksums_name}"
 }
 
 verify_checksum() {
@@ -144,21 +278,25 @@ install_archive() {
 }
 
 main() {
-  local os arch asset_name checksums_name token version_output
+  local os arch release_tag asset_name checksums_name version_output
 
+  parse_args "$@"
   os="$(detect_os)"
   arch="$(detect_arch)"
-  asset_name="heygen_${os}_${arch}.tar.gz"
+  release_tag="$(resolve_release_tag)"
+  if [[ -z "$release_tag" ]]; then
+    fail "could not determine release tag"
+  fi
+  asset_name="heygen_${release_tag}_${os}_${arch}.tar.gz"
   checksums_name="checksums.txt"
 
   log "Detected: ${os} ${arch}"
-  log "Installing heygen from ${REPO} release tag '${RELEASE_TAG}'"
+  log "Installing heygen from ${REPO} release tag '${release_tag}'"
 
-  if download_with_gh "$asset_name" "$checksums_name"; then
+  if download_with_gh "$release_tag" "$asset_name" "$checksums_name"; then
     log "Downloaded release assets with gh"
   else
-    token="$(github_token)"
-    download_with_curl "$asset_name" "$checksums_name" "$token"
+    download_with_curl "$release_tag" "$asset_name" "$checksums_name"
     log "Downloaded release assets with curl"
   fi
 


### PR DESCRIPTION
## Description

Replaces the dev-phase installer and release workflow with a versioned release cycle. Three changes:

**1. Dev release workflow rewrite (`.github/workflows/dev-release.yml`):**
The old workflow used a rolling `dev` tag with unversioned assets (`heygen_linux_amd64.tar.gz`) and `version="dev-<sha>"`. The new workflow auto-computes a semver-compliant tag from the latest stable release: bumps patch, appends `-dev.YYYYMMDD.SHORTHASH` (e.g., `v0.1.1-dev.20260406.abc1234`). Creates an immutable git tag and delegates to GoReleaser for versioned asset names, checksums, and prerelease publishing. Each dev build is a separate prerelease, not a rolling overwrite.

Version derivation: reads latest stable tag via `git tag --list`, bumps patch (`v0.1.0` → `v0.1.1`), appends dev metadata. If no stable tag exists, starts from `v0.0.1-dev.*`.

**2. Install script rewrite (`scripts/install.sh`):**
The old installer defaulted to the `dev` tag and required `GITHUB_TOKEN`. The new installer:
- Defaults to latest stable release (not dev)
- `--dev` flag installs latest dev prerelease
- `--version v0.1.0` pins to a specific version (`v` prefix required)
- Falls back to unauthenticated GitHub API when no token is available (ready for public repo)
- Uses versioned GoReleaser asset names (`heygen_v0.1.0_linux_amd64.tar.gz`)
- `--help` flag for discoverability
- `--dev` and `--version` are mutually exclusive

**3. GoReleaser asset naming (`.goreleaser.yaml`):**
Archive name template changed from `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}` to `{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}` — includes the `v` prefix in the filename for consistency with the tag format.

README, RELEASE.md, and SKILL.md updated to reflect the new install commands and versioning scheme.

Stacked on PR #23 (stable release workflow).

## Testing

Install script tested manually with `--help`, `--dev`, `--version`, and default (stable) modes. Dev release workflow validated by reading the computed version step output. GoReleaser config validated via `make goreleaser-check`.