### PR TITLE
cmd: add force confirmation for destructive actions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -76,5 +76,5 @@ heygen video get --response-schema
 
 - The CLI retries transient errors (429, 5xx) automatically.
 - Use `heygen update` to check for and install a newer CLI release.
-- Video download writes to `{video-id}.mp4` by default. Override with `--output-path`.
+- Video download writes to `{video-id}.mp4` by default. Override with `--output-path`. Errors if the file already exists; use `--force` to overwrite.
 - For the full API reference (concepts, limits, pricing), see https://developers.heygen.com

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -73,6 +73,19 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
+			if spec.Destructive {
+				force, _ := cmd.Flags().GetBool("force")
+				if !force && stdinIsTerminalFunc() {
+					if err := confirmAction(
+						cmd.ErrOrStderr(),
+						cmd.InOrStdin(),
+						fmt.Sprintf("Warning: %s. Continue?", spec.Summary),
+					); err != nil {
+						return err
+					}
+				}
+			}
+
 			// Poll config is looked up at call time, not attached to Spec.
 			// Spec is immutable (generated); poll configs are hand-written in cmd/.
 			pc := pollConfigs[spec.Group+"/"+spec.Name]
@@ -181,6 +194,9 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 	if spec.BodyEncoding == "json" {
 		cmd.Flags().StringVarP(&rawData, "data", "d", "",
 			"JSON request body (inline JSON, file path, or - for stdin). When used with individual flags, flags override matching fields in the JSON.")
+	}
+	if spec.Destructive {
+		cmd.Flags().Bool("force", false, "Skip confirmation prompt for destructive operations")
 	}
 
 	return cmd

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -106,6 +106,19 @@ var videoAgentWaitSpec = &command.Spec{
 	Examples:     []string{"heygen video-agent create --wait"},
 }
 
+var videoDeleteSpec = &command.Spec{
+	Group:       "video",
+	Name:        "delete",
+	Summary:     "Delete a video",
+	Endpoint:    "/v3/videos/{video_id}",
+	Method:      "DELETE",
+	Destructive: true,
+	Args: []command.ArgSpec{
+		{Name: "video-id", Param: "video_id"},
+	},
+	Examples: []string{"heygen video delete <video-id>"},
+}
+
 func TestGenBuilder_VideoList_Success(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
 		"GET /v3/videos": {
@@ -344,6 +357,153 @@ func TestGenBuilder_HelpShowsRequiredAnnotation(t *testing.T) {
 	}
 	if strings.Contains(res.Stdout, "Video orientation (required)") {
 		t.Fatalf("stdout = %s, optional flag should not be marked required", res.Stdout)
+	}
+}
+
+func TestGenBuilder_DestructiveForceSkipsPrompt(t *testing.T) {
+	var deleteCalls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"DELETE /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"vid_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				deleteCalls++
+			},
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", videoDeleteSpec, "delete", "vid_123", "--force")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("deleteCalls = %d, want 1", deleteCalls)
+	}
+	if strings.Contains(res.Stderr, "Continue? [y/N]") {
+		t.Fatalf("stderr = %q, want no prompt", res.Stderr)
+	}
+}
+
+func TestGenBuilder_DestructiveNonTTYSkipsPrompt(t *testing.T) {
+	var deleteCalls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"DELETE /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"vid_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				deleteCalls++
+			},
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", videoDeleteSpec, "delete", "vid_123")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("deleteCalls = %d, want 1", deleteCalls)
+	}
+	if strings.Contains(res.Stderr, "Continue? [y/N]") {
+		t.Fatalf("stderr = %q, want no prompt", res.Stderr)
+	}
+}
+
+func TestGenBuilder_DestructiveTTYYesConfirms(t *testing.T) {
+	orig := stdinIsTerminalFunc
+	stdinIsTerminalFunc = func() bool { return true }
+	t.Cleanup(func() { stdinIsTerminalFunc = orig })
+
+	var deleteCalls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"DELETE /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"vid_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				deleteCalls++
+			},
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommandWithInput(t, srv.URL, "test-key", videoDeleteSpec, strings.NewReader("y\n"), "delete", "vid_123")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("deleteCalls = %d, want 1", deleteCalls)
+	}
+	if !strings.Contains(res.Stderr, "Warning: Delete a video. Continue? [y/N]") {
+		t.Fatalf("stderr = %q, want prompt", res.Stderr)
+	}
+}
+
+func TestGenBuilder_DestructiveTTYNoCancels(t *testing.T) {
+	orig := stdinIsTerminalFunc
+	stdinIsTerminalFunc = func() bool { return true }
+	t.Cleanup(func() { stdinIsTerminalFunc = orig })
+
+	var deleteCalls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"DELETE /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"vid_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				deleteCalls++
+			},
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommandWithInput(t, srv.URL, "test-key", videoDeleteSpec, strings.NewReader("n\n"), "delete", "vid_123")
+
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitGeneral, res.Stderr)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("deleteCalls = %d, want 0", deleteCalls)
+	}
+	if !strings.Contains(res.Stderr, `"code":"canceled"`) {
+		t.Fatalf("stderr = %q, want canceled error code", res.Stderr)
+	}
+}
+
+func TestGenBuilder_DestructiveTTYEmptyCancels(t *testing.T) {
+	orig := stdinIsTerminalFunc
+	stdinIsTerminalFunc = func() bool { return true }
+	t.Cleanup(func() { stdinIsTerminalFunc = orig })
+
+	var deleteCalls int
+	srv := setupTestServer(t, map[string]testHandler{
+		"DELETE /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"id":"vid_123"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				deleteCalls++
+			},
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommandWithInput(t, srv.URL, "test-key", videoDeleteSpec, strings.NewReader("\n"), "delete", "vid_123")
+
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitGeneral, res.Stderr)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("deleteCalls = %d, want 0", deleteCalls)
+	}
+	if !strings.Contains(res.Stderr, `"code":"canceled"`) {
+		t.Fatalf("stderr = %q, want canceled error code", res.Stderr)
 	}
 }
 
@@ -1010,12 +1170,24 @@ func TestGenBuilder_MultipartFileFlag_RoutesToInvocationFilePath(t *testing.T) {
 func runGenCommand(t *testing.T, serverURL, apiKey string, spec *command.Spec, args ...string) cmdResult {
 	t.Helper()
 
-	return runGeneratedRootCommand(t, serverURL, apiKey, map[string][]*command.Spec{
+	return runGenCommandWithInput(t, serverURL, apiKey, spec, nil, args...)
+}
+
+func runGenCommandWithInput(t *testing.T, serverURL, apiKey string, spec *command.Spec, stdin io.Reader, args ...string) cmdResult {
+	t.Helper()
+
+	return runGeneratedRootCommandWithInput(t, serverURL, apiKey, map[string][]*command.Spec{
 		spec.Group: {spec},
-	}, append([]string{spec.Group}, args...)...)
+	}, stdin, append([]string{spec.Group}, args...)...)
 }
 
 func runGeneratedRootCommand(t *testing.T, serverURL, apiKey string, groups map[string][]*command.Spec, args ...string) cmdResult {
+	t.Helper()
+
+	return runGeneratedRootCommandWithInput(t, serverURL, apiKey, groups, nil, args...)
+}
+
+func runGeneratedRootCommandWithInput(t *testing.T, serverURL, apiKey string, groups map[string][]*command.Spec, stdin io.Reader, args ...string) cmdResult {
 	t.Helper()
 
 	var stdout, stderr bytes.Buffer
@@ -1032,6 +1204,9 @@ func runGeneratedRootCommand(t *testing.T, serverURL, apiKey string, groups map[
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
 	root.SetArgs(args)
+	if stdin != nil {
+		root.SetIn(stdin)
+	}
 
 	err := root.Execute()
 

--- a/cmd/heygen/confirm.go
+++ b/cmd/heygen/confirm.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+	"golang.org/x/term"
+)
+
+// stdinIsTerminalFunc checks whether the process stdin is a terminal.
+// Tests override this to exercise the interactive confirmation path.
+var stdinIsTerminalFunc = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+func newCanceledError() *clierrors.CLIError {
+	return &clierrors.CLIError{
+		Code:     "canceled",
+		Message:  "operation canceled",
+		ExitCode: clierrors.ExitGeneral,
+	}
+}
+
+func confirmAction(stderr io.Writer, stdin io.Reader, prompt string) error {
+	_, _ = fmt.Fprintf(stderr, "%s [y/N] ", prompt)
+
+	var answer string
+	_, _ = fmt.Fscanln(stdin, &answer)
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		return newCanceledError()
+	}
+	return nil
+}

--- a/cmd/heygen/confirm_test.go
+++ b/cmd/heygen/confirm_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+)
+
+func TestConfirmAction_Yes(t *testing.T) {
+	var stderr bytes.Buffer
+
+	if err := confirmAction(&stderr, strings.NewReader("y\n"), "Delete this?"); err != nil {
+		t.Fatalf("confirmAction returned error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Delete this? [y/N]") {
+		t.Fatalf("stderr = %q, want prompt", stderr.String())
+	}
+}
+
+func TestConfirmAction_No(t *testing.T) {
+	var stderr bytes.Buffer
+
+	err := confirmAction(&stderr, strings.NewReader("n\n"), "Delete this?")
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Code != "canceled" {
+		t.Fatalf("err = %v, want canceled CLIError", err)
+	}
+}
+
+func TestConfirmAction_EmptyDefaultsNo(t *testing.T) {
+	var stderr bytes.Buffer
+
+	err := confirmAction(&stderr, strings.NewReader("\n"), "Delete this?")
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Code != "canceled" {
+		t.Fatalf("err = %v, want canceled CLIError", err)
+	}
+}

--- a/cmd/heygen/video_download.go
+++ b/cmd/heygen/video_download.go
@@ -32,6 +32,7 @@ var assetTypes = map[string]assetInfo{
 func newVideoDownloadCmd(ctx *cmdContext) *cobra.Command {
 	var outputPath string
 	var asset string
+	var force bool
 
 	cmd := &cobra.Command{
 		Use:   "download <video-id>",
@@ -46,6 +47,33 @@ func newVideoDownloadCmd(ctx *cmdContext) *cobra.Command {
 			if !ok {
 				return clierrors.NewUsage(
 					fmt.Sprintf("invalid --asset value %q: must be one of: video, captioned", asset))
+			}
+
+			dest := outputPath
+			if dest == "" {
+				// Sanitize: strip directory components from video ID to prevent
+				// path traversal. Handles IDs with / or \\ safely.
+				dest = filepath.Base(videoID) + info.ext
+			}
+
+			if !force {
+				if _, err := os.Stat(dest); err == nil {
+					if !stdinIsTerminalFunc() {
+						return &clierrors.CLIError{
+							Code:     "file_exists",
+							Message:  fmt.Sprintf("file %q already exists", dest),
+							Hint:     "Use --force to overwrite, or --output-path to write to a different file",
+							ExitCode: clierrors.ExitGeneral,
+						}
+					}
+					if err := confirmAction(
+						cmd.ErrOrStderr(),
+						cmd.InOrStdin(),
+						fmt.Sprintf("File %q already exists. Overwrite?", dest),
+					); err != nil {
+						return err
+					}
+				}
 			}
 
 			spec := &command.Spec{
@@ -64,13 +92,6 @@ func newVideoDownloadCmd(ctx *cmdContext) *cobra.Command {
 			assetURL, err := extractAssetURL(result, videoID, info)
 			if err != nil {
 				return err
-			}
-
-			dest := outputPath
-			if dest == "" {
-				// Sanitize: strip directory components from video ID to prevent
-				// path traversal. Handles IDs with / or \ safely.
-				dest = filepath.Base(videoID) + info.ext
 			}
 
 			if err := downloadFile(cmd.Context(), assetURL, dest); err != nil {
@@ -92,6 +113,7 @@ func newVideoDownloadCmd(ctx *cmdContext) *cobra.Command {
 
 	cmd.Flags().StringVar(&asset, "asset", "video", "Asset to download: video, captioned")
 	cmd.Flags().StringVar(&outputPath, "output-path", "", "Output file path (default: {video-id}.mp4)")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing files without prompting")
 	return cmd
 }
 

--- a/cmd/heygen/video_download_test.go
+++ b/cmd/heygen/video_download_test.go
@@ -257,6 +257,88 @@ func TestVideoDownload_PreservesExistingFileOnFailure(t *testing.T) {
 	}
 }
 
+func TestVideoDownload_ForceOverwritesExistingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "existing.mp4")
+	if err := os.WriteFile(dest, []byte("original-content"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v3/videos/vid_123":
+			writeJSON(t, w, map[string]any{
+				"data": map[string]any{
+					"video_url": srv.URL + "/download/vid_123.mp4",
+					"status":    "completed",
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/download/vid_123.mp4":
+			_, _ = w.Write([]byte("new-content"))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest, "--force")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "new-content" {
+		t.Fatalf("file contents = %q, want %q", string(data), "new-content")
+	}
+}
+
+func TestVideoDownload_FileExistsNonTTYRequiresForce(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "existing.mp4")
+	if err := os.WriteFile(dest, []byte("original-content"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var videoRequests int
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/videos/vid_123": {
+			StatusCode: 200,
+			Body:       `{"data":{"video_url":"https://example.test/video.mp4","status":"completed"}}`,
+			ValidateRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				videoRequests++
+			},
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest)
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitGeneral, res.Stderr)
+	}
+	if videoRequests != 0 {
+		t.Fatalf("videoRequests = %d, want 0", videoRequests)
+	}
+	if !strings.Contains(res.Stderr, `"code":"file_exists"`) {
+		t.Fatalf("stderr = %q, want file_exists error code", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "--force") {
+		t.Fatalf("stderr = %q, want --force hint", res.Stderr)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "original-content" {
+		t.Fatalf("file contents = %q, want %q", string(data), "original-content")
+	}
+}
+
 func TestVideoDownload_VideoNotFound(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
 		"GET /v3/videos/vid_missing": {

--- a/codegen/grouper.go
+++ b/codegen/grouper.go
@@ -171,6 +171,7 @@ func buildSpec(
 	// Pagination — only sets Paginated bool. The cursor field names and data
 	// field are API conventions hardcoded in the client package.
 	spec.Paginated = detectPagination(op, pathItem)
+	spec.Destructive = method == "DELETE"
 
 	// Flags from query params
 	for _, paramRef := range collectParams(pathItem, op) {

--- a/codegen/templates/command.go.tmpl
+++ b/codegen/templates/command.go.tmpl
@@ -23,6 +23,9 @@ var {{pascalCase .Group}}{{pascalCase .Name}} = &command.Spec{
 {{- if .Paginated}}
 	Paginated:   true,
 {{- end}}
+{{- if .Destructive}}
+	Destructive: true,
+{{- end}}
 {{- if .Examples}}
 	Examples: []string{
 {{- range .Examples}}

--- a/codegen/testdata/golden/widget.go
+++ b/codegen/testdata/golden/widget.go
@@ -116,6 +116,7 @@ var WidgetDelete = &command.Spec{
 	Endpoint:       "/v3/widgets/{widget_id}",
 	Method:         "DELETE",
 	BodyEncoding:   "",
+	Destructive:    true,
 	Args: []command.ArgSpec{
 		{Name: "widget-id", Param: "widget_id", Help: ""},
 	},

--- a/gen/lipsync.go
+++ b/gen/lipsync.go
@@ -198,6 +198,7 @@ var LipsyncDelete = &command.Spec{
 	Endpoint:       "/v3/lipsyncs/{lipsync_id}",
 	Method:         "DELETE",
 	BodyEncoding:   "",
+	Destructive:    true,
 	Examples: []string{
 		"heygen lipsync delete <lipsync-id>",
 	},

--- a/gen/video-translate.go
+++ b/gen/video-translate.go
@@ -302,6 +302,7 @@ var VideoTranslateDelete = &command.Spec{
 	Endpoint:       "/v3/video-translations/{video_translation_id}",
 	Method:         "DELETE",
 	BodyEncoding:   "",
+	Destructive:    true,
 	Examples: []string{
 		"heygen video-translate delete <video-translation-id>",
 	},

--- a/gen/video.go
+++ b/gen/video.go
@@ -29,6 +29,7 @@ var VideoDelete = &command.Spec{
 	Endpoint:       "/v3/videos/{video_id}",
 	Method:         "DELETE",
 	BodyEncoding:   "",
+	Destructive:    true,
 	Examples: []string{
 		"heygen video delete <video-id>",
 	},

--- a/gen/webhook.go
+++ b/gen/webhook.go
@@ -66,6 +66,7 @@ var WebhookEndpointsDelete = &command.Spec{
 	Endpoint:       "/v3/webhooks/endpoints/{endpoint_id}",
 	Method:         "DELETE",
 	BodyEncoding:   "",
+	Destructive:    true,
 	Examples: []string{
 		"heygen webhook endpoints delete <endpoint-id>",
 	},

--- a/internal/command/spec.go
+++ b/internal/command/spec.go
@@ -60,7 +60,7 @@ type Spec struct {
 	// Execution behavior (used by executor)
 	Paginated   bool        // true → command supports cursor pagination via API query flags like --token/--limit
 	PollConfig  *PollConfig // non-nil → pollable; defines polling behavior for --wait
-	Destructive bool        // triggers --force confirmation prompt (not yet implemented)
+	Destructive bool        // true → command registers --force and prompts before destructive execution
 	Columns     []Column    // TUI table column definitions for --human output
 }
 


### PR DESCRIPTION
## Description

Add interactive confirmation prompts for destructive CLI operations, with a `--force` flag to bypass them.

**TTY detection:** The CLI checks whether stdin is a terminal using `term.IsTerminal(os.Stdin.Fd())`, the same POSIX `isatty()` mechanism used by gh, kubectl, and docker. This reliably answers "can someone respond to a prompt?" -- interactive terminals return true, while piped input, CI runners, and agent tool execution (e.g., Claude Code's Bash tool) return false. It's not a human-vs-agent check, but a "is interactive input possible?" check, which is the right question for confirmation prompts.

**Destructive commands** (all DELETE endpoints: video, lipsync, video-translate, webhook endpoints):
- TTY terminal: prompts `Warning: <summary>. Continue? [y/N]` on stderr. Default deny.
- Non-TTY (agents, CI, scripts): auto-proceeds with no prompt. Agents never see friction.
- `--force` flag: skips the TTY prompt.

**Video download** (file overwrite):
- File doesn't exist: proceeds normally.
- File exists + non-TTY: errors with `file_exists` code and hint to use `--force` or `--output-path`. No wasted API call (file check happens before fetching video metadata).
- File exists + TTY: prompts `File "<path>" already exists. Overwrite? [y/N]`.
- `--force`: overwrites silently.

**Implementation:**
- Codegen auto-sets `Destructive: true` for all DELETE methods in `grouper.go`. No hand-written overrides.
- Shared `confirmAction` helper in `confirm.go` used by both the builder and video download. `stdinIsTerminalFunc` is the test seam (injectable, checks `os.Stdin.Fd()` directly since Cobra's `cmd.InOrStdin()` returns `io.Reader`, not `*os.File`).
- Cancel returns `CLIError{Code: "canceled"}` with exit code 1.

## Testing

- 3 unit tests for `confirmAction` (yes/no/empty-defaults-no)
- 5 integration tests for destructive commands: `--force` skips prompt, non-TTY skips prompt, TTY+y confirms, TTY+n cancels with `code:"canceled"`, TTY+empty cancels
- 2 download tests: `--force` overwrites existing file, non-TTY errors with `file_exists` and `--force` hint
- Golden test updated for DELETE widget spec
- All CI checks pass (Linux/macOS/Windows, lint, goreleaser)