### PR TITLE
fix: tighten batch command edge cases

### DIFF
--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -3,10 +3,7 @@ package main
 import "github.com/spf13/cobra"
 
 func newAuthCmd(ctx *cmdContext) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "auth",
-		Short: "Manage authentication",
-	}
+	cmd := newCommandGroup("auth", "Manage authentication")
 	cmd.AddCommand(newAuthLoginCmd(ctx))
 	cmd.AddCommand(newAuthStatusCmd(ctx))
 	return cmd

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -44,7 +44,9 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if isSchemaRequest(cmd) {
-				clearRequiredFlagAnnotations(cmd)
+				clearRequiredFlagAnnotations(cmd, nil)
+			} else if cmd.Flags().Changed("data") {
+				clearRequiredFlagAnnotations(cmd, bodyFlagNames(spec))
 			}
 			return nil
 		},
@@ -239,14 +241,23 @@ func requestedSchema(cmd *cobra.Command, spec *command.Spec) (bool, string) {
 
 type requiredFlagAnnotationsKey struct{}
 
-func clearRequiredFlagAnnotations(cmd *cobra.Command) {
-	saved := make(map[string][]string)
+func clearRequiredFlagAnnotations(cmd *cobra.Command, filter map[string]bool) {
+	existing, _ := cmd.Context().Value(requiredFlagAnnotationsKey{}).(map[string][]string)
+	saved := make(map[string][]string, len(existing))
+	for name, annotations := range existing {
+		saved[name] = append([]string(nil), annotations...)
+	}
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if filter != nil && !filter[f.Name] {
+			return
+		}
 		annotations, ok := f.Annotations[cobra.BashCompOneRequiredFlag]
 		if !ok {
 			return
 		}
-		saved[f.Name] = append([]string(nil), annotations...)
+		if _, alreadySaved := saved[f.Name]; !alreadySaved {
+			saved[f.Name] = append([]string(nil), annotations...)
+		}
 		delete(f.Annotations, cobra.BashCompOneRequiredFlag)
 		if len(f.Annotations) == 0 {
 			f.Annotations = nil
@@ -256,6 +267,16 @@ func clearRequiredFlagAnnotations(cmd *cobra.Command) {
 		return
 	}
 	cmd.SetContext(context.WithValue(cmd.Context(), requiredFlagAnnotationsKey{}, saved))
+}
+
+func bodyFlagNames(spec *command.Spec) map[string]bool {
+	names := make(map[string]bool)
+	for _, flag := range spec.Flags {
+		if flag.Source == "body" {
+			names[flag.Name] = true
+		}
+	}
+	return names
 }
 
 func restoreRequiredFlagAnnotations(cmd *cobra.Command) {

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -74,6 +74,7 @@ var videoTranslateSchemaSpec = &command.Spec{
 	Summary:       "Create video translation",
 	Endpoint:      "/v3/video-translations",
 	Method:        "POST",
+	BodyEncoding:  "json",
 	RequestSchema: "{\n  \"type\": \"object\"\n}",
 	Flags: []command.FlagSpec{
 		{Name: "output-languages", Type: "string-slice", Source: "body", JSONName: "output_languages", Required: true},
@@ -257,6 +258,60 @@ func TestGenBuilder_ArgsStillValidatedWithoutSchema(t *testing.T) {
 	}
 	if !strings.Contains(res.Stderr, "accepts 1 arg(s), received 0") {
 		t.Fatalf("stderr = %q, want positional arg error", res.Stderr)
+	}
+}
+
+func TestGenBuilder_DataSatisfiesRequiredBodyFlags(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/video-translations": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"vt_123"}}`,
+		},
+	})
+	defer srv.Close()
+
+	spec := &command.Spec{
+		Group:        "video-translate",
+		Name:         "create",
+		Summary:      "Create translation",
+		Endpoint:     "/v3/video-translations",
+		Method:       "POST",
+		BodyEncoding: "json",
+		Flags: []command.FlagSpec{
+			{Name: "output-languages", Type: "string-slice", Source: "body", JSONName: "output_languages", Required: true},
+		},
+		Examples: []string{"heygen video-translate create -d '{\"output_languages\":[\"es\"]}'"},
+	}
+
+	res := runGenCommand(t, srv.URL, "test-key", spec, "create", "-d", `{"output_languages":["es"]}`)
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}
+
+func TestGenBuilder_DataDoesNotBypassRequiredQueryFlags(t *testing.T) {
+	spec := &command.Spec{
+		Group:        "video",
+		Name:         "create",
+		Summary:      "Create video",
+		Endpoint:     "/v3/videos",
+		Method:       "POST",
+		BodyEncoding: "json",
+		Flags: []command.FlagSpec{
+			{Name: "folder-id", Type: "string", Source: "query", JSONName: "folder_id", Required: true},
+			{Name: "title", Type: "string", Source: "body", JSONName: "title"},
+		},
+		Examples: []string{"heygen video create --folder-id folder_123"},
+	}
+
+	res := runGenCommand(t, "http://example.test", "test-key", spec, "create", "-d", `{"title":"Demo"}`)
+
+	if res.ExitCode != clierrors.ExitUsage {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "required flag(s)") || !strings.Contains(res.Stderr, "folder-id") {
+		t.Fatalf("stderr = %q, want required query flag error", res.Stderr)
 	}
 }
 
@@ -736,6 +791,48 @@ func TestGenBuilder_EnumValidation(t *testing.T) {
 	}
 }
 
+func TestGenBuilder_WebhookEventsFlag(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/webhooks/endpoints": {
+			StatusCode: 200,
+			Body:       `{"data":{"endpoint_id":"ep_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &gotBody)
+			},
+		},
+	})
+	defer srv.Close()
+
+	spec := &command.Spec{
+		Group:        "webhook",
+		Name:         "endpoints create",
+		Summary:      "Create endpoint",
+		Endpoint:     "/v3/webhooks/endpoints",
+		Method:       "POST",
+		BodyEncoding: "json",
+		Flags: []command.FlagSpec{
+			{Name: "url", Type: "string", Source: "body", JSONName: "url", Required: true},
+			{Name: "events", Type: "string-slice", Source: "body", JSONName: "events", Enum: []string{"avatar_video.success", "avatar_video.fail"}},
+		},
+		Examples: []string{"heygen webhook endpoints create --url https://example.com/hook --events avatar_video.success"},
+	}
+
+	res := runGenCommand(t, srv.URL, "test-key", spec, "endpoints", "create",
+		"--url", "https://example.com/hook", "--events", "avatar_video.success")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	events, ok := gotBody["events"].([]any)
+	if !ok || len(events) != 1 || events[0] != "avatar_video.success" {
+		t.Fatalf("body.events = %#v, want [avatar_video.success]", gotBody["events"])
+	}
+}
+
 func TestGenBuilder_NestedCommand_Executes(t *testing.T) {
 	var gotBody map[string]any
 
@@ -844,7 +941,7 @@ func TestGenBuilder_IntermediateHelp_ShowsChildCommands(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if !strings.Contains(res.Stdout, "Usage:\n  heygen voice speech [command]") {
+	if !strings.Contains(res.Stdout, "Usage:") || !strings.Contains(res.Stdout, "heygen voice speech [command]") {
 		t.Errorf("help missing nested usage\nstdout: %s", res.Stdout)
 	}
 	if !strings.Contains(res.Stdout, "Available Commands:") || !strings.Contains(res.Stdout, "create") {

--- a/cmd/heygen/config_cmd.go
+++ b/cmd/heygen/config_cmd.go
@@ -17,11 +17,8 @@ type configResponse struct {
 }
 
 func newConfigCmd(ctx *cmdContext) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:         "config",
-		Short:       "Manage CLI configuration",
-		Annotations: map[string]string{"skipAuth": "true"},
-	}
+	cmd := newCommandGroup("config", "Manage CLI configuration")
+	cmd.Annotations = map[string]string{"skipAuth": "true"}
 	cmd.AddCommand(newConfigSetCmd(ctx))
 	cmd.AddCommand(newConfigGetCmd(ctx))
 	cmd.AddCommand(newConfigListCmd(ctx))

--- a/cmd/heygen/generated_root_test.go
+++ b/cmd/heygen/generated_root_test.go
@@ -122,11 +122,53 @@ func TestGeneratedRoot_IntermediateHelp(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if !strings.Contains(res.Stdout, "Usage:\n  heygen voice speech [command]") {
+	if !strings.Contains(res.Stdout, "Usage:") || !strings.Contains(res.Stdout, "heygen voice speech [command]") {
 		t.Errorf("help missing nested usage\nstdout: %s", res.Stdout)
 	}
 	if !strings.Contains(res.Stdout, "create") {
 		t.Errorf("help missing nested child command\nstdout: %s", res.Stdout)
+	}
+}
+
+func TestGeneratedRoot_GroupCommand_UnknownSubcommand(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "nonexistent")
+
+	if res.ExitCode != clierrors.ExitUsage {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "unknown command") || !strings.Contains(res.Stderr, "heygen video") {
+		t.Fatalf("stderr = %q, want unknown subcommand error", res.Stderr)
+	}
+}
+
+func TestGeneratedRoot_GroupCommand_NoArgs_PrintsHelp(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "Available Commands:") {
+		t.Fatalf("stdout = %q, want group help", res.Stdout)
+	}
+}
+
+func TestGeneratedRoot_NestedGroupCommand_UnknownSubcommand(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video-agent", "sessions", "nonexistent")
+
+	if res.ExitCode != clierrors.ExitUsage {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "unknown command") || !strings.Contains(res.Stderr, "heygen video-agent sessions") {
+		t.Fatalf("stderr = %q, want nested unknown subcommand error", res.Stderr)
 	}
 }
 

--- a/cmd/heygen/help_flatten.go
+++ b/cmd/heygen/help_flatten.go
@@ -174,5 +174,5 @@ func visibleChildren(cmd *cobra.Command) []*cobra.Command {
 }
 
 func isLeafCommand(cmd *cobra.Command) bool {
-	return cmd.RunE != nil || cmd.Run != nil
+	return len(visibleChildren(cmd)) == 0
 }

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -21,7 +21,7 @@ func newRootCmd(version string, formatter output.Formatter) *cobra.Command {
 		// NOTE: Only user-facing env vars are listed here. Internal/operational
 		// vars (HEYGEN_MAX_RETRIES, HEYGEN_NO_ANALYTICS, HEYGEN_CONFIG_DIR) are
 		// intentionally hidden. Use "heygen config list" to see all settings.
-		Long: `HeyGen CLI — create and manage videos, avatars, and more.`,
+		Long:          `HeyGen CLI — create and manage videos, avatars, and more.`,
 		Version:       version,
 		SilenceUsage:  true, // we handle usage errors ourselves
 		SilenceErrors: true, // we handle error output ourselves
@@ -127,7 +127,7 @@ func registerGroups(root *cobra.Command, ctx *cmdContext, groups map[string][]*c
 		if short == "" {
 			short = humanizeCommandToken(groupName) + " commands"
 		}
-		groupCmd := &cobra.Command{Use: groupName, Short: short}
+		groupCmd := newCommandGroup(groupName, short)
 		for _, spec := range groups[groupName] {
 			registerSpecCommand(groupCmd, spec, ctx)
 		}
@@ -172,12 +172,23 @@ func ensureIntermediateCommand(parent *cobra.Command, token string) *cobra.Comma
 		}
 	}
 
-	child := &cobra.Command{
-		Use:   token,
-		Short: humanizeCommandToken(token) + " commands",
-	}
+	child := newCommandGroup(token, humanizeCommandToken(token)+" commands")
 	parent.AddCommand(child)
 	return child
+}
+
+func newCommandGroup(use, short string) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return clierrors.NewUsage(
+					fmt.Sprintf("unknown command %q for %q", args[0], cmd.CommandPath()))
+			}
+			return cmd.Help()
+		},
+	}
 }
 
 func humanizeCommandToken(token string) string {

--- a/internal/command/spec.go
+++ b/internal/command/spec.go
@@ -184,10 +184,20 @@ func (s *Spec) BuildInvocation(cmd *cobra.Command, args []string, data map[strin
 // validateFlag checks enum membership and min/max bounds.
 func validateFlag(cmd *cobra.Command, flag FlagSpec) error {
 	if len(flag.Enum) > 0 {
-		val, _ := cmd.Flags().GetString(flag.Name)
-		if !slices.Contains(flag.Enum, val) {
-			return clierrors.NewUsage(
-				fmt.Sprintf("--%s must be one of %v, got %q", flag.Name, flag.Enum, val))
+		if flag.Type == "string-slice" {
+			vals, _ := cmd.Flags().GetStringSlice(flag.Name)
+			for _, val := range vals {
+				if !slices.Contains(flag.Enum, val) {
+					return clierrors.NewUsage(
+						fmt.Sprintf("--%s value %q must be one of %v", flag.Name, val, flag.Enum))
+				}
+			}
+		} else {
+			val, _ := cmd.Flags().GetString(flag.Name)
+			if !slices.Contains(flag.Enum, val) {
+				return clierrors.NewUsage(
+					fmt.Sprintf("--%s must be one of %v, got %q", flag.Name, flag.Enum, val))
+			}
 		}
 	}
 

--- a/internal/command/spec_test.go
+++ b/internal/command/spec_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
@@ -87,8 +88,6 @@ func TestBuildInvocation_PathParamArg(t *testing.T) {
 		t.Errorf("PathParams[video_id] = %q, want %q", inv.PathParams["video_id"], "abc123")
 	}
 }
-
-
 
 func TestBuildInvocation_UnchangedFlagOmitted(t *testing.T) {
 	spec := &Spec{
@@ -236,7 +235,6 @@ func TestBuildInvocation_FlagOverridesData(t *testing.T) {
 	}
 }
 
-
 func TestBuildInvocation_NoBodyWhenNoContent(t *testing.T) {
 	spec := &Spec{
 		Flags: []FlagSpec{
@@ -272,5 +270,49 @@ func TestBuildInvocation_StringSliceFlag(t *testing.T) {
 	}
 	if len(events) != 2 {
 		t.Errorf("events length = %d, want 2", len(events))
+	}
+}
+
+func TestBuildInvocation_StringSliceEnumValidation(t *testing.T) {
+	spec := &Spec{
+		Flags: []FlagSpec{
+			{Name: "events", Type: "string-slice", Source: "body", JSONName: "events", Enum: []string{"avatar_video.success", "avatar_video.fail"}},
+		},
+	}
+
+	cmd := helperCmd(t, spec, []string{"--events", "avatar_video.success,bogus"})
+
+	_, err := spec.BuildInvocation(cmd, nil, nil)
+	if err == nil {
+		t.Fatal("expected enum validation error, got nil")
+	}
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T", err)
+	}
+	if cliErr.ExitCode != clierrors.ExitUsage {
+		t.Fatalf("ExitCode = %d, want %d", cliErr.ExitCode, clierrors.ExitUsage)
+	}
+	if got := cliErr.Message; got == "" || !strings.Contains(got, `value "bogus"`) {
+		t.Fatalf("message = %q, want invalid slice value", got)
+	}
+}
+
+func TestBuildInvocation_StringSliceEnumValid(t *testing.T) {
+	spec := &Spec{
+		Flags: []FlagSpec{
+			{Name: "events", Type: "string-slice", Source: "body", JSONName: "events", Enum: []string{"avatar_video.success", "avatar_video.fail"}},
+		},
+	}
+
+	cmd := helperCmd(t, spec, []string{"--events", "avatar_video.success,avatar_video.fail"})
+
+	inv, err := spec.BuildInvocation(cmd, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	events, ok := inv.Body["events"].([]string)
+	if !ok || len(events) != 2 {
+		t.Fatalf("Body[events] = %#v, want 2 validated string-slice values", inv.Body["events"])
 	}
 }

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -99,7 +99,7 @@ func (f *HumanFormatter) renderTable(rows []map[string]any, columns []command.Co
 
 	for _, row := range rows {
 		for i, col := range columns {
-			cell := formatCell(fieldValue(row, col.Field), col.Field)
+			cell := formatTableCell(fieldValue(row, col.Field), col.Field)
 			if w := lipgloss.Width(cell); w > widths[i] {
 				widths[i] = w
 			}
@@ -112,7 +112,7 @@ func (f *HumanFormatter) renderTable(rows []map[string]any, columns []command.Co
 	for _, row := range rows {
 		values := make([]string, len(columns))
 		for i, col := range columns {
-			values[i] = formatCell(fieldValue(row, col.Field), col.Field)
+			values[i] = formatTableCell(fieldValue(row, col.Field), col.Field)
 		}
 		if _, err := fmt.Fprintln(f.out, renderTableLine(values, widths, true)); err != nil {
 			return err
@@ -245,6 +245,10 @@ func formatCell(v any, fieldName string) string {
 	return formatValue(v)
 }
 
+func formatTableCell(v any, fieldName string) string {
+	return sanitizeForTable(formatCell(v, fieldName))
+}
+
 func formatValue(v any) string {
 	switch value := v.(type) {
 	case nil:
@@ -290,6 +294,14 @@ func formatDuration(seconds float64) string {
 		return fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
 	}
 	return fmt.Sprintf("%dh %dm %ds", int(d.Hours()), int(d.Minutes())%60, int(d.Seconds())%60)
+}
+
+func sanitizeForTable(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "\u00a0", " ")
+	return strings.TrimSpace(s)
 }
 
 func humanizeKey(key string) string {

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -79,6 +79,21 @@ func TestHumanFormatter_Data_KeyValue(t *testing.T) {
 	}
 }
 
+func TestHumanFormatter_Data_KeyValuePreservesMultilineStrings(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage("{\"data\":{\"name\":\"Line 1\\nLine 2\"}}")
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Line 1\nLine 2") {
+		t.Fatalf("key-value output should preserve multiline strings:\n%s", got)
+	}
+}
+
 func TestHumanFormatter_Data_TimestampFormatting(t *testing.T) {
 	var out bytes.Buffer
 	f := NewHumanFormatter(&out, &bytes.Buffer{})
@@ -141,6 +156,13 @@ func TestHumanFormatter_Data_PrimitiveArray(t *testing.T) {
 	got := stripANSI(out.String())
 	if !strings.Contains(got, "Value") || !strings.Contains(got, "en") || !strings.Contains(got, "es") {
 		t.Fatalf("primitive arrays should render as a single-column table:\n%s", got)
+	}
+}
+
+func TestFormatTableCell_SanitizesWhitespace(t *testing.T) {
+	got := formatTableCell("\nMark\u00a0", "name")
+	if got != "Mark" {
+		t.Fatalf("formatTableCell = %q, want %q", got, "Mark")
 	}
 }
 


### PR DESCRIPTION
## Description

Four bugfixes from stress testing, all independent:

**1. Unknown subcommand exits 0 instead of 2 (PRINFRA-155)**

`heygen video nonexistent` printed help and exited 0 — agents couldn't distinguish a typo from a successful help request. Fix: `newCommandGroup` helper with `RunE` that rejects unexpected args with exit 2. Applied to all group commands: generated groups (`registerGroups`), intermediate commands (`ensureIntermediateCommand`), and hand-written groups (`auth`, `config`). `isLeafCommand` updated from `RunE != nil` to `len(visibleChildren) == 0` since group commands now have `RunE`.

**2. `--data` JSON body doesn't satisfy required flag checks (PRINFRA-156)**

`heygen video-translate create -d '{"output_languages":["es"]}'` failed with "required flag not set" even though the field was in the JSON. Fix: when `--data` is provided, clear required flag annotations for body-sourced flags only in `PreRunE`. Extended the existing `clearRequiredFlagAnnotations` with an optional filter parameter — schema bypass passes `nil` (all flags), `--data` bypass passes `bodyFlagNames(spec)` (body only). Query/file required flags stay enforced. Save/restore mechanism merges without overwriting.

**3. Webhook `--events` string-slice flag validation broken (PRINFRA-154)**

`--events avatar_video.success` failed with empty-string enum validation error. Fix: `validateFlag` now handles `string-slice` type — calls `GetStringSlice()` and validates each element individually against the enum. Previously only called `GetString()` which returns empty for string-slice flags.

**4. Voice name whitespace breaks `--human` table (PRINFRA-149)**

Some voice names from the API contain `\n` and `\u00a0`, breaking table alignment. Fix: new `formatTableCell` wrapper that sanitizes whitespace (collapse newlines/tabs/NBSP to spaces, trim). Only applied in the table rendering path — key-value output preserves multiline strings via the unchanged `formatCell`.

## Testing

- `TestGroupCommand_UnknownSubcommand` — exit 2 with "unknown command" error
- `TestGroupCommand_NoArgs_PrintsHelp` — exit 0 with help output
- `TestNestedGroupCommand_UnknownSubcommand` — exit 2 for nested groups
- `TestGenBuilder_DataSatisfiesRequiredBodyFlags` — `-d` with required field passes
- `TestGenBuilder_DataDoesNotBypassRequiredQueryFlags` — query flags still enforced with `-d`
- `TestGenBuilder_WebhookEventsFlag` — string-slice flag reaches API correctly
- `TestBuildInvocation_StringSliceEnumValidation` — invalid element rejected
- `TestBuildInvocation_StringSliceEnumValid` — valid elements pass
- `TestFormatTableCell_SanitizesWhitespace` — dirty names cleaned
- `TestHumanFormatter_Data_KeyValuePreservesMultilineStrings` — key-value path unaffected

All tests pass on Linux, macOS, Windows.