### PR TITLE
fix: add billing link to insufficient_credit error hint

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -131,7 +131,7 @@ func hintForAPICode(code string) string {
 	case "voice_not_found":
 		return "This voice does not exist. Retrying the same ID is unlikely to help. List voices: heygen voice list"
 	case "insufficient_credit":
-		return "Check your credit balance: heygen user me get"
+		return "Check your credit balance: heygen user me get. Purchase API credits: https://app.heygen.com/settings?nav=API"
 	case "invalid_parameter":
 		return "Use --request-schema on the command to see expected fields"
 	case "rate_limited":


### PR DESCRIPTION
## Description

Users hitting `insufficient_credit` errors only saw "Check your credit balance: heygen user me get", with no guidance on where to actually purchase more credits. This adds a direct link to the API credits settings page (`https://app.heygen.com/settings?nav=API`) so users can resolve the issue without hunting through the HeyGen UI.

Discovered via PostHog error analysis: `insufficient_credit` on `video-agent create` was the #1 revenue-blocking error this week (48 distinct installs).

## Testing

- `go test ./internal/errors/ -run TestHintForAPICode` passes (test uses `Contains` assertion, so the appended URL doesn't break it)
- No other tests reference this hint string

🤖 Generated with [Claude Code](https://claude.com/claude-code)