### PR TITLE
analytics: add error_code to COMMAND_RUN_COMPLETE

### DIFF
--- a/cmd/heygen/main.go
+++ b/cmd/heygen/main.go
@@ -25,22 +25,29 @@ func main() {
 	executedCmd, err := cmd.ExecuteC()
 
 	exitCode := 0
+	errorCode := ""
 	if err != nil {
 		var cliErr *clierrors.CLIError
 		if errors.As(err, &cliErr) {
 			formatter.Error(cliErr)
 			exitCode = cliErr.ExitCode
+			errorCode = cliErr.Code
 		} else {
 			// Cobra returns plain errors for unknown commands and arg validation.
 			// Detect these and wrap as usage errors (exit 2).
 			wrapped := classifyError(err)
 			formatter.Error(wrapped)
 			exitCode = wrapped.ExitCode
+			errorCode = wrapped.Code
 		}
 	}
 
 	if analyticsClient.Started() && executedCmd != nil {
-		analyticsClient.CommandRunComplete(executedCmd.CommandPath(), exitCode, time.Since(start))
+		isAPICall := executedCmd != nil && !skipAuth(executedCmd) && !isSchemaRequest(executedCmd)
+		analyticsClient.CommandRunComplete(executedCmd.CommandPath(), exitCode, time.Since(start), analytics.CommandRunCompleteOpts{
+			ErrorCode: errorCode,
+			APICall:   isAPICall,
+		})
 	}
 	analyticsClient.Close()
 	os.Exit(exitCode)

--- a/cmd/heygen/main.go
+++ b/cmd/heygen/main.go
@@ -43,11 +43,7 @@ func main() {
 	}
 
 	if analyticsClient.Started() && executedCmd != nil {
-		isAPICall := executedCmd != nil && !skipAuth(executedCmd) && !isSchemaRequest(executedCmd)
-		analyticsClient.CommandRunComplete(executedCmd.CommandPath(), exitCode, time.Since(start), analytics.CommandRunCompleteOpts{
-			ErrorCode: errorCode,
-			APICall:   isAPICall,
-		})
+		analyticsClient.CommandRunComplete(executedCmd.CommandPath(), exitCode, time.Since(start), errorCode)
 	}
 	analyticsClient.Close()
 	os.Exit(exitCode)

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -71,13 +71,7 @@ func (c *Client) CommandRun(command string) {
 	})
 }
 
-// CommandRunCompleteOpts holds optional properties for COMMAND_RUN_COMPLETE.
-type CommandRunCompleteOpts struct {
-	ErrorCode string // structured error code from CLIError.Code (empty on success)
-	APICall   bool   // true if the command made a HeyGen API call
-}
-
-func (c *Client) CommandRunComplete(command string, exitCode int, duration time.Duration, opts CommandRunCompleteOpts) {
+func (c *Client) CommandRunComplete(command string, exitCode int, duration time.Duration, errorCode string) {
 	if !c.enabled || c.ph == nil {
 		return
 	}
@@ -92,8 +86,7 @@ func (c *Client) CommandRunComplete(command string, exitCode int, duration time.
 			Set("exit_code", exitCode).
 			Set("duration_ms", duration.Milliseconds()).
 			Set("success", exitCode == 0).
-			Set("error_code", opts.ErrorCode).
-			Set("api_call", opts.APICall),
+			Set("error_code", errorCode),
 	})
 }
 

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -71,7 +71,13 @@ func (c *Client) CommandRun(command string) {
 	})
 }
 
-func (c *Client) CommandRunComplete(command string, exitCode int, duration time.Duration) {
+// CommandRunCompleteOpts holds optional properties for COMMAND_RUN_COMPLETE.
+type CommandRunCompleteOpts struct {
+	ErrorCode string // structured error code from CLIError.Code (empty on success)
+	APICall   bool   // true if the command made a HeyGen API call
+}
+
+func (c *Client) CommandRunComplete(command string, exitCode int, duration time.Duration, opts CommandRunCompleteOpts) {
 	if !c.enabled || c.ph == nil {
 		return
 	}
@@ -85,7 +91,9 @@ func (c *Client) CommandRunComplete(command string, exitCode int, duration time.
 			Set("arch", runtime.GOARCH).
 			Set("exit_code", exitCode).
 			Set("duration_ms", duration.Milliseconds()).
-			Set("success", exitCode == 0),
+			Set("success", exitCode == 0).
+			Set("error_code", opts.ErrorCode).
+			Set("api_call", opts.APICall),
 	})
 }
 

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -59,7 +59,10 @@ func TestCommandRunComplete_Properties(t *testing.T) {
 	client := newWithCapture("v1.2.3", stub)
 	client.distinctID = "anon-id"
 
-	client.CommandRunComplete("heygen video create", 4, 1500*time.Millisecond)
+	client.CommandRunComplete("heygen video create", 4, 1500*time.Millisecond, CommandRunCompleteOpts{
+		ErrorCode: "timeout",
+		APICall:   true,
+	})
 
 	if len(stub.messages) != 1 {
 		t.Fatalf("messages = %d, want 1", len(stub.messages))
@@ -83,6 +86,12 @@ func TestCommandRunComplete_Properties(t *testing.T) {
 	}
 	if got := msg.Properties["success"]; got != false {
 		t.Fatalf("success = %v, want false", got)
+	}
+	if got := msg.Properties["error_code"]; got != "timeout" {
+		t.Fatalf("error_code = %v, want %q", got, "timeout")
+	}
+	if got := msg.Properties["api_call"]; got != true {
+		t.Fatalf("api_call = %v, want true", got)
 	}
 }
 

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -59,10 +59,7 @@ func TestCommandRunComplete_Properties(t *testing.T) {
 	client := newWithCapture("v1.2.3", stub)
 	client.distinctID = "anon-id"
 
-	client.CommandRunComplete("heygen video create", 4, 1500*time.Millisecond, CommandRunCompleteOpts{
-		ErrorCode: "timeout",
-		APICall:   true,
-	})
+	client.CommandRunComplete("heygen video create", 4, 1500*time.Millisecond, "timeout")
 
 	if len(stub.messages) != 1 {
 		t.Fatalf("messages = %d, want 1", len(stub.messages))
@@ -89,9 +86,6 @@ func TestCommandRunComplete_Properties(t *testing.T) {
 	}
 	if got := msg.Properties["error_code"]; got != "timeout" {
 		t.Fatalf("error_code = %v, want %q", got, "timeout")
-	}
-	if got := msg.Properties["api_call"]; got != true {
-		t.Fatalf("api_call = %v, want true", got)
 	}
 }
 


### PR DESCRIPTION
## Description

Adds `error_code` property to the `COMMAND_RUN_COMPLETE` PostHog event. This is the structured error code from `CLIError.Code` (e.g., `"timeout"`, `"auth_required"`, `"confirmation_required"`). Empty string on success.

Previously we only had `exit_code` (0-4) which groups all failures of the same type together. With `error_code`, we can distinguish "5 timeouts, 3 auth errors, 1 usage error" instead of just "9 failures with exit code 1".

## Testing

- Updated `TestCommandRunComplete_Properties` to verify `error_code` property
- All tests pass