### PR TITLE
perf: compact JSON for --request-schema and --response-schema

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -54,7 +55,13 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 			defer restoreRequiredFlagAnnotations(cmd)
 
 			if show, schema := requestedSchema(cmd, spec); show {
-				_, err := fmt.Fprintln(cmd.OutOrStdout(), schema)
+				var buf bytes.Buffer
+				if err := json.Compact(&buf, []byte(schema)); err != nil {
+					// Fallback: print as-is if compact fails.
+					_, err = fmt.Fprintln(cmd.OutOrStdout(), schema)
+					return err
+				}
+				_, err := fmt.Fprintln(cmd.OutOrStdout(), buf.String())
 				return err
 			}
 

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -44,6 +44,14 @@ var videoCreateWaitSpec = &command.Spec{
 	Examples:     []string{"heygen video create --wait"},
 }
 
+func compactSchema(s string) string {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(s)); err != nil {
+		return s
+	}
+	return buf.String()
+}
+
 var videoCreateSchemaSpec = &command.Spec{
 	Group:          "video",
 	Name:           "create",
@@ -184,7 +192,7 @@ func TestGenBuilder_VideoCreate_RequestSchema(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if res.Stdout != videoCreateSchemaSpec.RequestSchema+"\n" {
+	if res.Stdout != compactSchema(videoCreateSchemaSpec.RequestSchema)+"\n" {
 		t.Fatalf("stdout = %q, want request schema", res.Stdout)
 	}
 	if res.Stderr != "" {
@@ -198,7 +206,7 @@ func TestGenBuilder_VideoGet_ResponseSchema(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if res.Stdout != videoGetSchemaSpec.ResponseSchema+"\n" {
+	if res.Stdout != compactSchema(videoGetSchemaSpec.ResponseSchema)+"\n" {
 		t.Fatalf("stdout = %q, want response schema", res.Stdout)
 	}
 }
@@ -220,7 +228,7 @@ func TestGenBuilder_VideoCreate_SchemaSkipsAuth(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if res.Stdout != videoCreateSchemaSpec.ResponseSchema+"\n" {
+	if res.Stdout != compactSchema(videoCreateSchemaSpec.ResponseSchema)+"\n" {
 		t.Fatalf("stdout = %q, want response schema", res.Stdout)
 	}
 }
@@ -231,7 +239,7 @@ func TestGenBuilder_SchemaBypassesRequiredFlags(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if res.Stdout != videoTranslateSchemaSpec.RequestSchema+"\n" {
+	if res.Stdout != compactSchema(videoTranslateSchemaSpec.RequestSchema)+"\n" {
 		t.Fatalf("stdout = %q, want request schema", res.Stdout)
 	}
 	if res.Stderr != "" {
@@ -245,7 +253,7 @@ func TestGenBuilder_SchemaBypassesArgs(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if res.Stdout != webhookEndpointUpdateSchemaSpec.RequestSchema+"\n" {
+	if res.Stdout != compactSchema(webhookEndpointUpdateSchemaSpec.RequestSchema)+"\n" {
 		t.Fatalf("stdout = %q, want request schema", res.Stdout)
 	}
 	if res.Stderr != "" {


### PR DESCRIPTION
## Description

`--request-schema` and `--response-schema` output was pretty-printed with 2-space indentation. For AI agents consuming this output as context, the whitespace wastes tokens.

Now the output is compact JSON (single line, no whitespace). Schemas remain pretty-printed in `gen/` source files for diff readability; compaction happens at the print site via `json.Compact`.

**Empirical measurement across all 64 schemas:**

```
Pretty:  139,648 bytes  (~34,912 tokens)
Compact:  87,462 bytes  (~21,866 tokens)
Saved:    52,186 bytes  (~13,046 tokens)  37.4%
```

Top schemas by savings:

```
Command                                       Pretty  Compact  Saved    %
video create --request-schema                 12,973    8,252  4,721  36%
avatar create --request-schema                 9,928    5,497  4,431  45%
video-translate create --request-schema        7,593    5,094  2,499  33%
user me get --response-schema                  4,151    1,935  2,216  53%
```

The change is a single `json.Compact` call in `builder.go` at the schema print site, with a fallback to raw output if compact fails.

## Testing

- Updated 5 existing schema output tests to expect compact JSON
- `make test` passes (all packages)
- `make build` succeeds
- Smoke tested: `heygen video create --request-schema` outputs single-line JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)