### PR TITLE
ci: auto-trigger dev release on merge to main

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,6 +2,8 @@ name: Dev Release
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

Every merge to main now auto-triggers a dev release. No more manual `gh workflow run dev-release.yml` needed.

One line added: `push: branches: [main]` alongside the existing `workflow_dispatch` trigger. Manual trigger preserved for ad-hoc builds.

The `concurrency: group: dev-release, cancel-in-progress: false` setting ensures simultaneous merges don't corrupt each other — they queue.

## Testing

Workflow syntax validated. After merge, the next PR merged to main will auto-trigger a dev release.