### PR TITLE
errors: add retryable field to CLIError for machine consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Every command supports `--help`.
 | Aspect | Behavior |
 |--------|----------|
 | **stdout** | Always JSON. Even `video download` — binary writes to disk; stdout emits `{"asset", "message", "path"}` so you can chain on `.path`. |
-| **stderr** | Structured envelope on error: `{"error": {"code", "message", "hint", "retryable"}}`. Stable `code` values for programmatic branching. `retryable` is best-effort: `true` (transient), `false` (permanent), or omitted (unknown). |
+| **stderr** | Structured envelope on error: `{"error": {"code", "message", "hint", "retryable"}}`. Stable `code` values for programmatic branching. When present, `retryable` is definitive: `true` (transient), `false` (permanent). Omitted when unrecognized. |
 | **Exit codes** | `0` ok · `1` API or network · `2` usage · `3` auth · `4` timeout under `--wait` (stdout contains partial resource for resume) |
 | **Request bodies** | Flags for simple inputs; `-d` for nested JSON (inline, file path, or `-` for stdin). Flags override matching fields. |
 | **Async jobs** | `--wait` blocks with exponential backoff; `--timeout` sets max (default 20m). 429s and 5xx retry automatically. |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Every command supports `--help`.
 | Aspect | Behavior |
 |--------|----------|
 | **stdout** | Always JSON. Even `video download` — binary writes to disk; stdout emits `{"asset", "message", "path"}` so you can chain on `.path`. |
-| **stderr** | Structured envelope on error: `{"error": {"code", "message", "hint"}}`. Stable `code` values for programmatic branching. |
+| **stderr** | Structured envelope on error: `{"error": {"code", "message", "hint", "retryable"}}`. Stable `code` values for programmatic branching. `retryable` is best-effort: `true` (transient), `false` (permanent), or omitted (unknown). |
 | **Exit codes** | `0` ok · `1` API or network · `2` usage · `3` auth · `4` timeout under `--wait` (stdout contains partial resource for resume) |
 | **Request bodies** | Flags for simple inputs; `-d` for nested JSON (inline, file path, or `-` for stdin). Flags override matching fields. |
 | **Async jobs** | `--wait` blocks with exponential backoff; `--timeout` sets max (default 20m). 429s and 5xx retry automatically. |
@@ -125,7 +125,7 @@ Every command supports `--help`.
 Example error envelope:
 
 ```json
-{"error": {"code": "not_found", "message": "Video not found", "hint": "Check ID with: heygen video list"}}
+{"error": {"code": "not_found", "message": "Video not found", "hint": "Check ID with: heygen video list", "retryable": false}}
 ```
 
 ## Configuration

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,7 +69,11 @@ heygen video get --response-schema
 ## Output Contract
 
 - **stdout**: JSON (always). This is the only output agents should consume.
-- **stderr**: JSON error envelope on failure: `{"error":{"code":"...","message":"...","hint":"..."}}`
+- **stderr**: JSON error envelope on failure: `{"error":{"code":"...","message":"...","hint":"...","retryable":true|false}}`
+  - `retryable` is **best-effort guidance** (not an API guarantee):
+    - `true`: transient, same request may succeed later (429, 5xx, network errors, timeouts)
+    - `false`: permanent, retrying the same request won't help (not-found, auth errors, insufficient credit)
+    - omitted: unknown or context-dependent. Treat as "do not retry automatically"
 - Do not pass `--human`. It produces unstructured text that cannot be parsed.
 
 ## Notes

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,10 +70,10 @@ heygen video get --response-schema
 
 - **stdout**: JSON (always). This is the only output agents should consume.
 - **stderr**: JSON error envelope on failure: `{"error":{"code":"...","message":"...","hint":"...","retryable":true|false}}`
-  - `retryable` is **best-effort guidance** (not an API guarantee). Branch on `retryable`, not on `code`:
+  - `retryable`: when present, definitively classifies the error. When omitted, the CLI lacks enough context to classify it. Branch on `retryable`, not on `code`:
     - `true`: transient, same request may succeed later (429, 5xx, network errors)
-    - `false`: permanent, retrying the same request won't help (not-found with known code, auth errors, insufficient credit, `--wait` timeouts where the create already succeeded)
-    - omitted: unknown or context-dependent. Treat as "do not retry automatically"
+    - `false`: permanent, retrying the same request won't help (not-found with known code, auth errors, insufficient credit)
+    - omitted: unrecognized error code or ambiguous context. Treat as "do not retry automatically"
   - `code: "timeout"` appears in multiple contexts with different `retryable` values. Always use the `retryable` field, not the code, to decide whether to retry.
 - Do not pass `--human`. It produces unstructured text that cannot be parsed.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,10 +70,11 @@ heygen video get --response-schema
 
 - **stdout**: JSON (always). This is the only output agents should consume.
 - **stderr**: JSON error envelope on failure: `{"error":{"code":"...","message":"...","hint":"...","retryable":true|false}}`
-  - `retryable` is **best-effort guidance** (not an API guarantee):
-    - `true`: transient, same request may succeed later (429, 5xx, network errors, timeouts)
-    - `false`: permanent, retrying the same request won't help (not-found, auth errors, insufficient credit)
+  - `retryable` is **best-effort guidance** (not an API guarantee). Branch on `retryable`, not on `code`:
+    - `true`: transient, same request may succeed later (429, 5xx, network errors)
+    - `false`: permanent, retrying the same request won't help (not-found with known code, auth errors, insufficient credit, `--wait` timeouts where the create already succeeded)
     - omitted: unknown or context-dependent. Treat as "do not retry automatically"
+  - `code: "timeout"` appears in multiple contexts with different `retryable` values. Always use the `retryable` field, not the code, to decide whether to retry.
 - Do not pass `--human`. It produces unstructured text that cannot be parsed.
 
 ## Notes

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -165,13 +165,11 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 							if pc.HintCommand != "" {
 								hint = fmt.Sprintf("heygen %s %s", pc.HintCommand, timeoutErr.ResourceID)
 							}
-							notRetryable := false
 							return &clierrors.CLIError{
-								Code:      "timeout",
-								Message:   fmt.Sprintf("still processing after --wait of %s (not failed, just not done yet)", timeout),
-								Hint:      hint,
-								ExitCode:  clierrors.ExitTimeout,
-								Retryable: &notRetryable,
+								Code:     "timeout",
+								Message:  fmt.Sprintf("still processing after --wait of %s (not failed, just not done yet)", timeout),
+								Hint:     hint,
+								ExitCode: clierrors.ExitTimeout,
 							}
 						}
 						var failErr *client.ErrPollFailed

--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -165,11 +165,13 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 							if pc.HintCommand != "" {
 								hint = fmt.Sprintf("heygen %s %s", pc.HintCommand, timeoutErr.ResourceID)
 							}
+							notRetryable := false
 							return &clierrors.CLIError{
-								Code:     "timeout",
-								Message:  fmt.Sprintf("still processing after --wait of %s (not failed, just not done yet)", timeout),
-								Hint:     hint,
-								ExitCode: clierrors.ExitTimeout,
+								Code:      "timeout",
+								Message:   fmt.Sprintf("still processing after --wait of %s (not failed, just not done yet)", timeout),
+								Hint:      hint,
+								ExitCode:  clierrors.ExitTimeout,
+								Retryable: &notRetryable,
 							}
 						}
 						var failErr *client.ErrPollFailed

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -80,7 +80,7 @@ Exit Codes:
 
 Error Envelope (stderr on failure):
   {"error": {"code": "...", "message": "...", "hint": "...", "retryable": true|false}}
-  retryable is best-effort: true (transient), false (permanent), or omitted (unknown).
+  When present, retryable is definitive. true (transient), false (permanent), omitted (unrecognized).
   Branch on retryable, not on specific code values.
 
 Tip: Use --request-schema on any command to see the expected JSON input fields.

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -78,6 +78,11 @@ Exit Codes:
   3   Authentication error (missing or invalid API key)
   4   Timeout (resource created but operation not yet complete)
 
+Error Envelope (stderr on failure):
+  {"error": {"code": "...", "message": "...", "hint": "...", "retryable": true|false}}
+  retryable is best-effort: true (transient), false (permanent), or omitted (unknown).
+  Branch on retryable, not on specific code values.
+
 Tip: Use --request-schema on any command to see the expected JSON input fields.
 Use "heygen update" to check for and install newer versions.
 `)

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -192,11 +192,13 @@ func (c *Client) executeWithContext(ctx context.Context, spec *command.Spec, inv
 
 	resp, err := c.Do(req)
 	if err != nil {
+		retryable := true
 		return nil, &clierrors.CLIError{
-			Code:     "network_error",
-			Message:  fmt.Sprintf("request failed: %v", err),
-			Hint:     "This is usually a temporary network issue. If it persists, check your connection",
-			ExitCode: clierrors.ExitGeneral,
+			Code:      "network_error",
+			Message:   fmt.Sprintf("request failed: %v", err),
+			Hint:      "This is usually a temporary network issue. If it persists, check your connection",
+			ExitCode:  clierrors.ExitGeneral,
+			Retryable: &retryable,
 		}
 	}
 	defer resp.Body.Close()

--- a/internal/client/executor_test.go
+++ b/internal/client/executor_test.go
@@ -248,6 +248,9 @@ func TestExecute_NetworkError(t *testing.T) {
 	if cliErr.Hint == "" {
 		t.Error("Hint should be non-empty for network errors")
 	}
+	if cliErr.Retryable == nil || !*cliErr.Retryable {
+		t.Error("Retryable should be true for network errors")
+	}
 }
 
 func TestExecute_RetryOn429(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -19,7 +19,7 @@ type CLIError struct {
 	Hint      string // actionable fix: "Run heygen auth login"
 	RequestID string // from API X-Request-Id header (if applicable)
 	ExitCode  int    // process exit code (0/1/2/3/4)
-	Retryable *bool  // nil=unknown, true=transient, false=permanent (best-effort guidance)
+	Retryable *bool  // nil=unrecognized, true=transient, false=permanent
 }
 
 // Error implements the error interface.
@@ -126,12 +126,12 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 	}
 }
 
-// retryableForError returns best-effort retry guidance based on error code,
+// retryableForError classifies retry behavior based on error code,
 // HTTP status, and exit code. Code-based classification takes priority;
 // HTTP status is the fallback.
-//   - false: known permanent (wrong ID, expired key, insufficient funds)
-//   - true: known transient (rate limit, server error, timeout)
-//   - nil: unknown or context-dependent
+//   - false: permanent (wrong ID, expired key, insufficient funds)
+//   - true: transient (rate limit, server error, timeout)
+//   - nil: unrecognized code or ambiguous context
 func retryableForError(code string, statusCode int, exitCode int) *bool {
 	switch code {
 	case "video_not_found", "avatar_not_found", "voice_not_found",

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -111,8 +111,8 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 		}
 	}
 
-	hint := hintForAPICode(code)
-	if code == "invalid_parameter" && apiErr.Param != nil && *apiErr.Param != "" {
+	hint := hintForAPICode(apiErr.Code)
+	if apiErr.Code == "invalid_parameter" && apiErr.Param != nil && *apiErr.Param != "" {
 		hint = fmt.Sprintf("Invalid field %q. %s", *apiErr.Param, hint)
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -19,6 +19,7 @@ type CLIError struct {
 	Hint      string // actionable fix: "Run heygen auth login"
 	RequestID string // from API X-Request-Id header (if applicable)
 	ExitCode  int    // process exit code (0/1/2/3/4)
+	Retryable *bool  // nil=unknown, true=transient, false=permanent (best-effort guidance)
 }
 
 // Error implements the error interface.
@@ -41,6 +42,9 @@ func (e *CLIError) ToErrorEnvelope() map[string]any {
 	}
 	if e.RequestID != "" {
 		inner["request_id"] = e.RequestID
+	}
+	if e.Retryable != nil {
+		inner["retryable"] = *e.Retryable
 	}
 	return map[string]any{"error": inner}
 }
@@ -117,19 +121,48 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 		Hint:      hint,
 		RequestID: requestID,
 		ExitCode:  exitCode,
+		Retryable: retryableForError(code, statusCode, exitCode),
 	}
 }
+
+// retryableForError returns best-effort retry guidance based on error code,
+// HTTP status, and exit code. Code-based classification takes priority;
+// HTTP status is the fallback.
+//   - false: known permanent (wrong ID, expired key, insufficient funds)
+//   - true: known transient (rate limit, server error, timeout)
+//   - nil: unknown or context-dependent
+func retryableForError(code string, statusCode int, exitCode int) *bool {
+	switch code {
+	case "video_not_found", "avatar_not_found", "voice_not_found",
+		"resource_not_found", "not_found", "insufficient_credit":
+		return boolPtr(false)
+	case "rate_limited", "timeout":
+		return boolPtr(true)
+	}
+	if exitCode == ExitAuth {
+		return boolPtr(false)
+	}
+	switch {
+	case statusCode == 429:
+		return boolPtr(true)
+	case statusCode >= 500:
+		return boolPtr(true)
+	}
+	return nil
+}
+
+func boolPtr(b bool) *bool { return &b }
 
 // hintForAPICode returns a CLI-specific actionable hint for known API error
 // codes. Returns "" if the code has no associated hint.
 func hintForAPICode(code string) string {
 	switch code {
 	case "avatar_not_found":
-		return "List available avatars: heygen avatar list"
+		return "This avatar does not exist. Retrying the same ID is unlikely to help. List avatars: heygen avatar list"
 	case "video_not_found":
-		return "List your videos: heygen video list"
+		return "This resource does not exist. Retrying the same ID is unlikely to help. List your videos: heygen video list"
 	case "voice_not_found":
-		return "List available voices: heygen voice list"
+		return "This voice does not exist. Retrying the same ID is unlikely to help. List voices: heygen voice list"
 	case "insufficient_credit":
 		return "Check your credit balance: heygen user me get"
 	case "invalid_parameter":
@@ -137,7 +170,7 @@ func hintForAPICode(code string) string {
 	case "rate_limited":
 		return "The CLI retries rate-limited requests automatically. If this persists, reduce request frequency"
 	case "resource_not_found", "not_found":
-		return "The requested resource does not exist. Verify the ID is correct"
+		return "The requested resource does not exist. Retrying the same ID is unlikely to help"
 	case "asset_not_available":
 		return "The asset may still be processing or was deleted"
 	case "timeout":

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -61,10 +61,11 @@ func New(message string) *CLIError {
 // NewAuth creates a CLIError with ExitAuth.
 func NewAuth(message, hint string) *CLIError {
 	return &CLIError{
-		Code:     "auth_error",
-		Message:  message,
-		Hint:     hint,
-		ExitCode: ExitAuth,
+		Code:      "auth_error",
+		Message:   message,
+		Hint:      hint,
+		ExitCode:  ExitAuth,
+		Retryable: boolPtr(false),
 	}
 }
 
@@ -121,7 +122,7 @@ func FromAPIError(statusCode int, apiErr *APIError, requestID string) *CLIError 
 		Hint:      hint,
 		RequestID: requestID,
 		ExitCode:  exitCode,
-		Retryable: retryableForError(code, statusCode, exitCode),
+		Retryable: retryableForError(apiErr.Code, statusCode, exitCode),
 	}
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -79,6 +79,9 @@ func TestCLIError_ToErrorEnvelope_OmitsEmpty(t *testing.T) {
 	if _, ok := inner["request_id"]; ok {
 		t.Error("request_id should be omitted when empty")
 	}
+	if _, ok := inner["retryable"]; ok {
+		t.Error("retryable should be omitted when nil")
+	}
 }
 
 func TestFromAPIError_ExitCodes(t *testing.T) {
@@ -211,6 +214,99 @@ func TestFromAPIError_InvalidParam_NilParam(t *testing.T) {
 	}
 	if !strings.Contains(cliErr.Hint, "--request-schema") {
 		t.Errorf("Hint = %q, want --request-schema in hint", cliErr.Hint)
+	}
+}
+
+func TestFromAPIError_KnownPermanentCode_NotRetryable(t *testing.T) {
+	apiErr := &APIError{Code: "video_not_found", Message: "video not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if cliErr.Retryable == nil {
+		t.Fatal("Retryable should be non-nil for video_not_found")
+	}
+	if *cliErr.Retryable != false {
+		t.Errorf("Retryable = %v, want false", *cliErr.Retryable)
+	}
+}
+
+func TestFromAPIError_500_Retryable(t *testing.T) {
+	apiErr := &APIError{Message: "internal server error"}
+	cliErr := FromAPIError(500, apiErr, "")
+
+	if cliErr.Retryable == nil {
+		t.Fatal("Retryable should be non-nil for 500")
+	}
+	if *cliErr.Retryable != true {
+		t.Errorf("Retryable = %v, want true", *cliErr.Retryable)
+	}
+}
+
+func TestFromAPIError_429_Retryable(t *testing.T) {
+	apiErr := &APIError{Message: "too many requests"}
+	cliErr := FromAPIError(429, apiErr, "")
+
+	if cliErr.Retryable == nil {
+		t.Fatal("Retryable should be non-nil for 429")
+	}
+	if *cliErr.Retryable != true {
+		t.Errorf("Retryable = %v, want true", *cliErr.Retryable)
+	}
+}
+
+func TestFromAPIError_400_RetryableNil(t *testing.T) {
+	apiErr := &APIError{Code: "validation_error", Message: "bad request"}
+	cliErr := FromAPIError(400, apiErr, "")
+
+	if cliErr.Retryable != nil {
+		t.Errorf("Retryable = %v, want nil for generic 400", *cliErr.Retryable)
+	}
+}
+
+func TestFromAPIError_404_UnknownCode_RetryableNil(t *testing.T) {
+	apiErr := &APIError{Code: "something_unusual", Message: "not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if cliErr.Retryable != nil {
+		t.Errorf("Retryable = %v, want nil for unknown 404 code", *cliErr.Retryable)
+	}
+}
+
+func TestFromAPIError_AuthError_NotRetryable(t *testing.T) {
+	apiErr := &APIError{Code: "forbidden", Message: "access denied"}
+	cliErr := FromAPIError(403, apiErr, "")
+
+	if cliErr.Retryable == nil {
+		t.Fatal("Retryable should be non-nil for auth errors")
+	}
+	if *cliErr.Retryable != false {
+		t.Errorf("Retryable = %v, want false for auth errors", *cliErr.Retryable)
+	}
+}
+
+func TestToErrorEnvelope_IncludesRetryable(t *testing.T) {
+	retryable := false
+	err := &CLIError{Code: "video_not_found", Message: "not found", Retryable: &retryable}
+	envelope := err.ToErrorEnvelope()
+
+	data, marshalErr := json.Marshal(envelope)
+	if marshalErr != nil {
+		t.Fatalf("failed to marshal envelope: %v", marshalErr)
+	}
+	if !strings.Contains(string(data), `"retryable":false`) {
+		t.Errorf("envelope = %s, want retryable:false", string(data))
+	}
+}
+
+func TestToErrorEnvelope_OmitsRetryableWhenNil(t *testing.T) {
+	err := &CLIError{Code: "error", Message: "fail"}
+	envelope := err.ToErrorEnvelope()
+
+	data, marshalErr := json.Marshal(envelope)
+	if marshalErr != nil {
+		t.Fatalf("failed to marshal envelope: %v", marshalErr)
+	}
+	if strings.Contains(string(data), "retryable") {
+		t.Errorf("envelope = %s, should not contain retryable when nil", string(data))
 	}
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -278,6 +278,9 @@ func TestFromAPIError_GenericEmpty404_RetryableNil(t *testing.T) {
 	if cliErr.Retryable != nil {
 		t.Errorf("Retryable = %v, want nil for generic 404 without API code", *cliErr.Retryable)
 	}
+	if strings.Contains(cliErr.Hint, "unlikely to help") {
+		t.Errorf("Hint = %q, generic 404 should not contain permanence language", cliErr.Hint)
+	}
 }
 
 func TestFromAPIError_AuthError_NotRetryable(t *testing.T) {

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -271,6 +271,15 @@ func TestFromAPIError_404_UnknownCode_RetryableNil(t *testing.T) {
 	}
 }
 
+func TestFromAPIError_GenericEmpty404_RetryableNil(t *testing.T) {
+	apiErr := &APIError{Message: "not found"}
+	cliErr := FromAPIError(404, apiErr, "")
+
+	if cliErr.Retryable != nil {
+		t.Errorf("Retryable = %v, want nil for generic 404 without API code", *cliErr.Retryable)
+	}
+}
+
 func TestFromAPIError_AuthError_NotRetryable(t *testing.T) {
 	apiErr := &APIError{Code: "forbidden", Message: "access denied"}
 	cliErr := FromAPIError(403, apiErr, "")
@@ -325,6 +334,9 @@ func TestConstructors(t *testing.T) {
 		}
 		if err.Hint != "set HEYGEN_API_KEY" {
 			t.Errorf("Hint = %q, want expected value", err.Hint)
+		}
+		if err.Retryable == nil || *err.Retryable != false {
+			t.Errorf("Retryable = %v, want false for auth errors", err.Retryable)
 		}
 	})
 


### PR DESCRIPTION
## Description

PostHog analytics (Apr 21-27) revealed a polling storm pattern: a single install called
`lipsync get` 5,429 times with a bad ID. The CLI's built-in `--wait` polling has backoff,
but external scripts and LLM agents retrying not-found errors had no signal that these
errors are permanent.

This PR adds a `retryable` field to the error JSON envelope. It is best-effort tri-state
guidance for machine consumers:

- **`true`**: transient; same request may succeed later (429, 5xx, network errors)
- **`false`**: permanent; retrying won't help without changing input (known not-found codes, auth errors, insufficient credit)
- **omitted**: unknown or context-dependent (generic 404 without recognized API code, validation errors, `--wait` timeouts, request deadline timeouts)

Classification is code-based first, HTTP status as fallback. A generic 404 without a
recognized API error code returns `retryable: nil` (unknown), not `false`.

### Hint and retryable consistency

Both hints and retryable use the raw API error code (`apiErr.Code`), not the display code
defaulted from HTTP status. This ensures the three user-facing surfaces (code, hint, retryable)
tell one story:

- Explicit `not_found` from API: permanence hint + `retryable: false`
- Generic 404 (empty API code): no hint + `retryable: nil`
- `asset_not_available`: "may still be processing" + `retryable: nil`

### Timeout semantics

`code: "timeout"` appears in three contexts with different `retryable` values:
- API timeout error code: `retryable: true` (server-side operation still processing)
- `--wait` CLI timeout: `retryable: nil` (create succeeded but poll timed out; whether to re-poll or re-create depends on caller context)
- Request deadline exceeded: `retryable: nil` (unknown whether server received request)

SKILL.md documents that agents should branch on `retryable`, not `code == "timeout"`.

### Discoverability

The error envelope shape and retryable semantics are now documented in:
- `heygen --help` (Error Envelope section): agents discover this on first use
- `SKILL.md`: the full agent-facing contract
- `README.md`: user-facing docs

```json
{"error": {"code": "video_not_found", "message": "...", "hint": "...", "retryable": false}}
```

`retryable` is omitted entirely when unknown.

**Stacked on #124**

## Testing

- Retryable classification: permanent codes -> false, 500/429 -> true, unknown 404 -> nil, generic empty 404 -> nil + no permanence hint, auth -> false
- Envelope JSON shape: includes `retryable` when set, omits when nil
- `NewAuth` constructor sets `retryable: false`
- Network error sets `retryable: true`
- `make test` passes (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)