### PR TITLE
docs: fix stale source code references after video-agent restructure

### DIFF
--- a/.github/GIT_CONVENTIONS.md
+++ b/.github/GIT_CONVENTIONS.md
@@ -25,7 +25,7 @@ output: add TUI table formatter
 
 # Cross-cutting (multiple packages)
 add --wait polling with status tracking
-add pagination with --all flag
+add --force confirmation for destructive commands
 
 # Infrastructure
 ci: add golangci-lint

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -211,7 +211,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 }
 
 // commandPathParts splits a generated command path into nested Cobra tokens.
-// Example: "sessions messages create" -> ["sessions", "messages", "create"].
+// Example: "proofreads srt update" -> ["proofreads", "srt", "update"].
 func commandPathParts(spec *command.Spec) []string {
 	return strings.Fields(spec.Name)
 }

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -1037,9 +1037,9 @@ func TestGenBuilder_DeepNestedCommand_Executes(t *testing.T) {
 	var gotBody map[string]any
 
 	srv := setupTestServer(t, map[string]testHandler{
-		"POST /v3/video-agents/sessions/sess_123/messages": {
+		"PUT /v3/video-translations/proofreads/pr_123/srt": {
 			StatusCode: 200,
-			Body:       `{"data":{"id":"msg_123"}}`,
+			Body:       `{"data":{"id":"pr_123"}}`,
 			ValidateRequest: func(t *testing.T, r *http.Request) {
 				t.Helper()
 				body, _ := io.ReadAll(r.Body)
@@ -1050,29 +1050,29 @@ func TestGenBuilder_DeepNestedCommand_Executes(t *testing.T) {
 	defer srv.Close()
 
 	spec := &command.Spec{
-		Group:        "video-agent",
-		Name:         "sessions messages create",
-		Summary:      "Create a session message",
-		Endpoint:     "/v3/video-agents/sessions/{session_id}/messages",
-		Method:       "POST",
+		Group:        "video-translate",
+		Name:         "proofreads srt update",
+		Summary:      "Upload proofread SRT",
+		Endpoint:     "/v3/video-translations/proofreads/{proofread_id}/srt",
+		Method:       "PUT",
 		BodyEncoding: "json",
 		Args: []command.ArgSpec{
-			{Name: "session-id", Param: "session_id"},
+			{Name: "proofread-id", Param: "proofread_id"},
 		},
 		Flags: []command.FlagSpec{
-			{Name: "message", Type: "string", Source: "body", JSONName: "message", Required: true},
+			{Name: "content", Type: "string", Source: "body", JSONName: "content", Required: true},
 		},
-		Examples: []string{"heygen video-agent sessions messages create <session-id> --message 'Add intro'"},
+		Examples: []string{"heygen video-translate proofreads srt update <proofread-id> --content 'SRT data'"},
 	}
 
-	res := runGenCommand(t, srv.URL, "test-key", spec, "sessions", "messages", "create",
-		"sess_123", "--message", "Add intro")
+	res := runGenCommand(t, srv.URL, "test-key", spec, "proofreads", "srt", "update",
+		"pr_123", "--content", "SRT data")
 
 	if res.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if gotBody["message"] != "Add intro" {
-		t.Errorf("body.message = %v, want %q", gotBody["message"], "Add intro")
+	if gotBody["content"] != "SRT data" {
+		t.Errorf("body.content = %v, want %q", gotBody["content"], "SRT data")
 	}
 }
 

--- a/codegen/grouper.go
+++ b/codegen/grouper.go
@@ -47,12 +47,12 @@ import (
 //
 // Edge case — nested sub-resource with action:
 //
-//	POST /v3/video-agents/sessions/{session_id}/stop  [x-cli-action: true]
-//	  → group: "video-agent" (from tag "Video Agent")
-//	  → remaining segments: [sessions, {session_id}, stop]
-//	  → sessions → sub-group, {session_id} → arg, stop → sub-group
+//	POST /v3/webhooks/endpoints/{endpoint_id}/rotate-secret  [x-cli-action: true]
+//	  → group: "webhook" (from tag "Webhooks")
+//	  → remaining segments: [endpoints, {endpoint_id}, rotate-secret]
+//	  → endpoints → sub-group, {endpoint_id} → arg, rotate-secret → literal
 //	  → x-cli-action: true → no terminal verb appended
-//	  → result: heygen video-agent sessions stop <session-id>
+//	  → result: heygen webhook endpoints rotate-secret <endpoint-id>
 //
 // GroupDescriptions maps group name → description from the OpenAPI tag.
 // Used by the builder for group command help text.


### PR DESCRIPTION
## Description

PR #80 restructured the video-agent sessions API (flattened `sessions` sub-group), but several source code comments and a test still referenced the old command structure. This fixes all stale references:

- `codegen/grouper.go`: Comment example updated from stale `video-agent sessions stop` to current `webhook endpoints rotate-secret` (a real nested action endpoint)
- `cmd/heygen/builder.go`: Comment example updated from `sessions messages create` to `proofreads srt update`
- `cmd/heygen/builder_test.go`: Deep-nested command test updated from phantom `sessions messages create` to real `video-translate proofreads srt update`
- `.github/GIT_CONVENTIONS.md`: Example commit changed from `--all flag` (intentionally never built) to `--force confirmation`

## Testing

`make test` passes. The updated test (`TestGenBuilder_DeepNestedCommand_Executes`) verifies the builder handles 3-level nested command names with a real current endpoint.