### PR TITLE
fix(codegen): emit valid JSON Schema for nullable type arrays

### DIFF
--- a/codegen/schema.go
+++ b/codegen/schema.go
@@ -97,8 +97,12 @@ func resolveSchemaValue(schema *openapi3.Schema, seen map[string]bool) map[strin
 			resolved["items"] = resolveSchema(schema.Items, seen)
 		}
 	default:
-		if schemaType := schemaTypeName(schema); schemaType != "" {
-			resolved["type"] = schemaType
+		typeName, hasNull := schemaTypeName(schema)
+		if typeName != "" {
+			resolved["type"] = typeName
+		}
+		if hasNull {
+			resolved["nullable"] = true
 		}
 	}
 
@@ -174,15 +178,20 @@ func isNullSchema(ref *openapi3.SchemaRef) bool {
 	return ref != nil && ref.Value != nil && ref.Value.Type != nil && ref.Value.Type.Is("null")
 }
 
-func schemaTypeName(schema *openapi3.Schema) string {
+func schemaTypeName(schema *openapi3.Schema) (typeName string, hasNull bool) {
 	if schema == nil || schema.Type == nil {
-		return ""
+		return "", false
 	}
-	types := schema.Type.Slice()
-	if len(types) == 0 {
-		return ""
+	for _, t := range schema.Type.Slice() {
+		if t == "null" {
+			hasNull = true
+			continue
+		}
+		if typeName == "" {
+			typeName = t
+		}
 	}
-	return strings.Join(types, "|")
+	return typeName, hasNull
 }
 
 func schemaNameFromRef(ref string) string {

--- a/codegen/schema_test.go
+++ b/codegen/schema_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -86,6 +87,51 @@ func TestResolveSchema_NullableFields(t *testing.T) {
 	}
 	if got["description"] != "optional name" {
 		t.Fatalf("description = %v, want optional name", got["description"])
+	}
+}
+
+func TestResolveSchema_NullableTypeArray(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type:        &openapi3.Types{"string", "null"},
+		Description: "cursor token",
+	}
+
+	got := resolveSchema(openapi3.NewSchemaRef("", schema), map[string]bool{})
+
+	if got["type"] != "string" {
+		t.Fatalf("type = %v, want string", got["type"])
+	}
+	if got["nullable"] != true {
+		t.Fatalf("nullable = %v, want true", got["nullable"])
+	}
+	if got["description"] != "cursor token" {
+		t.Fatalf("description = %v, want cursor token", got["description"])
+	}
+}
+
+func TestResolveSchema_ObjectWithNullableTypeArrayField(t *testing.T) {
+	root := openapi3.NewObjectSchema().
+		WithProperty("has_more", openapi3.NewBoolSchema()).
+		WithRequired([]string{"has_more"})
+	root.Properties["next_token"] = openapi3.NewSchemaRef("", &openapi3.Schema{
+		Type:        &openapi3.Types{"string", "null"},
+		Description: "Opaque cursor for the next page",
+	})
+
+	got := resolveSchema(openapi3.NewSchemaRef("", root), map[string]bool{})
+	properties := got["properties"].(map[string]any)
+	nextToken := properties["next_token"].(map[string]any)
+
+	if nextToken["type"] != "string" {
+		t.Fatalf("next_token.type = %v, want string", nextToken["type"])
+	}
+	if nextToken["nullable"] != true {
+		t.Fatalf("next_token.nullable = %v, want true", nextToken["nullable"])
+	}
+
+	j := schemaJSON(openapi3.NewSchemaRef("", root))
+	if strings.Contains(j, "string|null") {
+		t.Fatalf("schemaJSON contains invalid 'string|null':\n%s", j)
 	}
 }
 

--- a/codegen/testdata/golden/widget.go
+++ b/codegen/testdata/golden/widget.go
@@ -141,7 +141,7 @@ var WidgetList = &command.Spec{
 	Name:           "list",
 	Summary:        "List widgets",
 	Description:    "",
-	ResponseSchema: "{\n  \"properties\": {\n    \"data\": {\n      \"items\": {\n        \"properties\": {},\n        \"required\": [],\n        \"type\": \"object\"\n      },\n      \"type\": \"array\"\n    },\n    \"has_more\": {\n      \"type\": \"boolean\"\n    },\n    \"next_token\": {\n      \"type\": \"string|null\"\n    }\n  },\n  \"required\": [],\n  \"type\": \"object\"\n}",
+	ResponseSchema: "{\n  \"properties\": {\n    \"data\": {\n      \"items\": {\n        \"properties\": {},\n        \"required\": [],\n        \"type\": \"object\"\n      },\n      \"type\": \"array\"\n    },\n    \"has_more\": {\n      \"type\": \"boolean\"\n    },\n    \"next_token\": {\n      \"nullable\": true,\n      \"type\": \"string\"\n    }\n  },\n  \"required\": [],\n  \"type\": \"object\"\n}",
 	Endpoint:       "/v3/widgets",
 	Method:         "GET",
 	BodyEncoding:   "",


### PR DESCRIPTION
## Description

`schemaTypeName()` in `codegen/schema.go` was joining multi-type arrays with `"|"`, producing invalid JSON Schema like `"type": "string|null"` in embedded response schemas. This affected all paginated list endpoints (`next_token` fields) and any other response field using OpenAPI 3.1's `type: ["string", "null"]` nullable syntax.

**Root cause:** OpenAPI 3.1 represents nullable fields as `"type": ["string", "null"]`. The `kin-openapi` library parses this into a `Types` slice. `schemaTypeName()` called `strings.Join(types, "|")` on that slice, producing `"string|null"` instead of valid JSON Schema.

**Fix:** `schemaTypeName()` now iterates the type slice, returns the first non-`"null"` type, and signals whether `"null"` was present. The caller in `resolveSchemaValue()` sets `"nullable": true` on the resolved map when the null flag is set.

**Before:** `"next_token": { "type": "string|null" }`
**After:** `"next_token": { "nullable": true, "type": "string" }`

Note: `gen/` files are not regenerated in this PR to keep the diff focused on the codegen fix. The next spec sync will pick up the corrected output.

Flagged by @jrusso1020 in [PR #114 review](https://github.com/heygen-com/heygen-cli/pull/114#pullrequestreview-2912858720).

## Testing

- New unit tests: `TestResolveSchema_NullableTypeArray` (primitive field) and `TestResolveSchema_ObjectWithNullableTypeArrayField` (nested object, asserts no `string|null` in schemaJSON output)
- Golden file updated: `widget.go` now emits `"nullable": true, "type": "string"` for `next_token`
- Full test suite passes (`go test ./...`)