### PR TITLE
security: upgrade to Go 1.25, add govulncheck + gosec to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    allow:
-      - dependency-type: direct
-    # Only open PRs for security updates, not every minor/patch bump.
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-    commit-message:
-      prefix: "deps"
+  # GitHub Actions version updates only.
+  # Go module security updates are handled by Dependabot security updates
+  # (enabled in repo settings), not version updates here.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: direct
+    # Only open PRs for security updates, not every minor/patch bump.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
     commit-message:
       prefix: "deps"
   - package-ecosystem: github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
         with:
           go-version: "1.25"
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.11.4
 
   pr-template:
     if: github.event_name == 'pull_request'
@@ -83,7 +83,7 @@ jobs:
           go-version: "1.25"
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - name: Build
         run: make build
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - uses: golangci/golangci-lint-action@v6
         with:
@@ -73,6 +73,21 @@ jobs:
       - name: Run gitleaks
         run: gitleaks detect --source . --redact=10 --verbose
 
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
   goreleaser-check:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -83,7 +98,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - name: Run tests
         run: make test

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - name: Validate version
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
+/heygen
 *.exe

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+linters:
+  enable:
+    - gosec
+
+linters-settings:
+  gosec:
+    excludes:
+      # Env var name constants containing "KEY"/"TOKEN", not actual secrets.
+      - G101
+      # Standard term.IsTerminal(int(f.Fd())) idiom; uintptr -> int won't overflow.
+      - G115
+      # CLI reads user-provided file paths by design.
+      - G304
+      # Codegen writes 0755 dirs and 0644 source files; standard for generated code.
+      - G301
+      - G306

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,44 @@
+version: "2"
+
 linters:
   enable:
     - gosec
 
-linters-settings:
-  gosec:
-    excludes:
-      # Env var name constants containing "KEY"/"TOKEN", not actual secrets.
-      - G101
-      # Standard term.IsTerminal(int(f.Fd())) idiom; uintptr -> int won't overflow.
-      - G115
-      # CLI reads user-provided file paths by design.
-      - G304
-      # Codegen writes 0755 dirs and 0644 source files; standard for generated code.
-      - G301
-      - G306
+  settings:
+    gosec:
+      excludes:
+        # Env var name constants containing "KEY"/"TOKEN", not actual secrets.
+        - G101
+        # Standard term.IsTerminal(int(f.Fd())) idiom; uintptr -> int won't overflow.
+        - G115
+        # CLI reads user-provided file paths by design.
+        - G304
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Exclude gosec from test files: test code uses env-controlled paths
+      # and relaxed file permissions for fixture setup.
+      - linters: [gosec]
+        path: _test\.go$
+      # QF rules are optional style suggestions, not bugs.
+      # Not enforced in v1; keep them advisory.
+      - linters: [staticcheck]
+        text: "^QF"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,23 +22,15 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      # Exclude gosec from test files: test code uses env-controlled paths
-      # and relaxed file permissions for fixture setup.
+      # Test code uses env-controlled paths and relaxed file permissions
+      # for fixture setup; gosec rules don't apply.
       - linters: [gosec]
         path: _test\.go$
-      # QF rules are optional style suggestions, not bugs.
-      # Not enforced in v1; keep them advisory.
+      # QF rules are optional style refactors (e.g., De Morgan's law),
+      # not bugs. Pre-existing in test code; not worth enforcing.
       - linters: [staticcheck]
         text: "^QF"
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 
 formatters:
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -33,7 +33,7 @@ import (
 // All output is gofmt'd. Variable names are PascalCase derived from
 // group + command name via strcase.ToCamel.
 func Generate(groups command.Groups, descriptions GroupDescriptions, tmplDir, outDir string) error {
-	if err := os.MkdirAll(outDir, 0755); err != nil {
+	if err := os.MkdirAll(outDir, 0755); err != nil { //nolint:gosec // G301: generated source directory, 0755 is standard
 		return fmt.Errorf("creating output directory: %w", err)
 	}
 
@@ -101,11 +101,11 @@ func writeFromTemplate(tmpl *template.Template, data interface{}, filename strin
 	formatted, err := format.Source(buf.Bytes())
 	if err != nil {
 		// Write unformatted for debugging
-		_ = os.WriteFile(filename+".raw", buf.Bytes(), 0644)
+		_ = os.WriteFile(filename+".raw", buf.Bytes(), 0644) //nolint:gosec // G306: debug output for generated code
 		return fmt.Errorf("gofmt %s: %w (raw output written to %s.raw)", filename, err, filename)
 	}
 
-	return os.WriteFile(filename, formatted, 0644)
+	return os.WriteFile(filename, formatted, 0644) //nolint:gosec // G306: generated Go source files, 0644 is standard
 }
 
 // Template helper functions

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heygen-com/heygen-cli
 
-go 1.23.8
+go 1.25.9
 
 require (
 	github.com/getkin/kin-openapi v0.134.0
@@ -58,7 +58,7 @@ require (
 	github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/ulikunitz/xz v0.5.12 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
 	github.com/xanzy/go-gitlab v0.115.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
-github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
-github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 github.com/xanzy/go-gitlab v0.115.0 h1:6DmtItNcVe+At/liXSgfE/DZNZrGfalQmBRmOcJjOn8=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -81,7 +81,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if req.Header.Get("Content-Type") == "" && req.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	return c.httpClient.Do(req)
+	return c.httpClient.Do(req) //nolint:gosec // G704: CLI makes HTTP requests to user-configured API endpoints
 }
 
 // BaseURL returns the configured base URL.

--- a/internal/client/retry.go
+++ b/internal/client/retry.go
@@ -170,7 +170,7 @@ func backoffDelay(attempt int, config RetryConfig) time.Duration {
 		delay = float64(config.MaxDelay)
 	}
 
-	jitter := 0.75 + rand.Float64()*0.5
+	jitter := 0.75 + rand.Float64()*0.5 //nolint:gosec // G404: jitter does not need crypto randomness
 	return time.Duration(delay * jitter)
 }
 

--- a/internal/command/spec.go
+++ b/internal/command/spec.go
@@ -151,7 +151,7 @@ func (s *Spec) BuildInvocation(cmd *cobra.Command, args []string, data map[strin
 		if i >= len(args) {
 			break
 		}
-		inv.PathParams[arg.Param] = args[i]
+		inv.PathParams[arg.Param] = args[i] //nolint:gosec // G602: i is bounded by range over s.Args and len(args) guard above
 	}
 
 	// Step 3: Flags — only if explicitly set by the user


### PR DESCRIPTION
## Description

Pre-launch security hardening before making the repo public.

**Go upgrade (1.23 -> 1.25):**
Go 1.23 is end-of-life and has 22 known vulnerabilities in the standard library. Upgrading to 1.25 (actively maintained) resolves all of them. No code changes needed, all tests pass.

**Dependency fix:**
Bumps `ulikunitz/xz` to v0.5.15 to fix a memory leak in LZMA decoding ([GO-2025-3922](https://pkg.go.dev/vuln/GO-2025-3922)), reachable through the self-update code path.

**Three new CI security checks:**
1. **govulncheck** (pinned v1.1.4) - checks for known vulnerabilities in our dependencies. Blocks PRs that introduce vulnerable packages.
2. **gosec** via golangci-lint (pinned v2.11.4) - static analysis that catches common security mistakes in Go. False positives for standard CLI patterns are suppressed inline with comments explaining why.
3. **Dependabot** - weekly version update PRs for GitHub Actions (prevents gaps like the golangci-lint-action v6 -> v9 situation). Go module security PRs are handled separately via Dependabot security updates in repo settings.

**golangci-lint v1 -> v2:**
The old linter version couldn't handle Go 1.25. Upgraded to v2 with pinned versions so CI doesn't break when upstream releases new versions.

**One-time pre-launch scans (not in CI):**
- gitleaks full history: clean (323 commits)
- TruffleHog full history: clean

## Testing

- All tests pass on Go 1.25
- All new CI checks pass (govulncheck, gosec, gitleaks)
- Build and lint clean across Linux, macOS, Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)