### PR TITLE
fix: require --force for destructive operations in non-TTY environments

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -75,7 +75,15 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 
 			if spec.Destructive {
 				force, _ := cmd.Flags().GetBool("force")
-				if !force && stdinIsTerminalFunc() {
+				if !force {
+					if !stdinIsTerminalFunc() {
+						return &clierrors.CLIError{
+							Code:     "confirmation_required",
+							Message:  fmt.Sprintf("destructive operation %q requires confirmation", spec.Name),
+							Hint:     "Use --force to skip confirmation in non-interactive environments",
+							ExitCode: clierrors.ExitGeneral,
+						}
+					}
 					if err := confirmAction(
 						cmd.ErrOrStderr(),
 						cmd.InOrStdin(),

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -387,30 +387,25 @@ func TestGenBuilder_DestructiveForceSkipsPrompt(t *testing.T) {
 	}
 }
 
-func TestGenBuilder_DestructiveNonTTYSkipsPrompt(t *testing.T) {
-	var deleteCalls int
+func TestGenBuilder_DestructiveNonTTYRequiresForce(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
 		"DELETE /v3/videos/vid_123": {
 			StatusCode: 200,
 			Body:       `{"data":{"id":"vid_123"}}`,
-			ValidateRequest: func(t *testing.T, r *http.Request) {
-				t.Helper()
-				deleteCalls++
-			},
 		},
 	})
 	defer srv.Close()
 
 	res := runGenCommand(t, srv.URL, "test-key", videoDeleteSpec, "delete", "vid_123")
 
-	if res.ExitCode != 0 {
-		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	if res.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if deleteCalls != 1 {
-		t.Fatalf("deleteCalls = %d, want 1", deleteCalls)
+	if !strings.Contains(res.Stderr, "confirmation_required") {
+		t.Fatalf("stderr = %q, want confirmation_required error", res.Stderr)
 	}
-	if strings.Contains(res.Stderr, "Continue? [y/N]") {
-		t.Fatalf("stderr = %q, want no prompt", res.Stderr)
+	if !strings.Contains(res.Stderr, "--force") {
+		t.Fatalf("stderr = %q, want --force hint", res.Stderr)
 	}
 }
 


### PR DESCRIPTION
## Description

Destructive commands (delete) now refuse to proceed in non-TTY environments unless `--force` is set. Previously, running `echo "n" | heygen video delete <id>` would silently delete the video because the non-TTY path skipped confirmation entirely.

Now in non-TTY mode without `--force`, the command fails with:
```json
{"error":{"code":"confirmation_required","message":"destructive operation \"delete\" requires confirmation","hint":"Use --force to skip confirmation in non-interactive environments"}}
```

This matches the existing pattern in `video_download.go` where file overwrite in non-TTY mode requires `--force`.

## Testing

- `TestGenBuilder_DestructiveNonTTYRequiresForce`: verifies exit 1 with confirmation_required error
- `TestGenBuilder_DestructiveForceSkipsPrompt`: verifies --force still works
- `TestGenBuilder_DestructiveTTYYesConfirms`: verifies TTY prompt still works
- All existing destructive operation tests pass