### PR TITLE
docs: add /changelog skill for release notes generation

### DIFF
--- a/.claude/skills/changelog-cli/SKILL.md
+++ b/.claude/skills/changelog-cli/SKILL.md
@@ -17,28 +17,41 @@ the last stable tag.
 ```bash
 # Find the last stable tag
 LAST_STABLE=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-
-# Show commits since that tag
-git log "${LAST_STABLE}..origin/main" --oneline
 ```
 
-If no stable tag exists, use the full history (`git log --oneline`).
+If `LAST_STABLE` is empty (first stable release), use the full history by
+omitting the range:
 
-If a version argument was provided (e.g., `/changelog v0.0.6`), use it as the
-heading. Otherwise, infer the next version by bumping the patch of `$LAST_STABLE`.
+```bash
+# If LAST_STABLE is set:
+git log "${LAST_STABLE}..origin/main" --oneline
+
+# If LAST_STABLE is empty (first release):
+git log origin/main --oneline
+```
+
+If a version argument was provided (e.g., `/changelog-cli v0.0.6`), use it as
+the heading. Otherwise, infer the next version by bumping the patch of
+`$LAST_STABLE` (or use `v0.1.0` if no stable tag exists).
 
 ## Step 2: Read the full commit details
 
+Use the same range logic from Step 1 (with or without `$LAST_STABLE`):
+
 ```bash
+# With a previous stable tag:
 git log "${LAST_STABLE}..origin/main" --format="### %h%n%s%n%n%b%n---"
+
+# First release (no stable tag):
+git log origin/main --format="### %h%n%s%n%n%b%n---"
 ```
 
 Also read the PR descriptions for any merged PRs in the range to get richer
 context on what changed and why:
 
 ```bash
-# Extract PR numbers from commit messages
-git log "${LAST_STABLE}..origin/main" --oneline | grep -oP '#\K[0-9]+' | sort -u
+# Extract PR numbers from commit messages (works on both GNU and BSD grep)
+git log ${LAST_STABLE:+"${LAST_STABLE}.."}origin/main --oneline | grep -o '#[0-9]\+' | tr -d '#' | sort -u
 ```
 
 For each PR number, read the PR body:

--- a/.claude/skills/changelog-cli/SKILL.md
+++ b/.claude/skills/changelog-cli/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: changelog
+name: changelog-cli
 description: |
   Generate a user-facing changelog for the next stable release. Reads git log
   between the last stable tag and HEAD, categorizes changes, and outputs

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: changelog
+description: |
+  Generate a user-facing changelog for the next stable release. Reads git log
+  between the last stable tag and HEAD, categorizes changes, and outputs
+  formatted release notes. Use before triggering a stable release.
+argument-hint: "[version, e.g. v0.0.6]"
+---
+
+# Changelog Generator
+
+Generate release notes for a stable release by summarizing git commits since
+the last stable tag.
+
+## Step 1: Determine the range
+
+```bash
+# Find the last stable tag
+LAST_STABLE=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+
+# Show commits since that tag
+git log "${LAST_STABLE}..origin/main" --oneline
+```
+
+If no stable tag exists, use the full history (`git log --oneline`).
+
+If a version argument was provided (e.g., `/changelog v0.0.6`), use it as the
+heading. Otherwise, infer the next version by bumping the patch of `$LAST_STABLE`.
+
+## Step 2: Read the full commit details
+
+```bash
+git log "${LAST_STABLE}..origin/main" --format="### %h%n%s%n%n%b%n---"
+```
+
+Also read the PR descriptions for any merged PRs in the range to get richer
+context on what changed and why:
+
+```bash
+# Extract PR numbers from commit messages
+git log "${LAST_STABLE}..origin/main" --oneline | grep -oP '#\K[0-9]+' | sort -u
+```
+
+For each PR number, read the PR body:
+
+```bash
+gh pr view <number> --json title,body --jq '.title + "\n" + .body'
+```
+
+## Step 3: Categorize and write the changelog
+
+Group changes into these categories (omit empty categories):
+
+- **New** - new commands, features, or capabilities
+- **Improved** - enhancements to existing behavior
+- **Fixed** - bug fixes
+- **Internal** - codegen, CI, docs, refactors (collapsed, less detail)
+
+## Step 4: Format the output
+
+Output the changelog in this format:
+
+```markdown
+## <version> (<date>)
+
+### New
+- **Short title.** One-sentence description of what changed and why it matters. (#PR)
+
+### Improved
+- **Short title.** One-sentence description. (#PR)
+
+### Fixed
+- **Short title.** One-sentence description. (#PR)
+
+### Internal
+- Codegen resync from EF abcdef1 (#PR)
+- Updated CI workflow (#PR)
+```
+
+Rules:
+- Write for CLI users, not contributors. Focus on what changed from the user's
+  perspective, not implementation details.
+- Each entry should be one sentence. Lead with what the user can now do or what
+  was fixed, not what code changed.
+- Include the PR number in parentheses at the end of each entry.
+- Do not fabricate changes. Only include what is in the git log.
+- Collapse codegen resyncs, CI changes, and doc updates into the Internal section
+  with minimal detail.
+
+## Step 5: Present for review
+
+Print the formatted changelog and ask the releaser to confirm or edit before
+proceeding. Once confirmed, the releaser should paste it into the GitHub release
+notes when the release is published.

--- a/.claude/skills/e2e-cli-test/SKILL.md
+++ b/.claude/skills/e2e-cli-test/SKILL.md
@@ -77,6 +77,7 @@ sufficient data for meaningful get/detail coverage.
 ./bin/heygen video-agent videos list <session-id>
 ./bin/heygen video-translate get <id>          # .data[0].id from video-translate list
 ./bin/heygen lipsync get <id>                  # .data[0].id from lipsync list
+./bin/heygen voice get <voice-id>              # .data[0].voice_id from voice list
 ```
 
 For `video-agent resources get`: first run `./bin/heygen video-agent get <session-id>`,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,7 +49,7 @@ gh workflow run dev-release.yml
    ```bash
    gh release list --limit 3
    ```
-6. **Generate changelog.** Run `/changelog v0.x.y` in Claude Code. Review the output and save it for the release notes.
+6. **Generate changelog.** Run `/changelog-cli v0.x.y` in Claude Code. Review the output and save it for the release notes.
 
 ### Trigger the release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,7 @@ gh workflow run dev-release.yml
    ```bash
    gh release list --limit 3
    ```
+6. **Generate changelog.** Run `/changelog v0.x.y` in Claude Code. Review the output and save it for the release notes.
 
 ### Trigger the release
 


### PR DESCRIPTION
## Description

Adds a `/changelog` skill that generates user-facing release notes by reading git log between the last stable tag and HEAD. The skill:

- Determines the commit range automatically (last stable tag to origin/main)
- Reads full commit messages and PR descriptions for context
- Categorizes changes into New, Improved, Fixed, and Internal
- Outputs formatted markdown ready to paste into GitHub release notes
- Presents the draft for the releaser to review before use

No external LLM API keys needed. Claude generates the changelog directly since the releaser is already in Claude Code.

Also adds step 6 to the RELEASE.md pre-release checklist: "Generate changelog."

Stacked on #116 (e2e-cli-test skill).

## Testing

- Run `/changelog v0.0.6` from the repo root
- Confirm it reads commits since the last stable tag and produces categorized release notes
- Confirm it asks for review before finalizing

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>