### PR TITLE
errors: add hints for high-volume API error codes

### DIFF
--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -195,7 +195,7 @@ func (c *Client) executeWithContext(ctx context.Context, spec *command.Spec, inv
 		return nil, &clierrors.CLIError{
 			Code:     "network_error",
 			Message:  fmt.Sprintf("request failed: %v", err),
-			Hint:     "Check your internet connection. If HEYGEN_API_BASE is set, verify it is correct",
+			Hint:     "This is usually a temporary network issue. If it persists, check your connection",
 			ExitCode: clierrors.ExitGeneral,
 		}
 	}

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -195,6 +195,7 @@ func (c *Client) executeWithContext(ctx context.Context, spec *command.Spec, inv
 		return nil, &clierrors.CLIError{
 			Code:     "network_error",
 			Message:  fmt.Sprintf("request failed: %v", err),
+			Hint:     "Check your internet connection. If HEYGEN_API_BASE is set, verify it is correct",
 			ExitCode: clierrors.ExitGeneral,
 		}
 	}

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -245,6 +245,9 @@ func TestExecute_NetworkError(t *testing.T) {
 	if cliErr.Code != "network_error" {
 		t.Errorf("Code = %q, want %q", cliErr.Code, "network_error")
 	}
+	if cliErr.Hint == "" {
+		t.Error("Hint should be non-empty for network errors")
+	}
 }
 
 func TestExecute_RetryOn429(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -106,8 +106,8 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 		}
 	}
 
-	hint := hintForAPICode(code)
-	if code == "invalid_parameter" && apiErr.Param != nil && *apiErr.Param != "" {
+	hint := hintForAPICode(apiErr.Code)
+	if apiErr.Code == "invalid_parameter" && apiErr.Param != nil && *apiErr.Param != "" {
 		hint = fmt.Sprintf("Invalid field %q. %s", *apiErr.Param, hint)
 	}
 
@@ -125,11 +125,11 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 func hintForAPICode(code string) string {
 	switch code {
 	case "avatar_not_found":
-		return "List available avatars: heygen avatar list"
+		return "This avatar does not exist. Retrying the same ID is unlikely to help. List avatars: heygen avatar list"
 	case "video_not_found":
-		return "List your videos: heygen video list"
+		return "This resource does not exist. Retrying the same ID is unlikely to help. List your videos: heygen video list"
 	case "voice_not_found":
-		return "List available voices: heygen voice list"
+		return "This voice does not exist. Retrying the same ID is unlikely to help. List voices: heygen voice list"
 	case "insufficient_credit":
 		return "Check your credit balance: heygen user me get"
 	case "invalid_parameter":
@@ -137,7 +137,7 @@ func hintForAPICode(code string) string {
 	case "rate_limited":
 		return "The CLI retries rate-limited requests automatically. If this persists, reduce request frequency"
 	case "resource_not_found", "not_found":
-		return "The requested resource does not exist. Verify the ID is correct"
+		return "The requested resource does not exist. Retrying the same ID is unlikely to help"
 	case "asset_not_available":
 		return "The asset may still be processing or was deleted"
 	case "timeout":

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -107,6 +107,9 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 	}
 
 	hint := hintForAPICode(code)
+	if code == "invalid_parameter" && apiErr.Param != nil && *apiErr.Param != "" {
+		hint = fmt.Sprintf("Invalid field %q. %s", *apiErr.Param, hint)
+	}
 
 	return &CLIError{
 		Code:      code,
@@ -127,6 +130,18 @@ func hintForAPICode(code string) string {
 		return "List your videos: heygen video list"
 	case "voice_not_found":
 		return "List available voices: heygen voice list"
+	case "insufficient_credit":
+		return "Check your credit balance: heygen user me get\nBuy credits: https://app.heygen.com/settings/billing"
+	case "invalid_parameter":
+		return "Use --request-schema on the command to see expected fields"
+	case "rate_limited":
+		return "The CLI retries rate-limited requests automatically. If this persists, reduce request frequency"
+	case "resource_not_found", "not_found":
+		return "The requested resource does not exist. Verify the ID is correct"
+	case "asset_not_available":
+		return "The asset may still be processing or was deleted"
+	case "timeout":
+		return "The operation may still be in progress. Check status with the corresponding get command"
 	}
 	return ""
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -131,7 +131,7 @@ func hintForAPICode(code string) string {
 	case "voice_not_found":
 		return "List available voices: heygen voice list"
 	case "insufficient_credit":
-		return "Check your credit balance: heygen user me get\nBuy credits: https://app.heygen.com/settings/billing"
+		return "Check your credit balance: heygen user me get"
 	case "invalid_parameter":
 		return "Use --request-schema on the command to see expected fields"
 	case "rate_limited":

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -189,6 +189,15 @@ func TestHintForAPICode_AllMappedCodes(t *testing.T) {
 	}
 }
 
+func TestFromAPIError_Generic404_NoPermanenceHint(t *testing.T) {
+	apiErr := &APIError{Message: "not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if strings.Contains(cliErr.Hint, "unlikely to help") {
+		t.Errorf("Hint = %q, generic 404 without API code should not claim permanence", cliErr.Hint)
+	}
+}
+
 func TestFromAPIError_InvalidParam_WithParamName(t *testing.T) {
 	param := "avatar_id"
 	apiErr := &APIError{Code: "invalid_parameter", Message: "bad value", Param: &param}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -160,6 +160,60 @@ func TestFromAPIError_UnknownCode_NoHint(t *testing.T) {
 	}
 }
 
+func TestHintForAPICode_AllMappedCodes(t *testing.T) {
+	codes := []struct {
+		code         string
+		wantContains string
+	}{
+		{"avatar_not_found", "heygen avatar list"},
+		{"video_not_found", "heygen video list"},
+		{"voice_not_found", "heygen voice list"},
+		{"insufficient_credit", "heygen user me get"},
+		{"invalid_parameter", "--request-schema"},
+		{"rate_limited", "retries rate-limited"},
+		{"resource_not_found", "does not exist"},
+		{"not_found", "does not exist"},
+		{"asset_not_available", "may still be processing"},
+		{"timeout", "may still be in progress"},
+	}
+	for _, tt := range codes {
+		t.Run(tt.code, func(t *testing.T) {
+			hint := hintForAPICode(tt.code)
+			if hint == "" {
+				t.Fatalf("hintForAPICode(%q) returned empty", tt.code)
+			}
+			if !strings.Contains(hint, tt.wantContains) {
+				t.Errorf("hint = %q, want it to contain %q", hint, tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestFromAPIError_InvalidParam_WithParamName(t *testing.T) {
+	param := "avatar_id"
+	apiErr := &APIError{Code: "invalid_parameter", Message: "bad value", Param: &param}
+	cliErr := FromAPIError(400, apiErr, "")
+
+	if !strings.Contains(cliErr.Hint, "avatar_id") {
+		t.Errorf("Hint = %q, want param name in hint", cliErr.Hint)
+	}
+	if !strings.Contains(cliErr.Hint, "--request-schema") {
+		t.Errorf("Hint = %q, want --request-schema in hint", cliErr.Hint)
+	}
+}
+
+func TestFromAPIError_InvalidParam_NilParam(t *testing.T) {
+	apiErr := &APIError{Code: "invalid_parameter", Message: "bad value"}
+	cliErr := FromAPIError(400, apiErr, "")
+
+	if strings.Contains(cliErr.Hint, "Invalid field") {
+		t.Errorf("Hint = %q, should not mention field when param is nil", cliErr.Hint)
+	}
+	if !strings.Contains(cliErr.Hint, "--request-schema") {
+		t.Errorf("Hint = %q, want --request-schema in hint", cliErr.Hint)
+	}
+}
+
 func TestConstructors(t *testing.T) {
 	t.Run("New", func(t *testing.T) {
 		err := New("something broke")


### PR DESCRIPTION
## Description

PostHog analytics (Apr 21-27) showed that only 3 of ~20 API error codes had actionable
hints. The highest-volume unhinted codes: `invalid_parameter` (61 installs),
`insufficient_credit` (43), `network_error` (26), `timeout` (22). Users and agents hitting
these errors got no guidance on what to do next.

A separate finding showed a polling storm: a single install called `lipsync get` 5,429
times with a bad ID. Agents and scripts need a clear signal that not-found errors are
permanent so they stop retrying.

### New and updated hints

| Code | Hint |
|------|------|
| `video_not_found` | This resource does not exist. Retrying the same ID is unlikely to help. List your videos: `heygen video list` |
| `avatar_not_found` | This avatar does not exist. Retrying the same ID is unlikely to help. List avatars: `heygen avatar list` |
| `voice_not_found` | This voice does not exist. Retrying the same ID is unlikely to help. List voices: `heygen voice list` |
| `resource_not_found` / `not_found` | The requested resource does not exist. Retrying the same ID is unlikely to help |
| `insufficient_credit` | Check your credit balance: `heygen user me get` |
| `invalid_parameter` | Use `--request-schema` to see expected fields |
| `rate_limited` | CLI retries automatically; reduce frequency if persistent |
| `asset_not_available` | May still be processing or was deleted |
| `timeout` | May still be in progress; check with the corresponding get command |
| `network_error` | Usually a temporary network issue; check your connection if persistent |

When the API returns `invalid_parameter` with a `param` field, the hint is enriched
with the field name (e.g. `Invalid field "avatar_id". Use --request-schema...`).

### Hint lookup uses raw API code

Hints are looked up using the raw API error code, not the display code defaulted from
HTTP status. A generic 404 (empty API code) gets no hint because we can't confirm
permanence without a recognized code. This avoids claiming "retrying is unlikely to help"
when the CLI doesn't actually know why the 404 happened.

**Stacked on #123**

## Testing

- Table-driven `TestHintForAPICode_AllMappedCodes` verifies all 10 mapped codes
- `TestFromAPIError_Generic404_NoPermanenceHint`: empty API code 404 has no permanence language
- `TestFromAPIError_InvalidParam_WithParamName` / `_NilParam` for param enrichment
- `TestExecute_NetworkError` verifies non-empty hint on network errors
- `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)