### PR TITLE
ci: fix GoReleaser prerelease detection and version prefix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
+      - -X main.version={{.Tag}}
 archives:
   - id: default
     formats:
@@ -27,5 +27,7 @@ archives:
     name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
   version_template: "{{ .Tag }}-next"
+release:
+  prerelease: auto
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## Description

Two fixes discovered during the first versioned dev release:

1. **`release.prerelease: auto`** — GoReleaser wasn't marking dev releases as prereleases. The install script's `--dev` flag uses `gh release list --json isPrerelease` to find the latest dev build, which returned empty because the release wasn't flagged. With `prerelease: auto`, GoReleaser detects the `-dev.` semver prerelease suffix and sets the flag automatically.

2. **`{{.Tag}}` instead of `{{.Version}}`** — GoReleaser's `{{.Version}}` strips the `v` prefix from git tags. `heygen --version` showed `0.0.1-dev.20260407.c9e2db1` instead of `v0.0.1-dev.20260407.c9e2db1`. Using `{{.Tag}}` preserves the prefix, matching our convention that the `v` prefix is required everywhere.

## Testing

GoReleaser config validated by `goreleaser-check` CI job. After merge, trigger a new dev release and verify:
- Release is marked as prerelease on GitHub
- `heygen --version` shows `v` prefix
- `bash install.sh --dev` finds and installs the release