### PR TITLE
docs: clarify CI workflow changes require RELEASE.md update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,9 @@ Data(v json.RawMessage, dataField string, columns []command.Column) error
 When a change affects user-facing behavior, update the relevant doc:
 - New command group or removed group → README.md command table
 - New hand-written command or enhancement pattern → CONTRIBUTING.md
-- Changed release workflow → RELEASE.md
+- Changed release or CI workflow (triggers, versioning, channels) → RELEASE.md
 - Changed key commands or async patterns → SKILL.md
 
-Do not update docs for internal refactors, test changes, or codegen-only changes.
+CI workflow changes that affect how releases are built, triggered, or distributed count as release workflow changes — update RELEASE.md.
+
+Do not update docs for internal refactors, test changes, or codegen-only changes. Lint/CI changes that don't affect the release pipeline (e.g., adding a linter, changing test timeouts) are exempt.


### PR DESCRIPTION
## Description

PR #63 changed the dev release workflow trigger (auto-release on merge to main) but didn't update RELEASE.md, despite the CLAUDE.md documentation rule saying "Changed release workflow → RELEASE.md."

The rule was too easy to dismiss as "just a CI change." This tightens the language:

- **Before:** "Changed release workflow → RELEASE.md"
- **After:** "Changed release or CI workflow (triggers, versioning, channels) → RELEASE.md" with an explicit callout that CI changes affecting releases count.

Also clarifies the exemption: lint/CI changes that don't affect the release pipeline (adding a linter, test timeouts) are still exempt.

## Testing

Doc-only change. No functional impact.