### PR TITLE
fix: respect HEYGEN_OUTPUT env/config and fix timeout exit code

### DIFF
--- a/cmd/heygen/config_cmd_test.go
+++ b/cmd/heygen/config_cmd_test.go
@@ -76,7 +76,9 @@ func TestConfigGet_FromEnv(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 	t.Setenv("HEYGEN_OUTPUT", "human")
 
-	res := runCommand(t, "http://example.invalid", "", "config", "get", "output")
+	// Use --human=false to get JSON output, since HEYGEN_OUTPUT=human
+	// would otherwise switch the formatter to human mode.
+	res := runCommand(t, "http://example.invalid", "", "config", "get", "output", "--human=false")
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
@@ -96,7 +98,9 @@ func TestConfigGet_FromFile(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	res := runCommand(t, "http://example.invalid", "", "config", "get", "output")
+	// Use --human=false to get JSON output, since the config file sets
+	// output=human which would otherwise switch the formatter.
+	res := runCommand(t, "http://example.invalid", "", "config", "get", "output", "--human=false")
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}

--- a/cmd/heygen/formatter_select.go
+++ b/cmd/heygen/formatter_select.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"io"
+	"os"
 	"strconv"
 	"strings"
 
+	"github.com/heygen-com/heygen-cli/internal/config"
 	"github.com/heygen-com/heygen-cli/internal/output"
 )
 
@@ -16,9 +18,10 @@ func formatterForArgs(args []string, out, errOut io.Writer) output.Formatter {
 }
 
 func wantsHumanOutput(args []string) bool {
+	// 1. --human flag takes highest priority (both --human and --human=false)
 	for _, arg := range args {
 		if arg == "--" {
-			return false
+			break
 		}
 		if arg == "--human" {
 			return true
@@ -26,8 +29,24 @@ func wantsHumanOutput(args []string) bool {
 		if strings.HasPrefix(arg, "--human=") {
 			value := strings.TrimPrefix(arg, "--human=")
 			enabled, err := strconv.ParseBool(value)
-			return err == nil && enabled
+			// Explicit --human=true/false overrides env and config
+			if err == nil {
+				return enabled
+			}
 		}
 	}
+
+	// 2. HEYGEN_OUTPUT env var
+	if envVal := os.Getenv("HEYGEN_OUTPUT"); envVal != "" {
+		return strings.EqualFold(envVal, "human")
+	}
+
+	// 3. config file (config set output human)
+	fp := &config.FileProvider{}
+	val, found, err := fp.Get(config.KeyOutput)
+	if err == nil && found {
+		return strings.EqualFold(val, "human")
+	}
+
 	return false
 }

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -421,8 +421,9 @@ func extractJSONPath(raw json.RawMessage, path string) (string, error) {
 }
 
 // translateCreateContextError converts timeout/cancel errors before a resource
-// ID is known into user-friendly CLIErrors. At this stage the client cannot
-// confirm whether creation succeeded, so exit code stays general.
+// ID is known into user-friendly CLIErrors. Deadline exceeded returns exit 4
+// (timeout) since the operation may have been created server-side. Cancel
+// returns exit 1 (general) since the user explicitly interrupted.
 func translateCreateContextError(ctx context.Context, err error) error {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return newCreateContextError(ctxErr)

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -452,7 +452,7 @@ func newCreateContextError(err error) error {
 			Code:     "timeout",
 			Message:  "polling timed out before the operation completed",
 			Hint:     "Re-run the corresponding get command to check the current status manually",
-			ExitCode: clierrors.ExitGeneral,
+			ExitCode: clierrors.ExitTimeout,
 		}
 	case errors.Is(err, context.Canceled):
 		return &clierrors.CLIError{

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -625,6 +625,38 @@ func TestExecuteAndPoll_TimeoutDuringRequest(t *testing.T) {
 	}
 }
 
+func TestExecuteAndPoll_TimeoutDuringCreate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block the create request until context expires
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	c := New("key", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithMaxRetries(0))
+
+	_, err := c.ExecuteAndPoll(ctx, pollableVideoCreateSpec(), emptyInvocation(), PollOptions{
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var cliErr *clierrors.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *CLIError, got %T: %v", err, err)
+	}
+	if cliErr.Code != "timeout" {
+		t.Fatalf("code = %q, want timeout", cliErr.Code)
+	}
+	if cliErr.ExitCode != clierrors.ExitTimeout {
+		t.Fatalf("ExitCode = %d, want %d (ExitTimeout)", cliErr.ExitCode, clierrors.ExitTimeout)
+	}
+}
+
 func TestExecuteAndPoll_Cancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Description

Two fixes from QA testing:

**1. HEYGEN_OUTPUT env var and config ignored (Medium)**
`formatterForArgs` only checked the `--human` flag. Now it also checks `HEYGEN_OUTPUT` env var and `config set output human`, matching the precedence documented in `--help`: flag > env > config > default. `--human=false` explicitly overrides env/config.

**2. Timeout during initial POST returns exit 1 instead of 4 (Low)**
When `--timeout` is shorter than the initial create request (e.g., `--timeout 1s`), the context deadline fires during the POST, hitting `newCreateContextError` which returned `ExitGeneral` (1) instead of `ExitTimeout` (4). Fixed to return exit 4 consistently for all timeout scenarios.

## Testing

- `HEYGEN_OUTPUT=human heygen video list` now produces table output
- `--human=false` overrides env/config back to JSON
- Config tests updated to use `--human=false` when testing output=human config values
- All existing tests pass