### PR TITLE
cmd: add --request-schema tip to root help footer

### DIFF
--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -77,6 +77,7 @@ Exit Codes:
   3   Authentication error (missing or invalid API key)
   4   Timeout (resource created but operation not yet complete)
 
+Tip: Use --request-schema on any command to see the expected JSON input fields.
 Use "heygen update" to check for and install newer versions.
 `)
 	})


### PR DESCRIPTION
## Description

Adds a one-line tip to the root `heygen --help` footer: "Use --request-schema on any command to see the expected JSON input fields."

The `--request-schema` flag is one of the most useful features for agents using the CLI cold. It's already shown in per-command `--help` and documented in SKILL.md and README, but agents that start with `heygen --help` (root) had no way to discover it without drilling into a specific command first. This makes it visible on first contact.

## Testing

Verified `heygen --help` output includes the new tip line between exit codes and the update hint.