### PR TITLE
ci: fix GoReleaser tag selection in stable release workflow

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -61,3 +61,4 @@ jobs:
           args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.event.inputs.version }}


### PR DESCRIPTION
## Description

Sets `GORELEASER_CURRENT_TAG` to the input version in the stable release workflow. Without this, GoReleaser with `--skip=validate` picks the latest tag by semver, which can be a dev prerelease tag (e.g. `v0.0.1-dev.202604072327`) instead of the stable tag just created (e.g. `v0.0.1`). This caused the first `v0.0.1` release attempt to build artifacts with the dev version name and fail uploading to an existing dev release.

## Testing

The `v0.0.1` release will be re-triggered after this merges to verify the fix.