### PR TITLE
cmd: move env vars and exit codes below commands in root help

### DIFF
--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -20,22 +21,7 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 		// NOTE: Only user-facing env vars are listed here. Internal/operational
 		// vars (HEYGEN_MAX_RETRIES, HEYGEN_NO_ANALYTICS, HEYGEN_CONFIG_DIR) are
 		// intentionally hidden. Use "heygen config list" to see all settings.
-		Long: `HeyGen CLI — create and manage videos, avatars, and more.
-
-Environment Variables:
-  HEYGEN_API_KEY     API key for authentication (overrides stored credentials)
-  HEYGEN_OUTPUT      Output format: json, human (default: json)
-
-Use "heygen config list" to see all configuration settings and their sources.
-
-Exit Codes:
-  0   Success
-  1   General error (API error, network failure)
-  2   Usage error (invalid flags, missing arguments)
-  3   Authentication error (missing or invalid API key)
-  4   Timeout (resource created but operation not yet complete)
-
-Use "heygen update" to check for and install newer versions.`,
+		Long: `HeyGen CLI — create and manage videos, avatars, and more.`,
 		Version:       version,
 		SilenceUsage:  true, // we handle usage errors ourselves
 		SilenceErrors: true, // we handle error output ourselves
@@ -57,8 +43,37 @@ Use "heygen update" to check for and install newer versions.`,
 	registerGroups(root, ctx, gen.Groups)
 	attachCustomCommands(root, ctx)
 	installFlattenedHelp(root)
+	installRootHelpFooter(root)
 
 	return root
+}
+
+// installRootHelpFooter appends environment variables, exit codes, and hints
+// after the standard Cobra help output (commands + flags first, details last).
+func installRootHelpFooter(root *cobra.Command) {
+	defaultHelp := root.HelpFunc()
+	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		defaultHelp(cmd, args)
+		if cmd != root {
+			return
+		}
+		fmt.Fprint(cmd.OutOrStdout(), `
+Environment Variables:
+  HEYGEN_API_KEY     API key for authentication (overrides stored credentials)
+  HEYGEN_OUTPUT      Output format: json, human (default: json)
+
+  Use "heygen config list" to see all configuration settings and their sources.
+
+Exit Codes:
+  0   Success
+  1   General error (API error, network failure)
+  2   Usage error (invalid flags, missing arguments)
+  3   Authentication error (missing or invalid API key)
+  4   Timeout (resource created but operation not yet complete)
+
+Use "heygen update" to check for and install newer versions.
+`)
+	})
 }
 
 // newRootCmdWithSpecs creates a root command that registers generated commands


### PR DESCRIPTION
## Description

Moves environment variables, exit codes, and the update hint from above the command list to below it in root `--help` output. Every major CLI (gh, stripe, kubectl, gcloud) lists commands first — the most important info should be visible immediately.

**Before:**
```
HeyGen CLI — ...

Environment Variables:
  ...
Exit Codes:
  ...

Available Commands:
  video ...
  avatar ...
```

**After:**
```
HeyGen CLI — ...

Available Commands:
  video ...
  avatar ...

Flags:
  ...

Environment Variables:
  ...
Exit Codes:
  ...
```

Uses a custom help function (`installRootHelpFooter`) that wraps Cobra's default help and appends the footer. Only applies to root command — subcommand help is unaffected.

## Testing

All tests pass. Manually verified:
- `heygen --help` — footer appears after commands and flags
- `heygen video --help` — no footer (subcommand help clean)
- `heygen video create --help` — no footer