### PR TITLE
feat(release): move stable installs to cloudfront

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -82,10 +82,12 @@ jobs:
 
       - name: Upload stable release artifacts to S3
         shell: bash
+        env:
+          TAG: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
 
-          tag="${{ github.event.inputs.version }}"
+          tag="$TAG"
 
           # Upload immutable artifacts first.
           aws s3 cp dist/ "s3://heygen-public/cli/releases/${tag}/" \

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -43,6 +44,16 @@ jobs:
       - name: Run tests
         run: make test
 
+      - name: Validate AWS release config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${{ vars.AWS_ROLE_ARN }}" ]]; then
+            echo "missing GitHub Actions variable AWS_ROLE_ARN" >&2
+            exit 1
+          fi
+
       - name: Create git tag
         shell: bash
         run: |
@@ -62,3 +73,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.version }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Upload stable release artifacts to S3
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${{ github.event.inputs.version }}"
+
+          # Upload immutable artifacts first.
+          aws s3 cp dist/ "s3://heygen-public/cli/releases/${tag}/" \
+            --recursive \
+            --exclude "*" \
+            --include "heygen_*.tar.gz" \
+            --include "heygen_*.zip" \
+            --include "checksums.txt" \
+            --cache-control "public, max-age=31536000, immutable"
+
+          # Upload the installer before flipping the stable pointer.
+          aws s3 cp scripts/install.sh "s3://heygen-public/cli/install.sh" \
+            --content-type "text/plain" \
+            --cache-control "public, max-age=300"
+
+          # Activate the release last so clients never observe a partial rollout.
+          echo -n "${tag}" > /tmp/version-pointer
+          aws s3 cp /tmp/version-pointer "s3://heygen-public/cli/stable" \
+            --content-type "text/plain" \
+            --cache-control "public, max-age=60"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Built for developers, AI agents, and CI/CD pipelines. JSON output by default.
 ## Install
 
 ```bash
-curl -fsSL https://heygen-cli.heygen.com/install.sh | bash
+curl -fsSL https://static.heygen.ai/cli/install.sh | bash
 ```
 
 This installs the latest stable release into `~/.local/bin`.
@@ -24,7 +24,7 @@ brew install heygen/tap/heygen
 **Specific version:**
 
 ```bash
-curl -fsSL https://heygen-cli.heygen.com/install.sh | bash -s -- --version v0.1.0
+curl -fsSL https://static.heygen.ai/cli/install.sh | bash -s -- --version v0.1.0
 ```
 
 **From source** (requires Go 1.23+):

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,8 @@ gh workflow run release-stable.yml -f version=v0.1.0
 3. The workflow validates the version, creates the tag on `main`, and
    publishes the stable release artifacts via GoReleaser, then uploads the
    installer, checksums, and platform archives to S3 for CDN-backed installs.
+   CDN propagation takes up to 1 minute for the version pointer and 5 minutes
+   for the install script.
 
 ## Version Scheme
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,8 @@ gh workflow run release-stable.yml -f version=v0.1.0
 ```
 
 3. The workflow validates the version, creates the tag on `main`, and
-   publishes the stable release artifacts via GoReleaser.
+   publishes the stable release artifacts via GoReleaser, then uploads the
+   installer, checksums, and platform archives to S3 for CDN-backed installs.
 
 ## Version Scheme
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,7 +8,7 @@ description: "Create AI videos, manage avatars, translate videos, and download r
 Official CLI for the HeyGen video generation API. 30+ commands auto-generated from the OpenAPI spec. All output is JSON by default.
 
 - **API Docs**: https://developers.heygen.com
-- **Install**: `curl -fsSL https://heygen-cli.heygen.com/install.sh | bash`
+- **Install**: `curl -fsSL https://static.heygen.ai/cli/install.sh | bash`
 - **Auth**: Requires `HEYGEN_API_KEY` environment variable. The key must be provisioned by a user from https://app.heygen.com/settings/api
 
 ## Key Commands

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,9 +82,6 @@ parse_args() {
           fail "--version requires a value"
         fi
         REQUESTED_VERSION="$2"
-        if [[ ! "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].+)?$ ]]; then
-          fail "--version must include the leading v (for example: v0.1.0)"
-        fi
         if [[ ! "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           fail "--version only supports stable releases (for example: v0.1.0)"
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 REPO="${HEYGEN_REPO:-heygen-com/heygen-cli}"
+CDN_BASE="${HEYGEN_CDN_BASE_URL:-https://static.heygen.ai/cli}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -48,6 +49,31 @@ checksum_cmd() {
     return
   fi
   fail "missing sha256 tool (need sha256sum or shasum)"
+}
+
+download() {
+  local url="$1"
+  local output="${2:-}"
+
+  if command -v curl >/dev/null 2>&1; then
+    if [[ -n "$output" ]]; then
+      curl -fsSL "$url" -o "$output"
+    else
+      curl -fsSL "$url"
+    fi
+    return
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    if [[ -n "$output" ]]; then
+      wget -q -O "$output" "$url"
+    else
+      wget -q -O - "$url"
+    fi
+    return
+  fi
+
+  fail "curl or wget required"
 }
 
 github_token() {
@@ -137,7 +163,11 @@ github_api() {
 }
 
 latest_stable_tag() {
-  github_api "/releases/latest" | tr -d '\n' | json_get_string tag_name
+  local version
+  if ! version="$(download "${CDN_BASE}/stable")"; then
+    fail "failed to resolve latest stable version from ${CDN_BASE}/stable"
+  fi
+  printf '%s\n' "$version" | tr -d '\r\n'
 }
 
 latest_dev_tag() {
@@ -244,6 +274,20 @@ download_with_curl() {
   curl -fsSL "${base_url}/${checksums_name}" -o "${TMPDIR}/${checksums_name}"
 }
 
+download_with_cdn() {
+  local release_tag="$1"
+  local asset_name="$2"
+  local checksums_name="$3"
+  local release_url="${CDN_BASE}/releases/${release_tag}"
+
+  if ! download "${release_url}/${asset_name}" "${TMPDIR}/${asset_name}"; then
+    fail "failed to download ${asset_name} from ${release_url}"
+  fi
+  if ! download "${release_url}/${checksums_name}" "${TMPDIR}/${checksums_name}"; then
+    fail "failed to download ${checksums_name} from ${release_url}"
+  fi
+}
+
 verify_checksum() {
   local asset_name="$1"
   local checksums_name="$2"
@@ -277,12 +321,26 @@ install_archive() {
   install -m 0755 "$extracted_bin" "${INSTALL_DIR}/heygen"
 }
 
+normalize_arch() {
+  local os="$1"
+  local arch="$2"
+
+  if [[ "$os" == "darwin" && "$arch" == "amd64" ]]; then
+    if [[ "$(sysctl -n sysctl.proc_translated 2>/dev/null || true)" == "1" ]]; then
+      printf 'arm64\n'
+      return
+    fi
+  fi
+
+  printf '%s\n' "$arch"
+}
+
 main() {
-  local os arch release_tag asset_name checksums_name version_output
+  local os arch release_tag asset_name checksums_name version_output source_desc
 
   parse_args "$@"
   os="$(detect_os)"
-  arch="$(detect_arch)"
+  arch="$(normalize_arch "$os" "$(detect_arch)")"
   release_tag="$(resolve_release_tag)"
   if [[ -z "$release_tag" ]]; then
     fail "could not determine release tag"
@@ -291,14 +349,30 @@ main() {
   checksums_name="checksums.txt"
 
   log "Detected: ${os} ${arch}"
-  log "Installing heygen from ${REPO} release tag '${release_tag}'"
+  case "$MODE" in
+    dev)
+      source_desc="${REPO} GitHub release"
+      ;;
+    stable | version)
+      source_desc="${CDN_BASE}"
+      ;;
+  esac
+  log "Installing heygen release tag '${release_tag}' from ${source_desc}"
 
-  if download_with_gh "$release_tag" "$asset_name" "$checksums_name"; then
-    log "Downloaded release assets with gh"
-  else
-    download_with_curl "$release_tag" "$asset_name" "$checksums_name"
-    log "Downloaded release assets with curl"
-  fi
+  case "$MODE" in
+    dev)
+      if download_with_gh "$release_tag" "$asset_name" "$checksums_name"; then
+        log "Downloaded release assets with gh"
+      else
+        download_with_curl "$release_tag" "$asset_name" "$checksums_name"
+        log "Downloaded release assets with curl"
+      fi
+      ;;
+    stable | version)
+      download_with_cdn "$release_tag" "$asset_name" "$checksums_name"
+      log "Downloaded release assets from CDN"
+      ;;
+  esac
 
   verify_checksum "$asset_name" "$checksums_name"
   install_archive "${TMPDIR}/${asset_name}" "$os"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,12 +2,10 @@
 
 set -euo pipefail
 
-REPO="${HEYGEN_REPO:-heygen-com/heygen-cli}"
 CDN_BASE="${HEYGEN_CDN_BASE_URL:-https://static.heygen.ai/cli}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
-MODE="stable"
 REQUESTED_VERSION=""
 
 log() {
@@ -76,63 +74,29 @@ download() {
   fail "curl or wget required"
 }
 
-github_token() {
-  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-    printf '%s\n' "$GITHUB_TOKEN"
-    return
-  fi
-  if [[ -n "${GH_TOKEN:-}" ]]; then
-    printf '%s\n' "$GH_TOKEN"
-    return
-  fi
-  if command -v gh >/dev/null 2>&1; then
-    local token
-    token="$(gh auth token 2>/dev/null || true)"
-    if [[ -n "$token" ]]; then
-      printf '%s\n' "$token"
-      return
-    fi
-  fi
-  return 1
-}
-
-json_get_string() {
-  local key="$1"
-  sed -n "s/.*\"${key}\":\"\\([^\"]*\\)\".*/\\1/p"
-}
-
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --dev)
-        if [[ -n "$REQUESTED_VERSION" ]]; then
-          fail "--dev cannot be combined with --version"
-        fi
-        MODE="dev"
-        shift
-        ;;
       --version)
         if [[ $# -lt 2 ]]; then
           fail "--version requires a value"
-        fi
-        if [[ "$MODE" == "dev" ]]; then
-          fail "--version cannot be combined with --dev"
         fi
         REQUESTED_VERSION="$2"
         if [[ ! "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].+)?$ ]]; then
           fail "--version must include the leading v (for example: v0.1.0)"
         fi
-        MODE="version"
+        if [[ ! "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          fail "--version only supports stable releases (for example: v0.1.0)"
+        fi
         shift 2
         ;;
       -h | --help)
         cat <<'EOF'
-Usage: install.sh [--dev] [--version <tag>]
+Usage: install.sh [--version <tag>]
 
-Install the HeyGen CLI release for the current platform.
+Install the HeyGen CLI stable release for the current platform.
 
 Options:
-  --dev              Install the latest dev prerelease
   --version <tag>    Install a specific version tag (for example: v0.1.0)
 EOF
         exit 0
@@ -144,24 +108,6 @@ EOF
   done
 }
 
-github_api() {
-  local path="$1"
-  local token
-  local url="https://api.github.com/repos/${REPO}${path}"
-
-  if token="$(github_token)"; then
-    curl -fsSL \
-      -H "Authorization: Bearer ${token}" \
-      -H "Accept: application/vnd.github+json" \
-      "$url"
-    return
-  fi
-
-  curl -fsSL \
-    -H "Accept: application/vnd.github+json" \
-    "$url"
-}
-
 latest_stable_tag() {
   local version
   if ! version="$(download "${CDN_BASE}/stable")"; then
@@ -170,108 +116,12 @@ latest_stable_tag() {
   printf '%s\n' "$version" | tr -d '\r\n'
 }
 
-latest_dev_tag() {
-  if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
-    gh release list --repo "$REPO" --exclude-drafts --limit 50 --json tagName,isPrerelease --jq 'map(select(.isPrerelease))[0].tagName'
-    return
-  fi
-
-  github_api "/releases?per_page=50" | tr -d '\n' | sed 's/[[:space:]]//g' | awk '
-    BEGIN { RS="\\{"; FS="," }
-    {
-      tag=""; prerelease=""; draft=""
-      for (i = 1; i <= NF; i++) {
-        if ($i ~ /"tag_name":"/) {
-          field=$i
-          sub(/.*"tag_name":"/, "", field)
-          sub(/".*/, "", field)
-          tag=field
-        }
-        if ($i ~ /"prerelease":/) {
-          field=$i
-          sub(/.*"prerelease":/, "", field)
-          sub(/[^a-z].*/, "", field)
-          prerelease=field
-        }
-        if ($i ~ /"draft":/) {
-          field=$i
-          sub(/.*"draft":/, "", field)
-          sub(/[^a-z].*/, "", field)
-          draft=field
-        }
-      }
-      if (tag != "" && prerelease == "true" && draft != "true") {
-        print tag
-        exit
-      }
-    }
-  '
-}
-
 resolve_release_tag() {
-  case "$MODE" in
-    stable)
-      latest_stable_tag
-      ;;
-    dev)
-      latest_dev_tag
-      ;;
-    version)
-      printf '%s\n' "$REQUESTED_VERSION"
-      ;;
-  esac
-}
-
-download_with_gh() {
-  local release_tag="$1"
-  local asset_name="$2"
-  local checksums_name="$3"
-
-  if ! command -v gh >/dev/null 2>&1; then
-    return 1
-  fi
-  if ! gh auth token >/dev/null 2>&1; then
-    return 1
-  fi
-
-  if ! gh release download "$release_tag" --repo "$REPO" --pattern "$asset_name" --dir "$TMPDIR" >/dev/null 2>&1; then
-    return 1
-  fi
-  if ! gh release download "$release_tag" --repo "$REPO" --pattern "$checksums_name" --dir "$TMPDIR" >/dev/null 2>&1; then
-    return 1
-  fi
-  if [[ ! -f "${TMPDIR}/${asset_name}" || ! -f "${TMPDIR}/${checksums_name}" ]]; then
-    return 1
-  fi
-  return 0
-}
-
-download_with_curl() {
-  local release_tag="$1"
-  local asset_name="$2"
-  local checksums_name="$3"
-  local token=""
-  local base_url
-
-  if token="$(github_token)"; then
-    :
-  else
-    token=""
-  fi
-
-  base_url="https://github.com/${REPO}/releases/download/${release_tag}"
-  if [[ -n "${HEYGEN_RELEASE_BASE_URL:-}" ]]; then
-    base_url="${HEYGEN_RELEASE_BASE_URL%/}/${release_tag}"
-  fi
-
-  if [[ -n "$token" ]]; then
-    curl -fsSL -H "Authorization: Bearer ${token}" "${base_url}/${asset_name}" -o "${TMPDIR}/${asset_name}"
-    curl -fsSL -H "Authorization: Bearer ${token}" "${base_url}/${checksums_name}" -o "${TMPDIR}/${checksums_name}"
+  if [[ -n "$REQUESTED_VERSION" ]]; then
+    printf '%s\n' "$REQUESTED_VERSION"
     return
   fi
-
-  curl -fsSL "${base_url}/${asset_name}" -o "${TMPDIR}/${asset_name}"
-  curl -fsSL "${base_url}/${checksums_name}" -o "${TMPDIR}/${checksums_name}"
+  latest_stable_tag
 }
 
 download_with_cdn() {
@@ -336,7 +186,7 @@ normalize_arch() {
 }
 
 main() {
-  local os arch release_tag asset_name checksums_name version_output source_desc
+  local os arch release_tag asset_name checksums_name version_output
 
   parse_args "$@"
   os="$(detect_os)"
@@ -349,30 +199,10 @@ main() {
   checksums_name="checksums.txt"
 
   log "Detected: ${os} ${arch}"
-  case "$MODE" in
-    dev)
-      source_desc="${REPO} GitHub release"
-      ;;
-    stable | version)
-      source_desc="${CDN_BASE}"
-      ;;
-  esac
-  log "Installing heygen release tag '${release_tag}' from ${source_desc}"
+  log "Installing heygen release tag '${release_tag}' from ${CDN_BASE}"
 
-  case "$MODE" in
-    dev)
-      if download_with_gh "$release_tag" "$asset_name" "$checksums_name"; then
-        log "Downloaded release assets with gh"
-      else
-        download_with_curl "$release_tag" "$asset_name" "$checksums_name"
-        log "Downloaded release assets with curl"
-      fi
-      ;;
-    stable | version)
-      download_with_cdn "$release_tag" "$asset_name" "$checksums_name"
-      log "Downloaded release assets from CDN"
-      ;;
-  esac
+  download_with_cdn "$release_tag" "$asset_name" "$checksums_name"
+  log "Downloaded release assets from CDN"
 
   verify_checksum "$asset_name" "$checksums_name"
   install_archive "${TMPDIR}/${asset_name}" "$os"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,7 +110,7 @@ latest_stable_tag() {
   if ! version="$(download "${CDN_BASE}/stable")"; then
     fail "failed to resolve latest stable version from ${CDN_BASE}/stable"
   fi
-  printf '%s\n' "$version" | tr -d '\r\n'
+  printf '%s' "$version" | tr -d '\r'
 }
 
 resolve_release_tag() {


### PR DESCRIPTION
## Description

Moves stable installs from GitHub Releases to CloudFront (`static.heygen.ai`). Dev installs are removed from the script (team uses `heygen update` or builds from source).

**Why:** GitHub API rate limits (60 req/hr per IP) can fail installs during traffic bursts. CloudFront has no rate limit and serves from edge. Same pattern as Claude Code. Cost is ~$1.50/month at 1K installs.

**Install script changes:**
- Stable path resolves version from CDN pointer file, downloads binaries from CDN. No GitHub API calls.
- All GitHub-specific code removed (`--dev`, token handling, GitHub API). Script drops from ~400 to ~210 lines.
- Adds wget fallback and Rosetta 2 detection (Apple Silicon).
- `--version` restricted to stable versions only.

**Workflow changes:**
- After GoReleaser, uploads artifacts to S3 in safe order: binaries, then install.sh, then version pointer last.
- Validates `AWS_ROLE_ARN` before tag creation (fail fast).
- Adds `id-token: write` for OIDC.

**Docs:** README and SKILL.md install URLs updated. RELEASE.md documents S3 step.

Tested end-to-end: `curl -fsSL https://static.heygen.ai/cli/install.sh | bash` installs `v0.0.1` from CDN successfully.

## Testing

- `bash -n scripts/install.sh` (syntax check)
- End-to-end CDN install of `v0.0.1` on linux/amd64
- `go test ./...` passes
- Workflow changes are additive (new steps after existing GoReleaser step)