### PR TITLE
auth: read JSON credential format (read-side backwards compat)

### DIFF
--- a/internal/auth/file_resolver.go
+++ b/internal/auth/file_resolver.go
@@ -1,20 +1,56 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/paths"
 )
 
+// jsonCredentials is the on-disk format hyperframes-CLI (and future
+// heygen-cli releases) write to ~/.heygen/credentials. Mirror the
+// shape used by packages/cli/src/auth/store.ts in hyperframes-oss.
+type jsonCredentials struct {
+	APIKey string           `json:"api_key,omitempty"`
+	OAuth  *jsonOAuthTokens `json:"oauth,omitempty"`
+}
+
+type jsonOAuthTokens struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	// ExpiresAt is ISO-8601 UTC. The hyperframes resolver allows a 60s
+	// skew; we use the same here so behavior matches across CLIs.
+	ExpiresAt string `json:"expires_at,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	TokenType string `json:"token_type,omitempty"`
+}
+
+const oauthExpirySkew = 60 * time.Second
+
 // FileCredentialResolver reads the API key from the credentials file.
 type FileCredentialResolver struct{}
 
-// Resolve returns the API key from the credentials file, classifying
-// "not found" separately from broken file states.
+// Resolve returns a credential string from the shared credentials file.
+//
+// The on-disk format may be either:
+//
+//	1. The new JSON layout: `{ "api_key": "...", "oauth": { ... } }`
+//	   produced by hyperframes-CLI's `auth login`. When both fields
+//	   are present, an unexpired `oauth.access_token` wins; otherwise
+//	   the `api_key` is returned.
+//	2. The legacy single-line plaintext API key (what heygen-cli has
+//	   written historically). Kept readable so existing users don't
+//	   lose their session on upgrade.
+//
+// Future direction: when heygen-cli starts speaking OAuth at the HTTP
+// layer, this function should return a typed credential so the
+// client can pick the right header (Bearer vs x-api-key). For now,
+// callers continue to treat the returned string as opaque.
 func (r *FileCredentialResolver) Resolve() (string, error) {
 	path := filepath.Join(paths.ConfigDir(), "credentials")
 	data, err := os.ReadFile(path)
@@ -25,10 +61,71 @@ func (r *FileCredentialResolver) Resolve() (string, error) {
 		return "", fmt.Errorf("cannot read credentials file %s: %w", path, err)
 	}
 
-	key := strings.TrimSpace(string(data))
-	if key == "" {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
 		return "", fmt.Errorf("credentials file %s is empty", path)
 	}
 
-	return key, nil
+	if isJSONObject(trimmed) {
+		return resolveFromJSON(trimmed, path, time.Now())
+	}
+
+	// Legacy plaintext: anything single-line non-empty. The new format
+	// rejects garbage more strictly, but for the read-side we stay
+	// permissive — hyperframes-CLI's tightening lives on the write side.
+	if strings.ContainsAny(trimmed, "\r\n") {
+		return "", fmt.Errorf("credentials file %s is malformed (multi-line, expected JSON or a single-line key)", path)
+	}
+	return trimmed, nil
+}
+
+func isJSONObject(s string) bool {
+	return len(s) > 0 && s[0] == '{'
+}
+
+// resolveFromJSON parses the new shape and picks the right credential.
+// Errors that come out of here are typed as plain `error` (not
+// ErrNotConfigured) — a parseable-but-content-less file is broken
+// state, not "absent", and the chain resolver should surface it.
+func resolveFromJSON(text, path string, now time.Time) (string, error) {
+	var parsed jsonCredentials
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		return "", fmt.Errorf("credentials file %s contains invalid JSON: %w", path, err)
+	}
+
+	// Prefer OAuth when its access_token is present and unexpired.
+	// Expired-but-refreshable tokens stay unused here — refresh logic
+	// lives in hyperframes-CLI. heygen-cli sees only the persisted
+	// pair and treats expired access_tokens as 'not usable' so the
+	// api_key (if any) wins instead.
+	if parsed.OAuth != nil && parsed.OAuth.AccessToken != "" {
+		if !isOAuthExpired(parsed.OAuth, now) {
+			return parsed.OAuth.AccessToken, nil
+		}
+	}
+
+	if parsed.APIKey != "" {
+		return parsed.APIKey, nil
+	}
+
+	return "", fmt.Errorf("credentials file %s has no usable credential (oauth expired and no api_key)", path)
+}
+
+func isOAuthExpired(t *jsonOAuthTokens, now time.Time) bool {
+	if t.ExpiresAt == "" {
+		// No expiry stored — treat as fresh (we have no basis to
+		// declare it expired).
+		return false
+	}
+	expiry, err := time.Parse(time.RFC3339Nano, t.ExpiresAt)
+	if err != nil {
+		// Loose ISO-8601 fallback: try plain RFC3339.
+		expiry, err = time.Parse(time.RFC3339, t.ExpiresAt)
+		if err != nil {
+			// Unparseable expires_at — be conservative and treat as
+			// fresh; the server will reject if it's actually dead.
+			return false
+		}
+	}
+	return expiry.Add(-oauthExpirySkew).Before(now)
 }

--- a/internal/auth/file_resolver_test.go
+++ b/internal/auth/file_resolver_test.go
@@ -5,16 +5,29 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/paths"
 )
 
-func TestFileCredentialResolver_ReadsKey(t *testing.T) {
-	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	path := filepath.Join(paths.ConfigDir(), "credentials")
-	if err := os.WriteFile(path, []byte("test-key-123\n"), 0o600); err != nil {
+func writeCredentials(t *testing.T, contents string) string {
+	t.Helper()
+	dir := paths.ConfigDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(dir, "credentials")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+	return path
+}
+
+// --- legacy plaintext ------------------------------------------------------
+
+func TestFileCredentialResolver_ReadsKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeCredentials(t, "test-key-123\n")
 
 	r := &FileCredentialResolver{}
 	key, err := r.Resolve()
@@ -43,10 +56,7 @@ func TestFileCredentialResolver_MissingFile(t *testing.T) {
 
 func TestFileCredentialResolver_EmptyFile(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	path := filepath.Join(paths.ConfigDir(), "credentials")
-	if err := os.WriteFile(path, []byte(" \n"), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	writeCredentials(t, " \n")
 
 	r := &FileCredentialResolver{}
 	_, err := r.Resolve()
@@ -57,10 +67,7 @@ func TestFileCredentialResolver_EmptyFile(t *testing.T) {
 
 func TestFileCredentialResolver_WhitespaceHandling(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	path := filepath.Join(paths.ConfigDir(), "credentials")
-	if err := os.WriteFile(path, []byte("test-key-123  \n"), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	writeCredentials(t, "test-key-123  \n")
 
 	r := &FileCredentialResolver{}
 	key, err := r.Resolve()
@@ -69,5 +76,163 @@ func TestFileCredentialResolver_WhitespaceHandling(t *testing.T) {
 	}
 	if key != "test-key-123" {
 		t.Fatalf("key = %q, want %q", key, "test-key-123")
+	}
+}
+
+// --- new JSON format -------------------------------------------------------
+
+func TestFileCredentialResolver_JSON_APIKeyOnly(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeCredentials(t, `{"api_key":"hg_json_abc"}`)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if key != "hg_json_abc" {
+		t.Fatalf("key = %q, want hg_json_abc", key)
+	}
+}
+
+func TestFileCredentialResolver_JSON_OAuthOnly_Fresh(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	writeCredentials(t, `{"oauth":{"access_token":"fresh_at","expires_at":"`+future+`"}}`)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if key != "fresh_at" {
+		t.Fatalf("key = %q, want fresh_at", key)
+	}
+}
+
+func TestFileCredentialResolver_JSON_BothFreshOAuthWins(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	writeCredentials(t, `{"api_key":"hg_fallback","oauth":{"access_token":"fresh_at","expires_at":"`+future+`"}}`)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if key != "fresh_at" {
+		t.Fatalf("key = %q, want fresh_at (oauth should win)", key)
+	}
+}
+
+func TestFileCredentialResolver_JSON_ExpiredOAuthFallsThroughToAPIKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	writeCredentials(t, `{"api_key":"hg_fallback","oauth":{"access_token":"stale_at","expires_at":"`+past+`"}}`)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if key != "hg_fallback" {
+		t.Fatalf("key = %q, want hg_fallback (expired oauth should not be used)", key)
+	}
+}
+
+func TestFileCredentialResolver_JSON_ExpiredOAuthNoAPIKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	writeCredentials(t, `{"oauth":{"access_token":"stale_at","expires_at":"`+past+`"}}`)
+
+	r := &FileCredentialResolver{}
+	_, err := r.Resolve()
+	if err == nil {
+		t.Fatal("expected error when only expired oauth is present")
+	}
+}
+
+func TestFileCredentialResolver_JSON_OAuthWithoutExpiresAtIsAccepted(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	// No expires_at field — be lenient and trust the token. The server
+	// will reject if it's actually dead.
+	writeCredentials(t, `{"oauth":{"access_token":"at_no_expiry"}}`)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if key != "at_no_expiry" {
+		t.Fatalf("key = %q, want at_no_expiry", key)
+	}
+}
+
+func TestFileCredentialResolver_JSON_InvalidJSON(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeCredentials(t, `{this is not valid JSON`)
+
+	r := &FileCredentialResolver{}
+	_, err := r.Resolve()
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+
+	// Must NOT be ErrNotConfigured — a broken file is a hard error.
+	var notConfigured *ErrNotConfigured
+	if errors.As(err, &notConfigured) {
+		t.Fatalf("invalid JSON should not surface as ErrNotConfigured, got %T", err)
+	}
+}
+
+func TestFileCredentialResolver_JSON_EmptyObject(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeCredentials(t, `{}`)
+
+	r := &FileCredentialResolver{}
+	_, err := r.Resolve()
+	if err == nil {
+		t.Fatal("expected error when JSON has no credential fields")
+	}
+}
+
+func TestFileCredentialResolver_MultiLineNonJSONIsRejected(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeCredentials(t, "line1\nline2\nline3")
+
+	r := &FileCredentialResolver{}
+	_, err := r.Resolve()
+	if err == nil {
+		t.Fatal("expected error on multi-line non-JSON garbage")
+	}
+}
+
+func TestFileCredentialResolver_JSON_UnparseableExpiresAt(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeCredentials(t, `{"oauth":{"access_token":"at","expires_at":"not-a-date"}}`)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// Unparseable expiry is treated as 'fresh' rather than failing —
+	// the server is the source of truth for token validity.
+	if key != "at" {
+		t.Fatalf("key = %q, want at", key)
+	}
+}
+
+func TestFileCredentialResolver_JSON_DropsUnknownFields(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	writeCredentials(t, `{"api_key":"hg_x","future_field":{"nested":true}}`)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if key != "hg_x" {
+		t.Fatalf("key = %q, want hg_x", key)
 	}
 }


### PR DESCRIPTION
## Description

Teach heygen-cli's `FileCredentialResolver` to read the new JSON
credentials format that hyperframes-CLI writes, while staying fully
backwards-compatible with the legacy single-line plaintext file.

The shared file at `~/.heygen/credentials` may now contain either:

1. **JSON layout** (new):
   ```json
   {
     "api_key": "hg_...",
     "oauth": {
       "access_token": "...",
       "refresh_token": "...",
       "expires_at": "2026-06-25T12:00:00Z"
     }
   }
   ```
   Unexpired `oauth.access_token` wins over `api_key`; expired
   OAuth falls through to `api_key` (heygen-cli doesn't refresh
   today — that lives in hyperframes-CLI).
2. **Legacy plaintext** (single-line API key): kept readable so
   existing users don't lose their session.

The public `FileCredentialResolver.Resolve() (string, error)`
signature is unchanged — callers continue to treat the returned
string as opaque. When heygen-cli gains a Bearer-aware HTTP client,
the resolver can be expanded to return a typed credential.

Implementation notes:

- JSON detection is `trimmed[0] == '{'` — anything else routes to
  the legacy path.
- A 60s expiry skew matches the hyperframes-CLI resolver
  (`packages/cli/src/auth/resolver.ts`) so both CLIs agree on
  staleness.
- Unparseable `expires_at` is treated as fresh — the server is the
  source of truth for token validity.
- Unknown JSON fields are silently dropped (forward compat).
- Multi-line non-JSON garbage is rejected explicitly (previously
  would have been returned as a "credential").

## Testing

- 15 unit tests in `internal/auth/file_resolver_test.go` (4 legacy
  cases preserved, 11 new JSON cases): api_key only, oauth only
  fresh, both-fresh-oauth-wins, expired-oauth-fallback, expired-
  no-api-key error, no-expires_at lenient, invalid JSON, empty
  object, multi-line garbage rejected, unparseable expires_at,
  unknown-field drop.
- `go test ./internal/auth/...` clean.
- `go vet ./internal/auth/...` clean.
- Manual smoke (recommended pre-merge): `hyperframes auth login --api-key`
  on the prior hyperframes PR, then `heygen video list --limit 1`
  in this build — both CLIs share the same file with no extra
  setup.

Pre-existing test failure on `main` (`TestVideoList_AuthMissing`)
is unrelated to this PR — verified by running on a clean
`origin/main` checkout.