### PR TITLE
fix: reject empty POST body and add lipsync --wait

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -73,6 +73,15 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				return err
 			}
 
+			// POST/PUT/PATCH commands with JSON bodies must have input
+			// unless the request schema is intentionally empty (e.g.
+			// `video-agent stop`). Without this check, an empty body is
+			// sent to the API and returns a confusing 400.
+			if spec.BodyEncoding == "json" && inv.Body == nil && spec.Method != "DELETE" && !requestBodyOptional(spec) {
+				return clierrors.NewUsage(
+					fmt.Sprintf("request body required: use -d '{...}' or pass individual flags. Run 'heygen %s %s --request-schema' to see the expected format", spec.Group, spec.Name))
+			}
+
 			if spec.Destructive {
 				force, _ := cmd.Flags().GetBool("force")
 				if !force {
@@ -225,6 +234,32 @@ func hasBodyFlags(spec *command.Spec) bool {
 		}
 	}
 	return false
+}
+
+// requestBodyOptional reports whether the command's request schema accepts
+// an empty body. True when the schema has no properties, no required fields,
+// and no discriminators (oneOf/anyOf/allOf). Used to let commands like
+// `video-agent stop` — which POSTs an empty body by design — through the
+// empty-body guard in RunE.
+func requestBodyOptional(spec *command.Spec) bool {
+	if spec.RequestSchema == "" {
+		return true
+	}
+	var s struct {
+		Properties map[string]any `json:"properties"`
+		Required   []string       `json:"required"`
+		OneOf      []any          `json:"oneOf"`
+		AnyOf      []any          `json:"anyOf"`
+		AllOf      []any          `json:"allOf"`
+	}
+	if err := json.Unmarshal([]byte(spec.RequestSchema), &s); err != nil {
+		return false
+	}
+	return len(s.Properties) == 0 &&
+		len(s.Required) == 0 &&
+		len(s.OneOf) == 0 &&
+		len(s.AnyOf) == 0 &&
+		len(s.AllOf) == 0
 }
 
 func buildUseLine(spec *command.Spec) string {

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -535,7 +535,7 @@ func TestGenBuilder_VideoCreate_Wait_Success(t *testing.T) {
 		originalHandler.ServeHTTP(w, r)
 	})
 
-	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait")
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "-d", `{"test":true}`)
 
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
@@ -589,7 +589,7 @@ func TestGenBuilder_VideoCreate_Wait_Human_NonTTYFallback(t *testing.T) {
 		originalHandler.ServeHTTP(w, r)
 	})
 
-	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--human")
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--human", "-d", `{"test":true}`)
 
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
@@ -615,7 +615,7 @@ func TestGenBuilder_VideoCreate_Wait_Failure(t *testing.T) {
 	})
 	defer srv.Close()
 
-	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait")
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "-d", `{"test":true}`)
 
 	if res.ExitCode != 1 {
 		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
@@ -647,7 +647,7 @@ func TestGenBuilder_VideoCreate_Wait_Timeout(t *testing.T) {
 	})
 	defer srv.Close()
 
-	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--timeout", "20ms")
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--timeout", "20ms", "-d", `{"test":true}`)
 
 	if res.ExitCode != clierrors.ExitTimeout {
 		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitTimeout, res.Stderr)
@@ -686,7 +686,7 @@ func TestGenBuilder_VideoCreate_Wait_TimeoutBeforeFirstPoll(t *testing.T) {
 	})
 	defer srv.Close()
 
-	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--timeout", "20ms")
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--timeout", "20ms", "-d", `{"test":true}`)
 
 	if res.ExitCode != clierrors.ExitTimeout {
 		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitTimeout, res.Stderr)
@@ -709,7 +709,7 @@ func TestGenBuilder_VideoCreate_Wait_Timeout_Human(t *testing.T) {
 	})
 	defer srv.Close()
 
-	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--timeout", "20ms", "--human")
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "--wait", "--timeout", "20ms", "--human", "-d", `{"test":true}`)
 
 	if res.ExitCode != clierrors.ExitTimeout {
 		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitTimeout, res.Stderr)
@@ -744,7 +744,7 @@ func TestGenBuilder_VideoAgentCreate_Wait_Timeout_UsesVideoGetHint(t *testing.T)
 	})
 	defer srv.Close()
 
-	res := runGenCommand(t, srv.URL, "test-key", videoAgentWaitSpec, "create", "--wait", "--timeout", "20ms")
+	res := runGenCommand(t, srv.URL, "test-key", videoAgentWaitSpec, "create", "--wait", "--timeout", "20ms", "-d", `{"prompt":"test"}`)
 
 	if res.ExitCode != clierrors.ExitTimeout {
 		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitTimeout, res.Stderr)
@@ -775,7 +775,7 @@ func TestGenBuilder_VideoCreate_NoWait(t *testing.T) {
 	})
 	defer srv.Close()
 
-	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create")
+	res := runGenCommand(t, srv.URL, "test-key", videoCreateWaitSpec, "create", "-d", `{"test":true}`)
 
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
@@ -816,6 +816,72 @@ func TestGenBuilder_VideoCreate_WaitNotAvailable(t *testing.T) {
 	}
 	if !strings.Contains(res.Stderr, "unknown flag: --wait") {
 		t.Fatalf("stderr = %s, want unknown flag error", res.Stderr)
+	}
+}
+
+func TestGenBuilder_PostWithoutBody_RejectsEmptyRequest(t *testing.T) {
+	requiredBodySpec := &command.Spec{
+		Group:         "video",
+		Name:          "create",
+		Summary:       "Create a video",
+		Endpoint:      "/v3/videos",
+		Method:        "POST",
+		BodyEncoding:  "json",
+		RequestSchema: `{"type":"object","properties":{"title":{"type":"string"}},"required":["title"]}`,
+		Examples:      []string{"heygen video create -d ..."},
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", requiredBodySpec, "create")
+
+	if res.ExitCode != clierrors.ExitUsage {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitUsage, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "request body required") {
+		t.Fatalf("stderr = %s, want 'request body required' message", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "--request-schema") {
+		t.Fatalf("stderr = %s, want --request-schema hint", res.Stderr)
+	}
+}
+
+// POST commands with an intentionally empty request schema (e.g.
+// video-agent stop — properties: {}, required: []) must not be rejected
+// by the empty-body guard.
+func TestGenBuilder_PostWithEmptySchema_AllowsEmptyBody(t *testing.T) {
+	emptyBodySpec := &command.Spec{
+		Group:        "video-agent",
+		Name:         "stop",
+		Summary:      "Stop Video Agent session",
+		Endpoint:     "/v3/video-agents/{session_id}/stop",
+		Method:       "POST",
+		BodyEncoding: "json",
+		RequestSchema: `{
+			"description": "Request body for stopping a session (empty — no fields required).",
+			"properties": {},
+			"required": [],
+			"type": "object"
+		}`,
+		Args: []command.ArgSpec{
+			{Name: "session-id", Param: "session_id"},
+		},
+		Examples: []string{"heygen video-agent stop <session-id>"},
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"POST /v3/video-agents/sess_123/stop": {
+			StatusCode: 200,
+			Body:       `{"data":{"session_id":"sess_123"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runGenCommand(t, srv.URL, "test-key", emptyBodySpec, "stop", "sess_123")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
 }
 

--- a/cmd/heygen/poll_configs.go
+++ b/cmd/heygen/poll_configs.go
@@ -35,4 +35,12 @@ var pollConfigs = map[string]*command.PollConfig{
 		IDField:        "data.video_id",
 		HintCommand:    "video get",
 	},
+	"lipsync/create": {
+		StatusEndpoint: "/v3/lipsyncs/{lipsync_id}",
+		StatusField:    "data.status",
+		TerminalOK:     []string{"completed"},
+		TerminalFail:   []string{"failed"},
+		IDField:        "data.lipsync_id",
+		HintCommand:    "lipsync get",
+	},
 }


### PR DESCRIPTION
## Description

Two fixes from the v0.0.3 QA report.

**BUG-3: Empty body on POST commands.** Running `heygen video create` or `heygen lipsync create` with no `-d` flag and no body flags previously sent an empty JSON body to the API, which returned a confusing 400 error. Now it fails immediately with exit code 2 and a hint pointing to `--request-schema`. This applies to all POST/PUT/PATCH commands with JSON bodies.

**FLAG-5: lipsync create missing --wait.** Lipsync is async (returns `lipsync_id`, polled via `GET /v3/lipsyncs/{id}` with `pending/running/completed/failed` status). It was the only async create command without `--wait` support. Added poll config matching the existing pattern for video, video-agent, and video-translate.

## Testing

- `make test` all pass (new test for empty body rejection, existing poll tests updated to include `-d`)
- Smoke tested: `heygen video create` and `heygen lipsync create` both exit 2 with clear hint
- Smoke tested: `heygen lipsync create --help` shows `--wait` and `--timeout` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)