### PR TITLE
ci: allow PostHog ingest token

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[[allowlists]]
+description = "PostHog CLI analytics ingest token"
+paths = ['''internal/analytics/analytics.go''']
+regexTarget = "line"
+regexes = ['''const posthogAPIKey = "phc_[A-Za-z0-9]+"''']


### PR DESCRIPTION
## Description

Adds a `.gitleaks.toml` allowlist so the PostHog project API token in `internal/analytics/analytics.go` doesn't fail the secrets CI check.

PostHog project tokens are public client-side ingest tokens by design — they're embedded in every frontend and CLI that uses PostHog. This is not a secret leak. The allowlist is scoped narrowly: only matches the exact `const posthogAPIKey = "phc_..."` assignment in that one file.

Without this, the `secrets` CI job fails on PRs #23, #49, and #50 (the entire M6 stack).

## Testing

CI `secrets` job should pass after this merges. Verified the allowlist regex matches the token assignment pattern.