### PR TITLE
cmd: add request-schema hint for data-only commands

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -26,10 +26,15 @@ import (
 func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 	var rawData string
 
+	description := spec.Description
+	if spec.BodyEncoding == "json" && !hasBodyFlags(spec) {
+		description += "\n\nUse --request-schema to see all available request fields."
+	}
+
 	cmd := &cobra.Command{
 		Use:     buildUseLine(spec),
 		Short:   spec.Summary,
-		Long:    spec.Description,
+		Long:    description,
 		Example: strings.Join(spec.Examples, "\n"),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if isSchemaRequest(cmd) {
@@ -187,6 +192,15 @@ func commandPathParts(spec *command.Spec) []string {
 
 // buildUseLine constructs the leaf Cobra Use string from the spec name and args.
 // Example: "create <video-id>" or "list".
+func hasBodyFlags(spec *command.Spec) bool {
+	for _, f := range spec.Flags {
+		if f.Source == "body" {
+			return true
+		}
+	}
+	return false
+}
+
 func buildUseLine(spec *command.Spec) string {
 	path := commandPathParts(spec)
 	name := spec.Name


### PR DESCRIPTION
## Description

Adds a `Use --request-schema to see all available request fields.` hint to the description of commands that accept a JSON body (`-d`/`--data`) but have no promoted body flags.

Currently this only affects `video create` — after the v3 API redesigned the endpoint as a discriminated union (`oneOf`), the codegen correctly dropped all body flags. Users must construct JSON via `--data`, but the help text didn't guide them to `--request-schema` for discovering available fields.

The hint is auto-generated by the builder when `spec.BodyEncoding == "json"` and no flags have `Source: "body"`. Commands with promoted flags (like `video-agent create` with `--prompt`, `--avatar-id`, etc.) don't show the hint — the flags themselves are the discovery mechanism.

Stacked on PR #60 (examples after flags).

## Testing

All tests pass. Manually verified:
- `heygen video create --help` — shows hint
- `heygen video-agent create --help` — no hint (has body flags)
- `heygen video list --help` — no hint (no JSON body)