### PR TITLE
docs: link skills repo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Full reference and examples: **[developers.heygen.com/cli](https://developers.he
 - **Bulk operations** — translate 100 videos in one shell loop
 - **Custom integrations** — wrap it in your own tool
 
+**See it in action:** [heygen-com/skills](https://github.com/heygen-com/skills) — one-line install for Claude Code, Codex, and other agents. Create your own avatar and generate a video in a single conversation.
+
 ## Agent-first by design
 
 - **JSON on stdout, structured errors on stderr, stable exit codes.**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Full reference and examples: **[developers.heygen.com/cli](https://developers.he
 - **Bulk operations** — translate 100 videos in one shell loop
 - **Custom integrations** — wrap it in your own tool
 
-**See it in action:** [heygen-com/skills](https://github.com/heygen-com/skills) — one-line install for Claude Code, Codex, and other agents. Create your own avatar and generate a video in a single conversation.
+## Agent skills
+
+[heygen-com/skills](https://github.com/heygen-com/skills) — one-line install for Claude Code, Codex, and other agents. Create your own avatar and generate a video in a single conversation.
 
 ## Agent-first by design
 


### PR DESCRIPTION
## Description

Adds a link to [heygen-com/skills](https://github.com/heygen-com/skills) in the README, right after the "Built for" section. The skills repo wraps the CLI into one-line installable agent skills (avatar creation, video generation), and linking it shows what the CLI can do in practice rather than just listing API surface.

## Testing

Visual-only change. Verified the link target and markdown rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>