### PR TITLE
docs: update CONTRIBUTING.md layout, simplify CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ make generate SPEC=path/to/spec.json  # regenerate gen/ from OpenAPI spec
 Smoke test against real API: `HEYGEN_API_KEY=<key> ./bin/heygen video list --limit 2`
 
 For project layout and development guide, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+For branch names, commit messages, and PR titles, see [.github/GIT_CONVENTIONS.md](.github/GIT_CONVENTIONS.md).
 
 ## Key Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,3 @@
 # HeyGen CLI
 
 @AGENTS.md
-
-## Git Conventions
-
-See @.github/GIT_CONVENTIONS.md for branch names, commit messages, PR titles, and PR descriptions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ HEYGEN_API_KEY=<key> ./bin/heygen video list --limit 2
 
 ```
 cmd/heygen/        Cobra commands, hand-written enhancements, entry point
+internal/analytics/ PostHog usage tracking (opt-out)
 internal/auth/     Credential resolution (env var → file)
 internal/client/   HTTP client, executor, retry logic
 internal/command/  Spec, Invocation, Groups, Column types


### PR DESCRIPTION
## Description

Two small doc cleanups:

1. Added `internal/analytics/` to CONTRIBUTING.md's project layout (package added in PR #52, never documented).
2. Removed redundant git conventions reference from CLAUDE.md. AGENTS.md (imported via `@AGENTS.md`) already covers all agent instructions. Git conventions are discoverable from `.github/GIT_CONVENTIONS.md` when needed.

CONTRIBUTING.md is now the single source of truth for project layout after PR #84 removed the duplicated layouts from AGENTS.md and CLAUDE.md.

## Testing

No code changes.