### PR TITLE
fix: block HTTP base URL by default

### DIFF
--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -1190,6 +1190,7 @@ func runGeneratedRootCommandWithInput(t *testing.T, serverURL, apiKey string, gr
 
 	t.Setenv("HEYGEN_API_KEY", apiKey)
 	t.Setenv("HEYGEN_API_BASE", serverURL)
+	t.Setenv("HEYGEN_ALLOW_HTTP", "1")
 	t.Setenv("HEYGEN_NO_ANALYTICS", "1")
 	if _, ok := os.LookupEnv("HEYGEN_CONFIG_DIR"); !ok {
 		t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())

--- a/cmd/heygen/context.go
+++ b/cmd/heygen/context.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"net/url"
+	"os"
+
 	"github.com/heygen-com/heygen-cli/internal/auth"
 	"github.com/heygen-com/heygen-cli/internal/client"
 	"github.com/heygen-com/heygen-cli/internal/config"
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 	"github.com/heygen-com/heygen-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -69,8 +73,13 @@ func initContext(cmd *cobra.Command, version string, ctx *cmdContext) error {
 		return err
 	}
 
+	baseURL := provider.BaseURL()
+	if u, err := url.Parse(baseURL); err == nil && u.Scheme == "http" && os.Getenv("HEYGEN_ALLOW_HTTP") == "" {
+		return clierrors.NewUsage("HEYGEN_API_BASE uses HTTP which transmits API keys in plaintext. Set HEYGEN_ALLOW_HTTP=1 to allow.")
+	}
+
 	ctx.client = client.New(apiKey,
-		client.WithBaseURL(provider.BaseURL()),
+		client.WithBaseURL(baseURL),
 		client.WithUserAgent("heygen-cli/"+version),
 	)
 

--- a/cmd/heygen/testutil_test.go
+++ b/cmd/heygen/testutil_test.go
@@ -84,6 +84,7 @@ func runCommandWithInput(t *testing.T, serverURL, apiKey string, stdin io.Reader
 		t.Setenv("HEYGEN_API_KEY", apiKey)
 	}
 	t.Setenv("HEYGEN_API_BASE", serverURL)
+	t.Setenv("HEYGEN_ALLOW_HTTP", "1")
 	t.Setenv("HEYGEN_NO_ANALYTICS", "1")
 	if _, ok := os.LookupEnv("HEYGEN_CONFIG_DIR"); !ok {
 		t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())


### PR DESCRIPTION
## Description

Blocks `HEYGEN_API_BASE` with `http://` scheme by default. API keys sent over HTTP are transmitted in plaintext, which is a security risk. Set `HEYGEN_ALLOW_HTTP=1` to override (for local dev/testing only).

The check runs in `initContext` before the client is created, so no HTTP request is ever made.

## Testing

- `HEYGEN_API_BASE=http://... heygen video list` returns exit 2 with clear error
- `HEYGEN_API_BASE=http://... HEYGEN_ALLOW_HTTP=1 heygen video list` proceeds normally
- `HEYGEN_API_BASE=https://...` is unaffected
- All existing tests pass (test helpers set `HEYGEN_ALLOW_HTTP=1` since they use `httptest.Server`)