### PR TITLE
docs: fix Go version, timeout default, remove Homebrew from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,13 @@ This installs the latest stable release into `~/.local/bin`.
 <details>
 <summary>Other install methods</summary>
 
-**Homebrew** (once the repo is public):
-
-```bash
-brew install heygen/tap/heygen
-```
-
 **Specific version:**
 
 ```bash
 curl -fsSL https://static.heygen.ai/cli/install.sh | bash -s -- --version v0.1.0
 ```
 
-**From source** (requires Go 1.23+):
+**From source** (requires Go 1.25+):
 
 ```bash
 git clone https://github.com/heygen-com/heygen-cli.git
@@ -169,7 +163,7 @@ heygen video get <video-id>       # check status
 heygen video download <video-id>  # download when complete
 ```
 
-`--wait` uses exponential backoff and respects `--timeout` (default 10m). Exit code 4 on timeout — stdout contains partial resource data with a hint for manual follow-up.
+`--wait` uses exponential backoff and respects `--timeout` (default 20m). Exit code 4 on timeout — stdout contains partial resource data with a hint for manual follow-up.
 
 ## Agent and CI/CD Usage
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ curl -fsSL https://static.heygen.ai/cli/install.sh | bash
 
 This installs the latest stable release into `~/.local/bin`.
 
+**Supported platforms:** macOS (Apple Silicon and Intel) and Linux (x64 and arm64). Windows support is coming soon; use WSL in the meantime.
+
 <details>
 <summary>Other install methods</summary>
 
@@ -164,6 +166,19 @@ heygen video download <video-id>  # download when complete
 ```
 
 `--wait` uses exponential backoff and respects `--timeout` (default 20m). Exit code 4 on timeout — stdout contains partial resource data with a hint for manual follow-up.
+
+## Downloading Videos
+
+```bash
+# Defaults to ./{video-id}.mp4
+heygen video download <video-id>
+
+# Choose a destination path
+heygen video download <video-id> --output-path my-video.mp4
+
+# Download the captioned version (if the video was created with captions)
+heygen video download <video-id> --asset captioned
+```
 
 ## Agent and CI/CD Usage
 


### PR DESCRIPTION
## Description

Three README fixes:
- Go version: 1.23+ -> 1.25+ (matches go.mod after #86)
- Timeout default: 10m -> 20m (matches builder.go:199)
- Remove Homebrew install method (not shipping a tap)

## Testing

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)