### PR TITLE
fix: dev update channel detection and version sort order

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -38,8 +38,7 @@ jobs:
           fi
 
           base="$(echo "$latest_stable" | sed 's/^v//' | awk -F. '{printf "%d.%d.%d", $1, $2, $3 + 1}')"
-          short_sha="$(git rev-parse --short HEAD)"
-          version="v${base}-dev.$(date -u +%Y%m%d).${short_sha}"
+          version="v${base}-dev.$(date -u +%Y%m%d%H%M)"
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -105,7 +105,7 @@ All versions use semver with a `v` prefix. The `v` prefix is required everywhere
 | Build type | Tag format | Example |
 |---|---|---|
 | Stable | `v{major}.{minor}.{patch}` | `v0.1.0` |
-| Dev | `v{base}-dev.{YYYYMMDD}.{shorthash}` | `v0.1.1-dev.20260406.abc1234` |
+| Dev | `v{base}-dev.{YYYYMMDDHHmm}` | `v0.1.1-dev.202604071502` |
 | Local (no ldflags) | — | `dev` |
 
 ### Ordering
@@ -113,11 +113,11 @@ All versions use semver with a `v` prefix. The `v` prefix is required everywhere
 Semver ordering is guaranteed:
 
 ```
-v0.2.0 > v0.1.1-dev.20260407.def > v0.1.1-dev.20260406.abc > v0.1.0
+v0.2.0 > v0.1.1-dev.202604071502 > v0.1.1-dev.202604071400 > v0.1.0
 ```
 
 - Stable always beats prerelease of the same base version
-- Dev builds sort chronologically by date within the same base
+- Dev builds sort chronologically by minute-precision timestamp
 - Dev builds of the next version sort above the current stable
 
 ### Dev version auto-derivation
@@ -126,7 +126,7 @@ The dev release workflow auto-computes the version tag. No manual bumping or VER
 
 1. Reads the latest stable tag (e.g., `v0.1.0`)
 2. Bumps patch: `v0.1.0` → `v0.1.1`
-3. Appends `-dev.YYYYMMDD.SHORTHASH`: `v0.1.1-dev.20260406.abc1234`
+3. Appends `-dev.YYYYMMDDHHmm`: `v0.1.1-dev.202604071502`
 
 If no stable tag exists, starts from `v0.0.1-dev.*`.
 

--- a/cmd/heygen/update.go
+++ b/cmd/heygen/update.go
@@ -138,7 +138,10 @@ func runUpdate(ctx *cmdContext, targetVersion string) error {
 		return clierrors.New(fmt.Sprintf("failed to resolve executable path: %v", err))
 	}
 
-	updater, err := newReleaseUpdater(false)
+	// Auto-detect update channel from current version: dev builds track
+	// dev prereleases, stable builds track stable releases only.
+	isDevBuild := strings.Contains(current, "-dev.")
+	updater, err := newReleaseUpdater(isDevBuild)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Fixes `heygen update` always reporting "already at current version" for dev builds. Two root causes:

**Bug 1: Updater ignores prereleases**

`newReleaseUpdater(false)` hardcoded `Prerelease: false`, so `go-selfupdate` only searched stable releases. Since no stable releases exist, `DetectLatest` returned `found=false` and the code fell back to reporting the current version as up-to-date.

Fix: auto-detect the update channel from the current version string. If the version contains `-dev.`, set `Prerelease: true` so the updater searches dev prereleases. Stable users continue tracking stable only.

```go
isDevBuild := strings.Contains(current, "-dev.")
updater, err := newReleaseUpdater(isDevBuild)
```

**Bug 2: Dev versions sort incorrectly in semver**

The old format `v0.0.1-dev.20260407.c9e2db1` included the commit hash as a semver prerelease identifier. Semver compares these lexicographically, but commit hashes don't sort chronologically — `c9e2db1` sorts higher than `47546c3` even though the latter is a newer commit. This caused `DetectLatest` to return the oldest release as "latest."

Fix: drop the hash, use minute-precision timestamps: `v0.0.1-dev.202604071502`. The timestamp is monotonically increasing, sorting correctly in semver. The hash is redundant — the git tag points to the exact commit.

**New format:** `v{base}-dev.{YYYYMMDDHHmm}` (e.g., `v0.0.1-dev.202604071502`)

## Testing

All tests pass. After merge, trigger a dev release and verify `heygen update` picks up the new build.