### PR TITLE
ux: render nested JSON as readable sub-sections in --human mode

### DIFF
--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -169,7 +169,7 @@ func renderNestedKeyValue(w io.Writer, obj map[string]any, indent int) error {
 		value := obj[key]
 
 		if indent >= maxNestedDepth {
-			if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, formatCell(value, key)); err != nil {
+			if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, compactJSON(value)); err != nil {
 				return err
 			}
 			continue
@@ -198,11 +198,16 @@ func renderNestedKeyValue(w io.Writer, obj map[string]any, indent int) error {
 				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, formatArrayInline(v)); err != nil {
 					return err
 				}
-			} else {
+			} else if isObjectArray(v) {
 				if _, err := fmt.Fprintf(w, "%s%s:\n", prefix, label); err != nil {
 					return err
 				}
 				if err := renderArrayOfObjects(w, v, indent+1); err != nil {
+					return err
+				}
+			} else {
+				// Heterogeneous or mixed array: compact JSON fallback.
+				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, compactJSON(v)); err != nil {
 					return err
 				}
 			}
@@ -329,6 +334,28 @@ func formatCell(v any, fieldName string) string {
 
 func formatTableCell(v any, fieldName string) string {
 	return sanitizeForTable(formatCell(v, fieldName))
+}
+
+// isObjectArray returns true if every element is a map[string]any.
+func isObjectArray(v []any) bool {
+	for _, elem := range v {
+		if _, ok := elem.(map[string]any); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// compactJSON marshals a value to compact JSON, returning "" for nil.
+func compactJSON(v any) string {
+	if v == nil {
+		return ""
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	return string(data)
 }
 
 // isScalarArray returns true if every element is a non-nil scalar (string, float64, bool).

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -149,7 +149,10 @@ func (f *HumanFormatter) renderKeyValue(obj map[string]any) error {
 	return renderNestedKeyValue(f.out, obj, 0)
 }
 
-const maxNestedDepth = 5
+const (
+	maxNestedDepth = 5
+	kvSeparator    = ":  " // label-value separator in key-value output
+)
 
 func renderNestedKeyValue(w io.Writer, obj map[string]any, indent int) error {
 	prefix := strings.Repeat("  ", indent)
@@ -215,7 +218,7 @@ func renderNestedKeyValue(w io.Writer, obj map[string]any, indent int) error {
 			formatted := formatCell(value, key)
 			if s, ok := value.(string); ok && strings.Contains(s, "\n") {
 				// Multiline string: re-indent continuation lines.
-				valueIndent := prefix + strings.Repeat(" ", lipgloss.Width(label)+len(":  ")+len(padding))
+				valueIndent := prefix + strings.Repeat(" ", lipgloss.Width(label)+len(kvSeparator)+len(padding))
 				lines := strings.Split(formatted, "\n")
 				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, lines[0]); err != nil {
 					return err
@@ -239,6 +242,12 @@ func renderArrayOfObjects(w io.Writer, items []any, indent int) error {
 	prefix := strings.Repeat("  ", indent)
 	for i, item := range items {
 		if obj, ok := item.(map[string]any); ok {
+			// Blank line between entries with 3+ fields for scannability.
+			if i > 0 && len(obj) > 2 {
+				if _, err := fmt.Fprintln(w); err != nil {
+					return err
+				}
+			}
 			if _, err := fmt.Fprintf(w, "%s[%d]\n", prefix, i+1); err != nil {
 				return err
 			}
@@ -337,6 +346,7 @@ func formatTableCell(v any, fieldName string) string {
 }
 
 // isObjectArray returns true if every element is a map[string]any.
+// Returns true for empty slices (vacuous truth); callers check len first.
 func isObjectArray(v []any) bool {
 	for _, elem := range v {
 		if _, ok := elem.(map[string]any); !ok {
@@ -359,6 +369,7 @@ func compactJSON(v any) string {
 }
 
 // isScalarArray returns true if every element is a non-nil scalar (string, float64, bool).
+// Returns true for empty slices (vacuous truth); callers check len first.
 func isScalarArray(v []any) bool {
 	for _, elem := range v {
 		switch elem.(type) {
@@ -392,6 +403,7 @@ func formatArrayInline(v []any) string {
 }
 
 // formatMapInline renders a flat map as sorted key=value pairs.
+// Uses raw JSON keys (not humanizeKey) for compactness in table cells.
 func formatMapInline(m map[string]any) string {
 	keys := sortedKeys(m)
 	parts := make([]string, len(keys))

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -146,22 +146,104 @@ func (f *HumanFormatter) renderPrimitiveList(items []any) error {
 }
 
 func (f *HumanFormatter) renderKeyValue(obj map[string]any) error {
-	keys := make([]string, 0, len(obj))
+	return renderNestedKeyValue(f.out, obj, 0)
+}
+
+const maxNestedDepth = 5
+
+func renderNestedKeyValue(w io.Writer, obj map[string]any, indent int) error {
+	prefix := strings.Repeat("  ", indent)
+	keys := sortedKeys(obj)
+
 	maxLabelWidth := 0
-	for key := range obj {
-		keys = append(keys, key)
+	for _, key := range keys {
 		label := humanizeKey(key)
-		if w := lipgloss.Width(label); w > maxLabelWidth {
-			maxLabelWidth = w
+		if lw := lipgloss.Width(label); lw > maxLabelWidth {
+			maxLabelWidth = lw
 		}
 	}
-	sort.Strings(keys)
 
 	for _, key := range keys {
 		label := humanizeKey(key)
 		padding := strings.Repeat(" ", max(0, maxLabelWidth-lipgloss.Width(label)))
-		if _, err := fmt.Fprintf(f.out, "%s:%s  %s\n", label, padding, formatCell(obj[key], key)); err != nil {
-			return err
+		value := obj[key]
+
+		if indent >= maxNestedDepth {
+			if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, formatCell(value, key)); err != nil {
+				return err
+			}
+			continue
+		}
+
+		switch v := value.(type) {
+		case map[string]any:
+			if len(v) == 0 {
+				if _, err := fmt.Fprintf(w, "%s%s:%s  (none)\n", prefix, label, padding); err != nil {
+					return err
+				}
+			} else {
+				if _, err := fmt.Fprintf(w, "%s%s:\n", prefix, label); err != nil {
+					return err
+				}
+				if err := renderNestedKeyValue(w, v, indent+1); err != nil {
+					return err
+				}
+			}
+		case []any:
+			if len(v) == 0 {
+				if _, err := fmt.Fprintf(w, "%s%s:%s  (none)\n", prefix, label, padding); err != nil {
+					return err
+				}
+			} else if isScalarArray(v) {
+				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, formatArrayInline(v)); err != nil {
+					return err
+				}
+			} else {
+				if _, err := fmt.Fprintf(w, "%s%s:\n", prefix, label); err != nil {
+					return err
+				}
+				if err := renderArrayOfObjects(w, v, indent+1); err != nil {
+					return err
+				}
+			}
+		default:
+			formatted := formatCell(value, key)
+			if s, ok := value.(string); ok && strings.Contains(s, "\n") {
+				// Multiline string: re-indent continuation lines.
+				valueIndent := prefix + strings.Repeat(" ", lipgloss.Width(label)+len(":  ")+len(padding))
+				lines := strings.Split(formatted, "\n")
+				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, lines[0]); err != nil {
+					return err
+				}
+				for _, line := range lines[1:] {
+					if _, err := fmt.Fprintf(w, "%s%s\n", valueIndent, line); err != nil {
+						return err
+					}
+				}
+			} else {
+				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, formatted); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func renderArrayOfObjects(w io.Writer, items []any, indent int) error {
+	prefix := strings.Repeat("  ", indent)
+	for i, item := range items {
+		if obj, ok := item.(map[string]any); ok {
+			if _, err := fmt.Fprintf(w, "%s[%d]\n", prefix, i+1); err != nil {
+				return err
+			}
+			if err := renderNestedKeyValue(w, obj, indent+1); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintf(w, "%s[%d]  %s\n", prefix, i+1, formatValue(item)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -249,6 +331,59 @@ func formatTableCell(v any, fieldName string) string {
 	return sanitizeForTable(formatCell(v, fieldName))
 }
 
+// isScalarArray returns true if every element is a non-nil scalar (string, float64, bool).
+func isScalarArray(v []any) bool {
+	for _, elem := range v {
+		switch elem.(type) {
+		case string, float64, bool:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isFlatMap returns true if every value is a non-nil scalar (string, float64, bool).
+func isFlatMap(m map[string]any) bool {
+	for _, v := range m {
+		switch v.(type) {
+		case string, float64, bool:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// formatArrayInline renders a scalar array as comma-separated values.
+func formatArrayInline(v []any) string {
+	parts := make([]string, len(v))
+	for i, elem := range v {
+		parts[i] = formatValue(elem)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatMapInline renders a flat map as sorted key=value pairs.
+func formatMapInline(m map[string]any) string {
+	keys := sortedKeys(m)
+	parts := make([]string, len(keys))
+	for i, key := range keys {
+		parts[i] = key + "=" + formatValue(m[key])
+	}
+	return strings.Join(parts, ", ")
+}
+
+// sortedKeys returns the keys of a map sorted alphabetically.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func formatValue(v any) string {
 	switch value := v.(type) {
 	case nil:
@@ -259,7 +394,25 @@ func formatValue(v any) string {
 		return strconv.FormatFloat(value, 'f', -1, 64)
 	case bool:
 		return strconv.FormatBool(value)
-	case []any, map[string]any:
+	case []any:
+		if len(value) == 0 {
+			return ""
+		}
+		if isScalarArray(value) {
+			return formatArrayInline(value)
+		}
+		data, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Sprint(value)
+		}
+		return string(data)
+	case map[string]any:
+		if len(value) == 0 {
+			return ""
+		}
+		if isFlatMap(value) {
+			return formatMapInline(value)
+		}
 		data, err := json.Marshal(value)
 		if err != nil {
 			return fmt.Sprint(value)

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -74,8 +74,8 @@ func TestHumanFormatter_Data_KeyValue(t *testing.T) {
 	if !strings.Contains(got, "Id:") || !strings.Contains(got, "vid_123") {
 		t.Fatalf("missing id field in output:\n%s", got)
 	}
-	if !strings.Contains(got, `{"kind":"demo"}`) {
-		t.Fatalf("nested objects should render as inline JSON:\n%s", got)
+	if !strings.Contains(got, "Meta:\n") || !strings.Contains(got, "Kind:") || !strings.Contains(got, "demo") {
+		t.Fatalf("nested objects should render as indented sub-section:\n%s", got)
 	}
 }
 
@@ -89,7 +89,7 @@ func TestHumanFormatter_Data_KeyValuePreservesMultilineStrings(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Line 1\nLine 2") {
+	if !strings.Contains(got, "Line 1\n") || !strings.Contains(got, "Line 2") {
 		t.Fatalf("key-value output should preserve multiline strings:\n%s", got)
 	}
 }
@@ -163,6 +163,226 @@ func TestFormatTableCell_SanitizesWhitespace(t *testing.T) {
 	got := formatTableCell("\nMark\u00a0", "name")
 	if got != "Mark" {
 		t.Fatalf("formatTableCell = %q, want %q", got, "Mark")
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_StringArray(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"events":["avatar_video.success","avatar_video.fail"],"id":"ep_1"}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "avatar_video.success, avatar_video.fail") {
+		t.Fatalf("string arrays should render comma-separated:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_NestedObject(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"error":{"code":"not_found","message":"Video not found"},"id":"vid_1"}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Error:\n") {
+		t.Fatalf("nested object should start a sub-section:\n%s", got)
+	}
+	if !strings.Contains(got, "  Code:") || !strings.Contains(got, "not_found") {
+		t.Fatalf("nested object fields should be indented:\n%s", got)
+	}
+	if !strings.Contains(got, "  Message:") || !strings.Contains(got, "Video not found") {
+		t.Fatalf("nested object fields should be indented:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_DeepNesting(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"wallet":{"currency":"usd","remaining_balance":150,"auto_reload":{"enabled":true,"amount_usd":50}}}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Wallet:\n") {
+		t.Fatalf("top-level nested object should start a sub-section:\n%s", got)
+	}
+	if !strings.Contains(got, "  Auto Reload:\n") {
+		t.Fatalf("second-level nested object should start a sub-section:\n%s", got)
+	}
+	if !strings.Contains(got, "    Enabled:") || !strings.Contains(got, "true") {
+		t.Fatalf("third-level fields should be double-indented:\n%s", got)
+	}
+	if !strings.Contains(got, "  Currency:") || !strings.Contains(got, "usd") {
+		t.Fatalf("second-level scalar fields should be indented:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_ArrayOfObjects(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"messages":[{"role":"user","content":"hello"},{"role":"model","content":"hi"}]}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Messages:\n") {
+		t.Fatalf("array of objects should start a sub-section:\n%s", got)
+	}
+	if !strings.Contains(got, "[1]") || !strings.Contains(got, "[2]") {
+		t.Fatalf("array entries should be numbered:\n%s", got)
+	}
+	if !strings.Contains(got, "Role:") || !strings.Contains(got, "user") {
+		t.Fatalf("object fields should be rendered:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_EmptyCollections(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"metadata":{},"tags":[]}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	count := strings.Count(got, "(none)")
+	if count != 2 {
+		t.Fatalf("empty map and array should both render as (none), got %d occurrences:\n%s", count, got)
+	}
+}
+
+func TestHumanFormatter_Data_Table_StringArray(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":[{"id":"ep_1","events":["a.success","a.fail"]},{"id":"ep_2","events":["b.success"]}]}`)
+	columns := []command.Column{
+		{Header: "ID", Field: "id"},
+		{Header: "Events", Field: "events"},
+	}
+
+	if err := f.Data(input, "data", columns); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "a.success, a.fail") {
+		t.Fatalf("string arrays in tables should be comma-separated:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_Table_FlatMap(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":[{"id":"av_1","error":{"code":"bad_input","message":"invalid"}}]}`)
+	columns := []command.Column{
+		{Header: "ID", Field: "id"},
+		{Header: "Error", Field: "error"},
+	}
+
+	if err := f.Data(input, "data", columns); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "code=bad_input") || !strings.Contains(got, "message=invalid") {
+		t.Fatalf("flat maps in tables should render as key=value:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_Table_NullInArray(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":[{"id":"x","items":[null,"hello"]}]}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	// Arrays with null should fall back to compact JSON, not produce ", hello"
+	if strings.Contains(got, ", hello") {
+		t.Fatalf("arrays with null should not use inline format:\n%s", got)
+	}
+	if !strings.Contains(got, "null") {
+		t.Fatalf("null should be preserved in compact JSON:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_Table_NullInMap(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":[{"id":"x","info":{"a":null,"b":"val"}}]}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	// Maps with null values should not use inline format
+	if strings.Contains(got, "a=") {
+		t.Fatalf("maps with null values should not use inline format:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_NestedScalarArray(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"config":{"tags":["pro","team"],"name":"test"}}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "pro, team") {
+		t.Fatalf("scalar arrays inside nested objects should render comma-separated:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_NestedMultilineString(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage("{\"data\":{\"msg\":{\"content\":\"Line 1\\nLine 2\\nLine 3\"}}}")
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Line 1\n") || !strings.Contains(got, "Line 2\n") || !strings.Contains(got, "Line 3") {
+		t.Fatalf("multiline strings in nested objects should preserve all lines:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_NestedTimestampAndDuration(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"credits":{"resets_at":1710000000},"stats":{"duration":125}}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "2024-03-09") {
+		t.Fatalf("timestamps inside nested objects should be formatted:\n%s", got)
+	}
+	if !strings.Contains(got, "2m 5s") {
+		t.Fatalf("durations inside nested objects should be formatted:\n%s", got)
 	}
 }
 

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -383,6 +384,53 @@ func TestHumanFormatter_Data_KeyValue_NestedTimestampAndDuration(t *testing.T) {
 	}
 	if !strings.Contains(got, "2m 5s") {
 		t.Fatalf("durations inside nested objects should be formatted:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_HeterogeneousArray(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"items":[null,"hello",42]}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	// Heterogeneous arrays with null should fall back to compact JSON
+	if !strings.Contains(got, "null") {
+		t.Fatalf("heterogeneous arrays should preserve null in compact JSON:\n%s", got)
+	}
+	if strings.Contains(got, "[1]") {
+		t.Fatalf("heterogeneous arrays should not be expanded as numbered entries:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_DepthGuardUsesCompactJSON(t *testing.T) {
+	// Build a deeply nested object that exceeds maxNestedDepth (5).
+	// depth0 -> depth1 -> depth2 -> depth3 -> depth4 -> depth5 -> {leaf: "val", empty: []}
+	inner := map[string]any{"leaf": "val", "empty": []any{}}
+	obj := inner
+	for i := 0; i < 5; i++ {
+		obj = map[string]any{fmt.Sprintf("depth%d", 5-i): obj}
+	}
+
+	data, _ := json.Marshal(map[string]any{"data": obj})
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	if err := f.Data(json.RawMessage(data), "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	// At depth 5, individual fields are rendered with compactJSON.
+	// String values get JSON-quoted, empty arrays show as [].
+	if !strings.Contains(got, `"val"`) {
+		t.Fatalf("depth guard should render strings as compact JSON:\n%s", got)
+	}
+	if !strings.Contains(got, `[]`) {
+		t.Fatalf("depth guard should preserve empty arrays as [], not blank:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Description

Nested objects and arrays in API responses were rendered as compact JSON strings in `--human` mode (e.g. `{"code":"not_found","message":"Video not found"}`), making the output hard to scan.

This PR makes the `HumanFormatter` context-aware for nested structures:

**Key-value mode** (get commands) now renders nested data as indented sub-sections:
```
# Before
Wallet:  {"currency":"usd","remaining_balance":150,"auto_reload":{"enabled":true}}

# After
Wallet:
  Currency:          usd
  Remaining Balance: 150
  Auto Reload:
    Enabled:  true
```

**Table mode** (list commands) renders string arrays as comma-separated and flat objects as `key=value`:
```
# Before
Events: ["avatar_video.success","avatar_video.fail"]
Error:  {"code":"bad_input","message":"invalid"}

# After
Events: avatar_video.success, avatar_video.fail
Error:  code=bad_input, message=invalid
```

The approach is fully generic with no per-command special-casing. All 5 nesting types across 8 command groups are handled:
- **String arrays** (`events`, `tags`, `supported_api_engines`) -> comma-separated
- **Flat objects** (`error {code, message}`) -> `key=value` inline (tables) or indented sub-section (key-value)
- **Deep objects** (`wallet`, `subscription`) -> recursive indented sub-sections
- **Arrays of objects** (`messages`, `word_timestamps`) -> numbered entries with indented fields
- **Empty collections** -> blank in tables, `(none)` in key-value mode

Design decisions:
- `formatValue` (shared single-line formatter) handles table cells. `renderKeyValue` handles key-value mode separately to allow multi-line rendering.
- `isScalarArray`/`isFlatMap` exclude nil values to avoid malformed inline output like `, x` or `key=`.
- Recursive depth guard at 5 levels (falls back to compact JSON).
- Multiline strings get continuation-line re-indentation at nested levels.
- `formatCell` field-name-aware formatting (timestamps, durations) works at all nesting levels.

## Testing

- Updated 2 existing tests to match new output format
- Added 12 new test cases covering all nesting types, null handling, nested scalar arrays, nested multiline strings, and nested timestamp/duration formatting
- `make test` passes (all packages)
- `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)