### PR TITLE
ux: improve error hints and help text from launch-day data (PRINFRA-125)

### DIFF
--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -7,13 +7,13 @@ func newAuthCmd(ctx *cmdContext) *cobra.Command {
 	cmd.Long = `Manage how the CLI authenticates with the HeyGen API.
 
 Two ways to provide your API key:
-  1. Environment variable (preferred for CI/agents/ephemeral shells):
+  1. Environment variable:
        export HEYGEN_API_KEY=<your-key>
-  2. Stored credential file (preferred for human users):
+  2. Stored credential file:
        echo "$KEY" | heygen auth login    # piped
        heygen auth login                  # interactive prompt
 
-The env var takes priority over the stored file when both are set.
+When both are set, the env var takes priority.
 
 Get a key: https://app.heygen.com/settings/api`
 	cmd.AddCommand(newAuthLoginCmd(ctx))

--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -2,20 +2,32 @@ package main
 
 import "github.com/spf13/cobra"
 
+// Shared auth constants — single source of truth for auth guidance strings.
+// Referenced by auth_login.go, auth_status.go, and the auth group help below.
+const (
+	authKeyURL = "https://app.heygen.com/settings/api"
+	authEnvVar = "HEYGEN_API_KEY"
+
+	// authFixHint is the standard actionable hint for auth failures.
+	authFixHint = "Set:  export " + authEnvVar + "=<your-key>\n" +
+		"Or:   echo \"$KEY\" | heygen auth login\n" +
+		"Get a key: " + authKeyURL
+)
+
 func newAuthCmd(ctx *cmdContext) *cobra.Command {
 	cmd := newCommandGroup("auth", "Manage authentication")
 	cmd.Long = `Manage how the CLI authenticates with the HeyGen API.
 
 Two ways to provide your API key:
   1. Environment variable:
-       export HEYGEN_API_KEY=<your-key>
+       export ` + authEnvVar + `=<your-key>
   2. Stored credential file:
        echo "$KEY" | heygen auth login    # piped
        heygen auth login                  # interactive prompt
 
 When both are set, the env var takes priority.
 
-Get a key: https://app.heygen.com/settings/api`
+Get a key: ` + authKeyURL
 	cmd.AddCommand(newAuthLoginCmd(ctx))
 	cmd.AddCommand(newAuthStatusCmd(ctx))
 	return cmd

--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -2,32 +2,22 @@ package main
 
 import "github.com/spf13/cobra"
 
-// Shared auth constants — single source of truth for auth guidance strings.
+// authGuidance is the single source of truth for how to set up CLI auth.
 // Referenced by auth_login.go, auth_status.go, and the auth group help below.
-const (
-	authKeyURL = "https://app.heygen.com/settings/api"
-	authEnvVar = "HEYGEN_API_KEY"
-
-	// authFixHint is the standard actionable hint for auth failures.
-	authFixHint = "Set:  export " + authEnvVar + "=<your-key>\n" +
-		"Or:   echo \"$KEY\" | heygen auth login\n" +
-		"Get a key: " + authKeyURL
-)
-
-func newAuthCmd(ctx *cmdContext) *cobra.Command {
-	cmd := newCommandGroup("auth", "Manage authentication")
-	cmd.Long = `Manage how the CLI authenticates with the HeyGen API.
-
-Two ways to provide your API key:
+const authGuidance = `Two ways to provide your API key:
   1. Environment variable:
-       export ` + authEnvVar + `=<your-key>
+       export HEYGEN_API_KEY=<your-key>
   2. Stored credential file:
        echo "$KEY" | heygen auth login    # piped
        heygen auth login                  # interactive prompt
 
 When both are set, the env var takes priority.
 
-Get a key: ` + authKeyURL
+Get a key: https://app.heygen.com/settings/api`
+
+func newAuthCmd(ctx *cmdContext) *cobra.Command {
+	cmd := newCommandGroup("auth", "Manage authentication")
+	cmd.Long = "Manage how the CLI authenticates with the HeyGen API.\n\n" + authGuidance
 	cmd.AddCommand(newAuthLoginCmd(ctx))
 	cmd.AddCommand(newAuthStatusCmd(ctx))
 	return cmd

--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -4,14 +4,15 @@ import "github.com/spf13/cobra"
 
 // authGuidance is the single source of truth for how to set up CLI auth.
 // Referenced by auth_login.go, auth_status.go, and the auth group help below.
-const authGuidance = `Two ways to provide your API key:
+const authGuidance = `Three ways to provide your API key:
   1. Environment variable:
        export HEYGEN_API_KEY=<your-key>
-  2. Stored credential file:
-       echo "$KEY" | heygen auth login    # piped
-       heygen auth login                  # interactive prompt
+  2. Pipe to auth login:
+       echo "$KEY" | heygen auth login
+  3. Interactive prompt:
+       heygen auth login
 
-When both are set, the env var takes priority.
+When both env var and stored credential are set, the env var takes priority.
 
 Get a key: https://app.heygen.com/settings/api`
 

--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -4,6 +4,18 @@ import "github.com/spf13/cobra"
 
 func newAuthCmd(ctx *cmdContext) *cobra.Command {
 	cmd := newCommandGroup("auth", "Manage authentication")
+	cmd.Long = `Manage how the CLI authenticates with the HeyGen API.
+
+Two ways to provide your API key:
+  1. Environment variable (preferred for CI/agents/ephemeral shells):
+       export HEYGEN_API_KEY=<your-key>
+  2. Stored credential file (preferred for human users):
+       echo "$KEY" | heygen auth login    # piped
+       heygen auth login                  # interactive prompt
+
+The env var takes priority over the stored file when both are set.
+
+Get a key: https://app.heygen.com/settings/api`
 	cmd.AddCommand(newAuthLoginCmd(ctx))
 	cmd.AddCommand(newAuthStatusCmd(ctx))
 	return cmd

--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -5,11 +5,11 @@ import "github.com/spf13/cobra"
 // authGuidance is the single source of truth for how to set up CLI auth.
 // Referenced by auth_login.go, auth_status.go, and the auth group help below.
 const authGuidance = `Three ways to provide your API key:
-  1. Environment variable:
+  1. Environment variable (current shell only):
        export HEYGEN_API_KEY=<your-key>
-  2. Pipe to auth login:
+  2. Pipe to auth login (saves to ~/.heygen/credentials):
        echo "$KEY" | heygen auth login
-  3. Interactive prompt:
+  3. Interactive prompt (saves to ~/.heygen/credentials):
        heygen auth login
 
 When both env var and stored credential are set, the env var takes priority.

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -35,7 +36,35 @@ The env var takes priority over stored credentials.`,
 				return err
 			}
 			if key == "" {
-				return clierrors.NewUsage("no API key provided")
+				isTTY := isStdinTTY(cmd.InOrStdin())
+				envKey := os.Getenv("HEYGEN_API_KEY")
+
+				if !isTTY && envKey != "" {
+					// Non-interactive call with no piped input but env var is set.
+					// Most likely an agent/CI checking that auth is set up.
+					// Surface that env var is being used; suggest persistence path.
+					msg := "HEYGEN_API_KEY is set in your environment — the CLI is using that.\n" +
+						"To save it to disk for future sessions:\n" +
+						"  echo \"$HEYGEN_API_KEY\" | heygen auth login\n" +
+						"Or pipe a different key."
+					fmt.Fprintln(cmd.ErrOrStderr(), msg)
+					data, _ := json.Marshal(map[string]string{
+						"message": "Using HEYGEN_API_KEY from environment. No file written.",
+						"source":  "env",
+					})
+					return ctx.formatter.Data(data, "", nil)
+				}
+
+				if isTTY {
+					return clierrors.NewUsage(
+						"no API key entered — type your key after the prompt, or paste it.",
+					)
+				}
+				return clierrors.NewUsage(
+					"no API key provided on stdin.\n" +
+						"Pipe your key:  echo \"$KEY\" | heygen auth login\n" +
+						"Or set the HEYGEN_API_KEY environment variable.",
+				)
 			}
 
 			store := &auth.FileCredentialStore{}
@@ -54,6 +83,14 @@ The env var takes priority over stored credentials.`,
 			return ctx.formatter.Data(data, "", nil)
 		},
 	}
+}
+
+// isStdinTTY reports whether the given reader is a terminal (TTY).
+func isStdinTTY(in io.Reader) bool {
+	if file, ok := in.(interface{ Fd() uintptr }); ok {
+		return term.IsTerminal(int(file.Fd()))
+	}
+	return false
 }
 
 func readAPIKey(in io.Reader, errOut io.Writer) (string, error) {

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -36,7 +36,7 @@ The env var takes priority over stored credentials.`,
 				return err
 			}
 			if key == "" {
-				isTTY := isStdinTTY(cmd.InOrStdin())
+				isTTY := stdinIsTerminalFunc()
 				envKey := os.Getenv("HEYGEN_API_KEY")
 
 				if !isTTY && envKey != "" {
@@ -85,13 +85,6 @@ The env var takes priority over stored credentials.`,
 	}
 }
 
-// isStdinTTY reports whether the given reader is a terminal (TTY).
-func isStdinTTY(in io.Reader) bool {
-	if file, ok := in.(interface{ Fd() uintptr }); ok {
-		return term.IsTerminal(int(file.Fd()))
-	}
-	return false
-}
 
 func readAPIKey(in io.Reader, errOut io.Writer) (string, error) {
 	if file, ok := in.(interface{ Fd() uintptr }); ok && term.IsTerminal(int(file.Fd())) {

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -28,7 +28,7 @@ Interactive:
 Piped:
   echo "$KEY" | heygen auth login
 
-You can also set the ` + authEnvVar + ` environment variable.
+You can also set the HEYGEN_API_KEY environment variable.
 The env var takes priority over stored credentials.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key, err := readAPIKey(cmd.InOrStdin(), cmd.ErrOrStderr())
@@ -37,19 +37,19 @@ The env var takes priority over stored credentials.`,
 			}
 			if key == "" {
 				isTTY := isStdinTTY(cmd.InOrStdin())
-				envKey := os.Getenv(authEnvVar)
+				envKey := os.Getenv("HEYGEN_API_KEY")
 
 				if !isTTY && envKey != "" {
 					// Non-interactive call with no piped input but env var is set.
 					// Most likely an agent/CI checking that auth is set up.
 					// Surface that env var is being used; suggest persistence path.
-					msg := authEnvVar + " is set in your environment — the CLI is using that.\n" +
+					msg := "HEYGEN_API_KEY is set in your environment — the CLI is using that.\n" +
 						"To save it to disk for future sessions:\n" +
-						"  echo \"$" + authEnvVar + "\" | heygen auth login\n" +
+						"  echo \"$HEYGEN_API_KEY\" | heygen auth login\n" +
 						"Or pipe a different key."
 					fmt.Fprintln(cmd.ErrOrStderr(), msg)
 					data, _ := json.Marshal(map[string]string{
-						"message": "Using " + authEnvVar + " from environment. No file written.",
+						"message": "Using HEYGEN_API_KEY from environment. No file written.",
 						"source":  "env",
 					})
 					return ctx.formatter.Data(data, "", nil)
@@ -63,7 +63,7 @@ The env var takes priority over stored credentials.`,
 				return clierrors.NewUsage(
 					"no API key provided on stdin.\n" +
 						"Pipe your key:  echo \"$KEY\" | heygen auth login\n" +
-						"Or set the " + authEnvVar + " environment variable.",
+						"Or set the HEYGEN_API_KEY environment variable.",
 				)
 			}
 

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -36,26 +35,7 @@ The env var takes priority over stored credentials.`,
 				return err
 			}
 			if key == "" {
-				isTTY := stdinIsTerminalFunc()
-				envKey := os.Getenv("HEYGEN_API_KEY")
-
-				if !isTTY && envKey != "" {
-					// Non-interactive call with no piped input but env var is set.
-					// Most likely an agent/CI checking that auth is set up.
-					// Surface that env var is being used; suggest persistence path.
-					msg := "HEYGEN_API_KEY is set in your environment — the CLI is using that.\n" +
-						"To save it to disk for future sessions:\n" +
-						"  echo \"$HEYGEN_API_KEY\" | heygen auth login\n" +
-						"Or pipe a different key."
-					fmt.Fprintln(cmd.ErrOrStderr(), msg)
-					data, _ := json.Marshal(map[string]string{
-						"message": "Using HEYGEN_API_KEY from environment. No file written.",
-						"source":  "env",
-					})
-					return ctx.formatter.Data(data, "", nil)
-				}
-
-				if isTTY {
+				if stdinIsTerminalFunc() {
 					return clierrors.NewUsage(
 						"no API key entered — type your key after the prompt, or paste it.",
 					)

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -28,7 +28,7 @@ Interactive:
 Piped:
   echo "$KEY" | heygen auth login
 
-You can also set the HEYGEN_API_KEY environment variable.
+You can also set the ` + authEnvVar + ` environment variable.
 The env var takes priority over stored credentials.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key, err := readAPIKey(cmd.InOrStdin(), cmd.ErrOrStderr())
@@ -37,19 +37,19 @@ The env var takes priority over stored credentials.`,
 			}
 			if key == "" {
 				isTTY := isStdinTTY(cmd.InOrStdin())
-				envKey := os.Getenv("HEYGEN_API_KEY")
+				envKey := os.Getenv(authEnvVar)
 
 				if !isTTY && envKey != "" {
 					// Non-interactive call with no piped input but env var is set.
 					// Most likely an agent/CI checking that auth is set up.
 					// Surface that env var is being used; suggest persistence path.
-					msg := "HEYGEN_API_KEY is set in your environment — the CLI is using that.\n" +
+					msg := authEnvVar + " is set in your environment — the CLI is using that.\n" +
 						"To save it to disk for future sessions:\n" +
-						"  echo \"$HEYGEN_API_KEY\" | heygen auth login\n" +
+						"  echo \"$" + authEnvVar + "\" | heygen auth login\n" +
 						"Or pipe a different key."
 					fmt.Fprintln(cmd.ErrOrStderr(), msg)
 					data, _ := json.Marshal(map[string]string{
-						"message": "Using HEYGEN_API_KEY from environment. No file written.",
+						"message": "Using " + authEnvVar + " from environment. No file written.",
 						"source":  "env",
 					})
 					return ctx.formatter.Data(data, "", nil)
@@ -63,7 +63,7 @@ The env var takes priority over stored credentials.`,
 				return clierrors.NewUsage(
 					"no API key provided on stdin.\n" +
 						"Pipe your key:  echo \"$KEY\" | heygen auth login\n" +
-						"Or set the HEYGEN_API_KEY environment variable.",
+						"Or set the " + authEnvVar + " environment variable.",
 				)
 			}
 

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -1,18 +1,27 @@
 package main
 
 import (
+	"errors"
 	"net/url"
 
 	"github.com/heygen-com/heygen-cli/gen"
 	"github.com/heygen-com/heygen-cli/internal/client"
 	"github.com/heygen-com/heygen-cli/internal/command"
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 	"github.com/spf13/cobra"
 )
 
 func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 	return &cobra.Command{
-		Use:     "status",
-		Short:   "Verify stored API key and show account info",
+		Use:   "status",
+		Short: "Verify the active API key (env var or stored) and show account info",
+		Long: `Verifies the API key currently in use by calling the HeyGen API.
+
+The CLI resolves the active key in this order:
+  1. HEYGEN_API_KEY environment variable
+  2. ~/.heygen/credentials (set via 'heygen auth login')
+
+Use this command to confirm your auth setup is working before running other commands.`,
 		Example: "heygen auth status",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -21,6 +30,13 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 				QueryParams: make(url.Values),
 			})
 			if err != nil {
+				var cliErr *clierrors.CLIError
+				if errors.As(err, &cliErr) && cliErr.ExitCode == clierrors.ExitAuth {
+					cliErr.Hint = "Your API key is missing or invalid.\n" +
+						"  Set:  export HEYGEN_API_KEY=<your-key>\n" +
+						"  Or:   echo \"$KEY\" | heygen auth login\n" +
+						"  Get a key: https://app.heygen.com/settings/api"
+				}
 				return err
 			}
 			return ctx.formatter.Data(result, client.APIDataField, nil)

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -15,13 +15,7 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Verify the active API key (env var or stored) and show account info",
-		Long: `Verifies the API key currently in use by calling the HeyGen API.
-
-The CLI resolves the active key in this order:
-  1. ` + authEnvVar + ` environment variable
-  2. ~/.heygen/credentials (set via 'heygen auth login')
-
-Use this command to confirm your auth setup is working before running other commands.`,
+		Long: "Verifies the API key currently in use by calling the HeyGen API.\n\n" + authGuidance,
 		Example: "heygen auth status",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,7 +26,7 @@ Use this command to confirm your auth setup is working before running other comm
 			if err != nil {
 				var cliErr *clierrors.CLIError
 				if errors.As(err, &cliErr) && cliErr.ExitCode == clierrors.ExitAuth {
-					cliErr.Hint = "Your API key is missing or invalid.\n  " + authFixHint
+					cliErr.Hint = "Your API key is missing or invalid.\n" + authGuidance
 				}
 				return err
 			}

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -18,7 +18,7 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 		Long: `Verifies the API key currently in use by calling the HeyGen API.
 
 The CLI resolves the active key in this order:
-  1. HEYGEN_API_KEY environment variable
+  1. ` + authEnvVar + ` environment variable
   2. ~/.heygen/credentials (set via 'heygen auth login')
 
 Use this command to confirm your auth setup is working before running other commands.`,
@@ -32,10 +32,7 @@ Use this command to confirm your auth setup is working before running other comm
 			if err != nil {
 				var cliErr *clierrors.CLIError
 				if errors.As(err, &cliErr) && cliErr.ExitCode == clierrors.ExitAuth {
-					cliErr.Hint = "Your API key is missing or invalid.\n" +
-						"  Set:  export HEYGEN_API_KEY=<your-key>\n" +
-						"  Or:   echo \"$KEY\" | heygen auth login\n" +
-						"  Get a key: https://app.heygen.com/settings/api"
+					cliErr.Hint = "Your API key is missing or invalid.\n  " + authFixHint
 				}
 				return err
 			}

--- a/cmd/heygen/auth_status_test.go
+++ b/cmd/heygen/auth_status_test.go
@@ -61,6 +61,52 @@ func TestAuthStatus_InvalidKey(t *testing.T) {
 	}
 }
 
+// TestAuthStatus_AuthError_AddsHint verifies that a 401 from the API gets the
+// actionable auth hint injected by auth_status.go.
+func TestAuthStatus_AuthError_AddsHint(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 401,
+			Body:       `{"error":{"message":"unauthorized"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "bad-key", "auth", "status")
+
+	if res.ExitCode != clierrors.ExitAuth {
+		t.Fatalf("ExitCode = %d, want %d", res.ExitCode, clierrors.ExitAuth)
+	}
+	if !strings.Contains(res.Stderr, "HEYGEN_API_KEY") {
+		t.Fatalf("stderr = %s, want HEYGEN_API_KEY in hint", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "heygen auth login") {
+		t.Fatalf("stderr = %s, want heygen auth login in hint", res.Stderr)
+	}
+}
+
+// TestAuthStatus_NonAuthError_NoHintMutation verifies that non-auth errors are
+// not mutated by the auth hint injection in auth_status.go.
+func TestAuthStatus_NonAuthError_NoHintMutation(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 500,
+			Body:       `{"error":{"message":"internal server error"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Fatalf("ExitCode = %d, want %d", res.ExitCode, clierrors.ExitGeneral)
+	}
+	// The hint injected by auth_status.go should NOT appear for non-auth errors.
+	if strings.Contains(res.Stderr, "heygen auth login") {
+		t.Fatalf("stderr = %s, should not contain auth hint for non-auth error", res.Stderr)
+	}
+}
+
 func TestAuthStatus_NoKey(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 

--- a/cmd/heygen/auth_status_test.go
+++ b/cmd/heygen/auth_status_test.go
@@ -118,7 +118,11 @@ func TestAuthStatus_NoKey(t *testing.T) {
 	if !strings.Contains(res.Stderr, `"message":"no API key found"`) {
 		t.Fatalf("stderr = %s, want missing API key message", res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, `"hint":"Set HEYGEN_API_KEY env var or run: heygen auth login"`) {
-		t.Fatalf("stderr = %s, want auth hint", res.Stderr)
+	// context.go enriches cold-start auth errors with authGuidance.
+	if !strings.Contains(res.Stderr, "Three ways to provide your API key") {
+		t.Fatalf("stderr = %s, want auth guidance", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "app.heygen.com/settings/api") {
+		t.Fatalf("stderr = %s, want key URL in hint", res.Stderr)
 	}
 }

--- a/cmd/heygen/auth_test.go
+++ b/cmd/heygen/auth_test.go
@@ -28,42 +28,20 @@ func TestAuthLogin_EmptyStdin_NoEnvVar_NonTTY(t *testing.T) {
 }
 
 // TestAuthLogin_EmptyStdin_WithEnvVar_NonTTY verifies that when HEYGEN_API_KEY
-// is set and stdin is empty+non-TTY, the command exits 0, emits the env-var
-// message on stderr, and outputs success JSON on stdout without writing a file.
+// is set but stdin is empty+non-TTY, the command still returns exit 2 with a
+// helpful error. We don't silently exit 0 because Go can't distinguish "no
+// stdin" from "piped empty" (cat /dev/null), which would mask broken automation.
 func TestAuthLogin_EmptyStdin_WithEnvVar_NonTTY(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HEYGEN_CONFIG_DIR", dir)
-
-	// runCommandWithInput sets HEYGEN_API_KEY when apiKey is non-empty, but here
-	// we set it ourselves to simulate the env-var-present non-TTY scenario.
-	// Pass apiKey="" to runCommandWithInput to avoid double-setting; set it via
-	// t.Setenv directly before the call.
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 	t.Setenv("HEYGEN_API_KEY", "env-test-key")
 
 	res := runCommandWithInput(t, "http://example.invalid", "", strings.NewReader(""), "auth", "login")
 
-	if res.ExitCode != 0 {
-		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-
-	// Stderr should contain informational message about env var.
-	if !strings.Contains(res.Stderr, "HEYGEN_API_KEY") {
-		t.Fatalf("stderr = %q, want env var mention", res.Stderr)
-	}
-
-	// Stdout should be valid JSON with source="env".
-	var parsed map[string]string
-	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
-		t.Fatalf("stdout not valid JSON: %v\nstdout: %s", err, res.Stdout)
-	}
-	if parsed["source"] != "env" {
-		t.Fatalf("source = %q, want %q", parsed["source"], "env")
-	}
-
-	// No credentials file should have been written.
-	credPath := filepath.Join(dir, "credentials")
-	if _, err := os.Stat(credPath); !os.IsNotExist(err) {
-		t.Fatalf("credentials file should not exist, but found at %s", credPath)
+	if !strings.Contains(res.Stderr, "Pipe your key") {
+		t.Fatalf("stderr = %q, want pipe hint", res.Stderr)
 	}
 }
 

--- a/cmd/heygen/auth_test.go
+++ b/cmd/heygen/auth_test.go
@@ -8,6 +8,86 @@ import (
 	"testing"
 )
 
+// TestAuthLogin_EmptyStdin_NoEnvVar_NonTTY verifies that a non-TTY empty stdin
+// with no HEYGEN_API_KEY set returns exit 2 with the pipe-hint message.
+func TestAuthLogin_EmptyStdin_NoEnvVar_NonTTY(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "") // ensure env var is not set
+
+	res := runCommandWithInput(t, "http://example.invalid", "", strings.NewReader(""), "auth", "login")
+
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "Pipe your key") {
+		t.Fatalf("stderr = %q, want pipe hint", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "HEYGEN_API_KEY") {
+		t.Fatalf("stderr = %q, want env var hint", res.Stderr)
+	}
+}
+
+// TestAuthLogin_EmptyStdin_WithEnvVar_NonTTY verifies that when HEYGEN_API_KEY
+// is set and stdin is empty+non-TTY, the command exits 0, emits the env-var
+// message on stderr, and outputs success JSON on stdout without writing a file.
+func TestAuthLogin_EmptyStdin_WithEnvVar_NonTTY(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", dir)
+
+	// runCommandWithInput sets HEYGEN_API_KEY when apiKey is non-empty, but here
+	// we set it ourselves to simulate the env-var-present non-TTY scenario.
+	// Pass apiKey="" to runCommandWithInput to avoid double-setting; set it via
+	// t.Setenv directly before the call.
+	t.Setenv("HEYGEN_API_KEY", "env-test-key")
+
+	res := runCommandWithInput(t, "http://example.invalid", "", strings.NewReader(""), "auth", "login")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	// Stderr should contain informational message about env var.
+	if !strings.Contains(res.Stderr, "HEYGEN_API_KEY") {
+		t.Fatalf("stderr = %q, want env var mention", res.Stderr)
+	}
+
+	// Stdout should be valid JSON with source="env".
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\nstdout: %s", err, res.Stdout)
+	}
+	if parsed["source"] != "env" {
+		t.Fatalf("source = %q, want %q", parsed["source"], "env")
+	}
+
+	// No credentials file should have been written.
+	credPath := filepath.Join(dir, "credentials")
+	if _, err := os.Stat(credPath); !os.IsNotExist(err) {
+		t.Fatalf("credentials file should not exist, but found at %s", credPath)
+	}
+}
+
+// TestAuthLogin_PipedKey_StillWorks is a regression test ensuring neither
+// change 1 nor change 2 broke the happy path.
+func TestAuthLogin_PipedKey_StillWorks(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", dir)
+
+	res := runCommandWithInput(t, "http://example.invalid", "", strings.NewReader("real-key\n"), "auth", "login")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "credentials"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "real-key\n" {
+		t.Fatalf("credentials = %q, want %q", string(data), "real-key\n")
+	}
+}
+
 func TestAuthLogin_Success(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -160,7 +160,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 							}
 							return &clierrors.CLIError{
 								Code:     "timeout",
-								Message:  fmt.Sprintf("polling timed out after %s", timeout),
+								Message:  fmt.Sprintf("still processing after --wait of %s (not failed, just not done yet)", timeout),
 								Hint:     hint,
 								ExitCode: clierrors.ExitTimeout,
 							}

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -652,7 +652,7 @@ func TestGenBuilder_VideoCreate_Wait_Timeout(t *testing.T) {
 	if res.ExitCode != clierrors.ExitTimeout {
 		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitTimeout, res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, "polling timed out after 20ms") {
+	if !strings.Contains(res.Stderr, "still processing after --wait of 20ms") {
 		t.Fatalf("stderr = %s, want timeout message", res.Stderr)
 	}
 	if !strings.Contains(res.Stderr, "heygen video get vid_123") {
@@ -717,7 +717,7 @@ func TestGenBuilder_VideoCreate_Wait_Timeout_Human(t *testing.T) {
 	if !strings.Contains(res.Stderr, "Polling: status=processing") {
 		t.Fatalf("stderr = %s, want progress output", res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, "Error: polling timed out after 20ms") {
+	if !strings.Contains(res.Stderr, "Error: still processing after --wait of 20ms") {
 		t.Fatalf("stderr = %s, want human timeout error", res.Stderr)
 	}
 	if !strings.Contains(res.Stderr, "Hint: heygen video get vid_123") {

--- a/cmd/heygen/context.go
+++ b/cmd/heygen/context.go
@@ -71,10 +71,11 @@ func initContext(cmd *cobra.Command, version string, ctx *cmdContext) error {
 	}
 	apiKey, err := resolver.Resolve()
 	if err != nil {
-		// Enrich cold-start auth errors with the full auth guidance so
-		// first-time users see all three auth methods + the key URL.
+		// Enrich the generic cold-start auth error ("no API key found")
+		// with the full auth guidance. Don't overwrite specific hints
+		// like "Check the credentials file at ..." (broken file case).
 		var cliErr *clierrors.CLIError
-		if errors.As(err, &cliErr) && cliErr.ExitCode == clierrors.ExitAuth {
+		if errors.As(err, &cliErr) && cliErr.ExitCode == clierrors.ExitAuth && cliErr.Message == "no API key found" {
 			cliErr.Hint = authGuidance
 		}
 		return err

--- a/cmd/heygen/context.go
+++ b/cmd/heygen/context.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/url"
 	"os"
 
@@ -70,6 +71,12 @@ func initContext(cmd *cobra.Command, version string, ctx *cmdContext) error {
 	}
 	apiKey, err := resolver.Resolve()
 	if err != nil {
+		// Enrich cold-start auth errors with the full auth guidance so
+		// first-time users see all three auth methods + the key URL.
+		var cliErr *clierrors.CLIError
+		if errors.As(err, &cliErr) && cliErr.ExitCode == clierrors.ExitAuth {
+			cliErr.Hint = authGuidance
+		}
 		return err
 	}
 

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/heygen-com/heygen-cli/gen"
@@ -187,8 +188,16 @@ func newCommandGroup(use, short string) *cobra.Command {
 		Short: short,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
+				var available []string
+				for _, sub := range cmd.Commands() {
+					if !sub.Hidden && sub.Name() != "help" {
+						available = append(available, sub.Name())
+					}
+				}
+				sort.Strings(available)
 				return clierrors.NewUsage(
-					fmt.Sprintf("unknown command %q for %q", args[0], cmd.CommandPath()))
+					fmt.Sprintf("unknown command %q for %q.\nAvailable subcommands: %s",
+						args[0], cmd.CommandPath(), strings.Join(available, ", ")))
 			}
 			return cmd.Help()
 		},

--- a/cmd/heygen/root_test.go
+++ b/cmd/heygen/root_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCommandGroup_UnknownSubcommand_ListsAvailable verifies that typing an
+// unknown subcommand returns exit 2 and lists the available subcommands.
+func TestCommandGroup_UnknownSubcommand_ListsAvailable(t *testing.T) {
+	res := runCommand(t, "http://example.invalid", "test-key", "user", "info")
+
+	if res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 2\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "unknown command") {
+		t.Fatalf("stderr = %s, want unknown command message", res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "Available subcommands:") {
+		t.Fatalf("stderr = %s, want Available subcommands list", res.Stderr)
+	}
+	// "me" is the real subcommand under "user" (heygen user me).
+	if !strings.Contains(res.Stderr, "me") {
+		t.Fatalf("stderr = %s, want at least 'me' in available subcommands", res.Stderr)
+	}
+}
+
+// TestCommandGroup_BareInvocation_ShowsHelp verifies that calling a command
+// group with no arguments exits 0 and prints help (regression test).
+func TestCommandGroup_BareInvocation_ShowsHelp(t *testing.T) {
+	res := runCommand(t, "http://example.invalid", "test-key", "user")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -106,10 +106,27 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 		}
 	}
 
+	hint := hintForAPICode(code)
+
 	return &CLIError{
 		Code:      code,
 		Message:   apiErr.Message,
+		Hint:      hint,
 		RequestID: requestID,
 		ExitCode:  exitCode,
 	}
+}
+
+// hintForAPICode returns a CLI-specific actionable hint for known API error
+// codes. Returns "" if the code has no associated hint.
+func hintForAPICode(code string) string {
+	switch code {
+	case "avatar_not_found":
+		return "List available avatars: heygen avatar list"
+	case "video_not_found":
+		return "List your videos: heygen video list"
+	case "voice_not_found":
+		return "List available voices: heygen voice list"
+	}
+	return ""
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -120,6 +121,42 @@ func TestFromAPIError_PreservesAPICode(t *testing.T) {
 
 	if cliErr.Code != "custom_code" {
 		t.Errorf("Code = %q, want %q (should preserve API code)", cliErr.Code, "custom_code")
+	}
+}
+
+func TestFromAPIError_AvatarNotFound_AddsHint(t *testing.T) {
+	apiErr := &APIError{Code: "avatar_not_found", Message: "avatar with id X not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if !strings.Contains(cliErr.Hint,"heygen avatar list") {
+		t.Errorf("Hint = %q, want heygen avatar list", cliErr.Hint)
+	}
+}
+
+func TestFromAPIError_VideoNotFound_AddsHint(t *testing.T) {
+	apiErr := &APIError{Code: "video_not_found", Message: "video not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if !strings.Contains(cliErr.Hint,"heygen video list") {
+		t.Errorf("Hint = %q, want heygen video list", cliErr.Hint)
+	}
+}
+
+func TestFromAPIError_VoiceNotFound_AddsHint(t *testing.T) {
+	apiErr := &APIError{Code: "voice_not_found", Message: "voice not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if !strings.Contains(cliErr.Hint,"heygen voice list") {
+		t.Errorf("Hint = %q, want heygen voice list", cliErr.Hint)
+	}
+}
+
+func TestFromAPIError_UnknownCode_NoHint(t *testing.T) {
+	apiErr := &APIError{Code: "something_obscure", Message: "not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if cliErr.Hint != "" {
+		t.Errorf("Hint = %q, want empty for unknown code", cliErr.Hint)
 	}
 }
 


### PR DESCRIPTION
## Description

Better error messages and help text for first-time CLI users, based on PostHog data from the v0.0.4 launch day (Apr 13). None of these were blocking (15/17 auth-error users recovered on their own). All changes are additive hint/wording improvements. No exit codes, output shapes, or control flow changes.

**TTY** = interactive terminal. **Non-TTY** = piped input, script, CI, or coding agent.

### Changes

| # | What | File | Trigger (launch day) |
|---|------|------|----------------------|
| 1 | `auth login` with empty stdin now distinguishes TTY ("type your key") vs non-TTY ("pipe your key or set env var") | `auth_login.go` | 3 installs hit vague error, didn't retry |
| 2 | Unknown subcommands list what's available (`Available subcommands: me`) | `root.go` | 6 installs typed e.g. `heygen user info` |
| 3 | `--wait` timeout reworded from "polling timed out" to "still processing, not failed" | `builder.go` | 11 installs, wording implied failure |
| 4 | `auth status` errors include hint with all 3 auth methods + key URL | `auth_status.go` | 17 installs got unhelpful auth error |
| 5 | `heygen auth --help` explains all auth options (was just "Manage authentication") | `auth.go` | Consistent with #4 |
| 6 | `avatar_not_found` / `video_not_found` errors hint at the corresponding `list` command | `errors.go` | 8 installs retried wrong avatar IDs |

Auth guidance text is defined once in `auth.go` (`authGuidance` constant) and referenced everywhere.

Cold-start "no API key found" errors (from `chain_resolver.go`) are enriched with the same guidance in `context.go`, scoped to the cold-start case only (doesn't clobber the broken-credentials-file hint).

### What we chose NOT to do

- **Don't auto-persist env var to disk** on `auth login` empty stdin. `cat /dev/null | heygen auth login` would silently succeed, masking broken automation.
- **Don't bump the 20-min `--wait` default.** Only 4/11 timeouts hit it; the other 7 set shorter `--timeout` themselves.

## Testing

- 12 new + 2 updated tests
- `make test` and `make build` pass
- Manually verified: `heygen user info`, `heygen auth --help`, `heygen auth status --help`, empty-stdin `auth login`