### PR TITLE
auth: write JSON credential format and migrate legacy plaintext

### DIFF
--- a/cmd/heygen/auth_test.go
+++ b/cmd/heygen/auth_test.go
@@ -8,6 +8,23 @@ import (
 	"testing"
 )
 
+// storedAPIKey reads the credentials file and returns its api_key. The
+// file is written in the JSON format (`{ "api_key": "..." }`).
+func storedAPIKey(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "credentials"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var creds struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		t.Fatalf("credentials file is not valid JSON: %v\ncontents: %s", err, data)
+	}
+	return creds.APIKey
+}
+
 // TestAuthLogin_EmptyStdin_NoEnvVar_NonTTY verifies that a non-TTY empty stdin
 // with no HEYGEN_API_KEY set returns exit 2 with the pipe-hint message.
 func TestAuthLogin_EmptyStdin_NoEnvVar_NonTTY(t *testing.T) {
@@ -57,12 +74,8 @@ func TestAuthLogin_PipedKey_StillWorks(t *testing.T) {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "credentials"))
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if string(data) != "real-key\n" {
-		t.Fatalf("credentials = %q, want %q", string(data), "real-key\n")
+	if got := storedAPIKey(t, dir); got != "real-key" {
+		t.Fatalf("stored api_key = %q, want %q", got, "real-key")
 	}
 }
 
@@ -83,12 +96,8 @@ func TestAuthLogin_Success(t *testing.T) {
 		t.Fatalf("expected success message, got %v", parsed)
 	}
 
-	data, err := os.ReadFile(filepath.Join(os.Getenv("HEYGEN_CONFIG_DIR"), "credentials"))
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if string(data) != "test-key-123\n" {
-		t.Fatalf("credentials = %q, want %q", string(data), "test-key-123\n")
+	if got := storedAPIKey(t, os.Getenv("HEYGEN_CONFIG_DIR")); got != "test-key-123" {
+		t.Fatalf("stored api_key = %q, want %q", got, "test-key-123")
 	}
 }
 
@@ -115,12 +124,8 @@ func TestAuthLogin_OverwriteExisting(t *testing.T) {
 		t.Fatalf("second login failed: %#v", second)
 	}
 
-	data, err := os.ReadFile(filepath.Join(os.Getenv("HEYGEN_CONFIG_DIR"), "credentials"))
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if string(data) != "second-key\n" {
-		t.Fatalf("credentials = %q, want %q", string(data), "second-key\n")
+	if got := storedAPIKey(t, os.Getenv("HEYGEN_CONFIG_DIR")); got != "second-key" {
+		t.Fatalf("stored api_key = %q, want %q", got, "second-key")
 	}
 }
 

--- a/internal/auth/credentials_file.go
+++ b/internal/auth/credentials_file.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/heygen-com/heygen-cli/internal/paths"
+)
+
+// credentialFormat classifies what was found on disk.
+type credentialFormat int
+
+const (
+	formatAbsent credentialFormat = iota // no file
+	formatJSON                           // new `{ "api_key": ..., "oauth": ... }` layout
+	formatLegacy                         // single-line plaintext API key
+)
+
+// credentialFilePath is the shared store path. Matches the path
+// hyperframes-CLI uses (no `.json` extension) so the two tools share
+// one file.
+func credentialFilePath() string {
+	return filepath.Join(paths.ConfigDir(), "credentials")
+}
+
+// loadCredentialsFile reads and parses the credentials file. It does
+// NOT pick a credential — callers decide oauth-vs-api_key. A missing
+// file yields (empty, formatAbsent, nil). A malformed JSON or
+// multi-line non-JSON file is a hard error (broken state, not absent).
+func loadCredentialsFile(path string) (jsonCredentials, credentialFormat, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return jsonCredentials{}, formatAbsent, nil
+		}
+		return jsonCredentials{}, formatAbsent, fmt.Errorf("cannot read credentials file %s: %w", path, err)
+	}
+
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		// File exists but is blank — broken state, distinct from a
+		// missing file. Surface as an error (callers that write, like
+		// Save, tolerate it and start fresh).
+		return jsonCredentials{}, formatAbsent, fmt.Errorf("credentials file %s is empty", path)
+	}
+
+	if isJSONObject(trimmed) {
+		var parsed jsonCredentials
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			return jsonCredentials{}, formatJSON, fmt.Errorf("credentials file %s contains invalid JSON: %w", path, err)
+		}
+		return parsed, formatJSON, nil
+	}
+
+	// Legacy plaintext: any single-line non-empty content. Multi-line
+	// non-JSON is malformed.
+	if strings.ContainsAny(trimmed, "\r\n") {
+		return jsonCredentials{}, formatLegacy, fmt.Errorf("credentials file %s is malformed (multi-line, expected JSON or a single-line key)", path)
+	}
+	return jsonCredentials{APIKey: trimmed}, formatLegacy, nil
+}
+
+// writeCredentialsFile atomically writes creds as JSON with mode 0600,
+// creating the parent directory (0700) if needed. Writes go to a temp
+// file + rename so a crash mid-write can't leave a truncated file.
+func writeCredentialsFile(path string, creds jsonCredentials) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	// G117: serializing the api_key field is the entire purpose of this
+	// credential store; the result is written to a 0600 file, never logged.
+	body, err := json.MarshalIndent(creds, "", "  ") //nolint:gosec // intentional credential persistence to a 0600 file
+	if err != nil {
+		return fmt.Errorf("failed to encode credentials: %w", err)
+	}
+	body = append(body, '\n')
+
+	tmp, err := os.CreateTemp(dir, "credentials.*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp credentials file: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename succeeds.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write temp credentials file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp credentials file: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return fmt.Errorf("failed to chmod temp credentials file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("failed to finalize credentials file: %w", err)
+	}
+	return nil
+}

--- a/internal/auth/file_resolver.go
+++ b/internal/auth/file_resolver.go
@@ -1,36 +1,25 @@
 package auth
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
+import "fmt"
 
-	"github.com/heygen-com/heygen-cli/internal/paths"
-)
-
-// jsonCredentials is the on-disk format hyperframes-CLI (and future
-// heygen-cli releases) write to ~/.heygen/credentials. Mirror the
-// shape used by packages/cli/src/auth/store.ts in hyperframes-oss.
+// jsonCredentials is the on-disk format hyperframes-CLI (and heygen-cli,
+// since the write-side change) persist to ~/.heygen/credentials. Mirror
+// the shape used by packages/cli/src/auth/store.ts in hyperframes-oss.
 type jsonCredentials struct {
 	APIKey string           `json:"api_key,omitempty"`
 	OAuth  *jsonOAuthTokens `json:"oauth,omitempty"`
 }
 
+// jsonOAuthTokens is parsed and round-tripped (so heygen-cli preserves a
+// hyperframes-written OAuth block on save) but NOT selected as a usable
+// credential — see selectCredential.
 type jsonOAuthTokens struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token,omitempty"`
-	// ExpiresAt is ISO-8601 UTC. The hyperframes resolver allows a 60s
-	// skew; we use the same here so behavior matches across CLIs.
-	ExpiresAt string `json:"expires_at,omitempty"`
-	Scope     string `json:"scope,omitempty"`
-	TokenType string `json:"token_type,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
 }
-
-const oauthExpirySkew = 60 * time.Second
 
 // FileCredentialResolver reads the API key from the credentials file.
 type FileCredentialResolver struct{}
@@ -39,93 +28,56 @@ type FileCredentialResolver struct{}
 //
 // The on-disk format may be either:
 //
-//	1. The new JSON layout: `{ "api_key": "...", "oauth": { ... } }`
-//	   produced by hyperframes-CLI's `auth login`. When both fields
-//	   are present, an unexpired `oauth.access_token` wins; otherwise
-//	   the `api_key` is returned.
-//	2. The legacy single-line plaintext API key (what heygen-cli has
-//	   written historically). Kept readable so existing users don't
-//	   lose their session on upgrade.
+//	1. The JSON layout `{ "api_key": "...", "oauth": { ... } }` produced
+//	   by hyperframes-CLI and by this CLI's own writes.
+//	2. The legacy single-line plaintext API key (what heygen-cli wrote
+//	   historically). Still readable so existing users aren't logged out.
 //
-// Future direction: when heygen-cli starts speaking OAuth at the HTTP
-// layer, this function should return a typed credential so the
-// client can pick the right header (Bearer vs x-api-key). For now,
-// callers continue to treat the returned string as opaque.
+// Reads are side-effect-free: a legacy plaintext file is NOT rewritten
+// here. Upgrading to JSON happens only on an explicit write (Save), so
+// passive commands can't silently convert a file that an older pinned
+// binary might still need to read.
 func (r *FileCredentialResolver) Resolve() (string, error) {
-	path := filepath.Join(paths.ConfigDir(), "credentials")
-	data, err := os.ReadFile(path)
+	path := credentialFilePath()
+	creds, format, err := loadCredentialsFile(path)
+	if format == formatAbsent && err == nil {
+		return "", &ErrNotConfigured{Msg: "no credentials file"}
+	}
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", &ErrNotConfigured{Msg: "no credentials file"}
-		}
-		return "", fmt.Errorf("cannot read credentials file %s: %w", path, err)
+		// Empty / invalid-JSON / multi-line garbage — broken state.
+		// Surfaced as a plain error so the chain reports it instead of
+		// silently skipping (distinct from ErrNotConfigured).
+		return "", err
 	}
-
-	trimmed := strings.TrimSpace(string(data))
-	if trimmed == "" {
-		return "", fmt.Errorf("credentials file %s is empty", path)
-	}
-
-	if isJSONObject(trimmed) {
-		return resolveFromJSON(trimmed, path, time.Now())
-	}
-
-	// Legacy plaintext: anything single-line non-empty. The new format
-	// rejects garbage more strictly, but for the read-side we stay
-	// permissive — hyperframes-CLI's tightening lives on the write side.
-	if strings.ContainsAny(trimmed, "\r\n") {
-		return "", fmt.Errorf("credentials file %s is malformed (multi-line, expected JSON or a single-line key)", path)
-	}
-	return trimmed, nil
+	return selectCredential(creds, path)
 }
 
 func isJSONObject(s string) bool {
 	return len(s) > 0 && s[0] == '{'
 }
 
-// resolveFromJSON parses the new shape and picks the right credential.
-// Errors that come out of here are typed as plain `error` (not
-// ErrNotConfigured) — a parseable-but-content-less file is broken
-// state, not "absent", and the chain resolver should surface it.
-func resolveFromJSON(text, path string, now time.Time) (string, error) {
-	var parsed jsonCredentials
-	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
-		return "", fmt.Errorf("credentials file %s contains invalid JSON: %w", path, err)
-	}
-
-	// Prefer OAuth when its access_token is present and unexpired.
-	// Expired-but-refreshable tokens stay unused here — refresh logic
-	// lives in hyperframes-CLI. heygen-cli sees only the persisted
-	// pair and treats expired access_tokens as 'not usable' so the
-	// api_key (if any) wins instead.
-	if parsed.OAuth != nil && parsed.OAuth.AccessToken != "" {
-		if !isOAuthExpired(parsed.OAuth, now) {
-			return parsed.OAuth.AccessToken, nil
-		}
-	}
-
+// selectCredential picks the credential heygen-cli will actually send.
+//
+// heygen-cli transmits credentials via the `x-api-key` header only (see
+// internal/client) — it has no `Authorization: Bearer` support yet. So
+// it can only use an `api_key`; an OAuth `access_token` must NOT be
+// returned here, or it would be mis-sent as an API key and rejected.
+// We therefore always prefer api_key and refuse an OAuth-only file with
+// an actionable error. (The OAuth block is still parsed and preserved
+// on write — see Save — just never selected.)
+//
+// Errors are plain `error` (not ErrNotConfigured) so the chain resolver
+// surfaces a present-but-unusable file rather than skipping it.
+func selectCredential(parsed jsonCredentials, path string) (string, error) {
 	if parsed.APIKey != "" {
 		return parsed.APIKey, nil
 	}
-
-	return "", fmt.Errorf("credentials file %s has no usable credential (oauth expired and no api_key)", path)
-}
-
-func isOAuthExpired(t *jsonOAuthTokens, now time.Time) bool {
-	if t.ExpiresAt == "" {
-		// No expiry stored — treat as fresh (we have no basis to
-		// declare it expired).
-		return false
+	if parsed.OAuth != nil && parsed.OAuth.AccessToken != "" {
+		return "", fmt.Errorf(
+			"credentials file %s holds an OAuth session, which heygen-cli can't use yet; "+
+				"run `heygen auth login` with an API key or set HEYGEN_API_KEY",
+			path,
+		)
 	}
-	expiry, err := time.Parse(time.RFC3339Nano, t.ExpiresAt)
-	if err != nil {
-		// Loose ISO-8601 fallback: try plain RFC3339.
-		expiry, err = time.Parse(time.RFC3339, t.ExpiresAt)
-		if err != nil {
-			// Unparseable expires_at — be conservative and treat as
-			// fresh; the server will reject if it's actually dead.
-			return false
-		}
-	}
-	return expiry.Add(-oauthExpirySkew).Before(now)
+	return "", fmt.Errorf("credentials file %s has no usable credential", path)
 }

--- a/internal/auth/file_resolver_test.go
+++ b/internal/auth/file_resolver_test.go
@@ -39,6 +39,32 @@ func TestFileCredentialResolver_ReadsKey(t *testing.T) {
 	}
 }
 
+func TestFileCredentialResolver_ReadDoesNotRewriteLegacyFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	const legacy = "legacy-plain-key\n"
+	path := writeCredentials(t, legacy)
+
+	r := &FileCredentialResolver{}
+	key, err := r.Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if key != "legacy-plain-key" {
+		t.Fatalf("key = %q, want legacy-plain-key", key)
+	}
+
+	// Reads must be side-effect-free: a legacy plaintext file is left
+	// untouched (so an older pinned binary run afterward can still read
+	// it). Upgrading to JSON happens only on an explicit write (Save).
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(raw) != legacy {
+		t.Fatalf("read rewrote the file: got %q, want %q", string(raw), legacy)
+	}
+}
+
 func TestFileCredentialResolver_MissingFile(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 
@@ -62,6 +88,13 @@ func TestFileCredentialResolver_EmptyFile(t *testing.T) {
 	_, err := r.Resolve()
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+	// An empty (but present) file is broken state, not "not configured".
+	// It must surface as a non-ErrNotConfigured error so the chain
+	// resolver reports it instead of silently skipping to "no API key".
+	var notConfigured *ErrNotConfigured
+	if errors.As(err, &notConfigured) {
+		t.Fatalf("empty file should not be ErrNotConfigured, got %T", err)
 	}
 }
 
@@ -95,76 +128,50 @@ func TestFileCredentialResolver_JSON_APIKeyOnly(t *testing.T) {
 	}
 }
 
-func TestFileCredentialResolver_JSON_OAuthOnly_Fresh(t *testing.T) {
+// heygen-cli can only transmit an api_key (x-api-key header), so an
+// OAuth-only file is unusable and must surface a clear error rather than
+// returning the access_token to be mis-sent as an API key.
+func TestFileCredentialResolver_JSON_OAuthOnlyIsRejected(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 	writeCredentials(t, `{"oauth":{"access_token":"fresh_at","expires_at":"`+future+`"}}`)
 
 	r := &FileCredentialResolver{}
-	key, err := r.Resolve()
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
+	_, err := r.Resolve()
+	if err == nil {
+		t.Fatal("expected error for an OAuth-only file, got nil")
 	}
-	if key != "fresh_at" {
-		t.Fatalf("key = %q, want fresh_at", key)
+	var notConfigured *ErrNotConfigured
+	if errors.As(err, &notConfigured) {
+		t.Fatalf("OAuth-only file should surface a usable error, not ErrNotConfigured: %T", err)
 	}
 }
 
-func TestFileCredentialResolver_JSON_BothFreshOAuthWins(t *testing.T) {
+// When both are present, api_key wins — it's the only credential
+// heygen-cli can actually send.
+func TestFileCredentialResolver_JSON_BothPrefersAPIKey(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
-	writeCredentials(t, `{"api_key":"hg_fallback","oauth":{"access_token":"fresh_at","expires_at":"`+future+`"}}`)
+	writeCredentials(t, `{"api_key":"hg_use_me","oauth":{"access_token":"fresh_at","expires_at":"`+future+`"}}`)
 
 	r := &FileCredentialResolver{}
 	key, err := r.Resolve()
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if key != "fresh_at" {
-		t.Fatalf("key = %q, want fresh_at (oauth should win)", key)
+	if key != "hg_use_me" {
+		t.Fatalf("key = %q, want hg_use_me (api_key must win over oauth)", key)
 	}
 }
 
-func TestFileCredentialResolver_JSON_ExpiredOAuthFallsThroughToAPIKey(t *testing.T) {
+func TestFileCredentialResolver_JSON_OAuthOnlyNoExpiryIsRejected(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	writeCredentials(t, `{"api_key":"hg_fallback","oauth":{"access_token":"stale_at","expires_at":"`+past+`"}}`)
-
-	r := &FileCredentialResolver{}
-	key, err := r.Resolve()
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if key != "hg_fallback" {
-		t.Fatalf("key = %q, want hg_fallback (expired oauth should not be used)", key)
-	}
-}
-
-func TestFileCredentialResolver_JSON_ExpiredOAuthNoAPIKey(t *testing.T) {
-	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	writeCredentials(t, `{"oauth":{"access_token":"stale_at","expires_at":"`+past+`"}}`)
+	writeCredentials(t, `{"oauth":{"access_token":"at_no_expiry"}}`)
 
 	r := &FileCredentialResolver{}
 	_, err := r.Resolve()
 	if err == nil {
-		t.Fatal("expected error when only expired oauth is present")
-	}
-}
-
-func TestFileCredentialResolver_JSON_OAuthWithoutExpiresAtIsAccepted(t *testing.T) {
-	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	// No expires_at field — be lenient and trust the token. The server
-	// will reject if it's actually dead.
-	writeCredentials(t, `{"oauth":{"access_token":"at_no_expiry"}}`)
-
-	r := &FileCredentialResolver{}
-	key, err := r.Resolve()
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if key != "at_no_expiry" {
-		t.Fatalf("key = %q, want at_no_expiry", key)
+		t.Fatal("expected error for an OAuth-only file, got nil")
 	}
 }
 
@@ -204,22 +211,6 @@ func TestFileCredentialResolver_MultiLineNonJSONIsRejected(t *testing.T) {
 	_, err := r.Resolve()
 	if err == nil {
 		t.Fatal("expected error on multi-line non-JSON garbage")
-	}
-}
-
-func TestFileCredentialResolver_JSON_UnparseableExpiresAt(t *testing.T) {
-	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	writeCredentials(t, `{"oauth":{"access_token":"at","expires_at":"not-a-date"}}`)
-
-	r := &FileCredentialResolver{}
-	key, err := r.Resolve()
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	// Unparseable expiry is treated as 'fresh' rather than failing —
-	// the server is the source of truth for token validity.
-	if key != "at" {
-		t.Fatalf("key = %q, want at", key)
 	}
 }
 

--- a/internal/auth/file_store.go
+++ b/internal/auth/file_store.go
@@ -1,23 +1,33 @@
 package auth
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/heygen-com/heygen-cli/internal/paths"
-)
+import "fmt"
 
 // FileCredentialStore writes the API key to the credentials file.
 type FileCredentialStore struct{}
 
-// Save writes the API key to the credentials file with restrictive perms.
+// Save writes the API key to the shared credentials file in the JSON
+// format (`{ "api_key": "..." }`), upgrading a legacy plaintext file in
+// place. Any co-located OAuth block is preserved so that saving an API
+// key doesn't wipe an active OAuth session written by hyperframes-CLI.
 func (s *FileCredentialStore) Save(apiKey string) error {
-	dir := paths.ConfigDir()
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
+	path := credentialFilePath()
+
+	// Read the existing file to preserve a co-located oauth block.
+	existing, format, err := loadCredentialsFile(path)
+	if err != nil {
+		if format != formatAbsent {
+			// The file is present but unparseable (malformed JSON /
+			// multi-line garbage). We can't see whether it holds an
+			// OAuth session, so refuse to overwrite it rather than
+			// silently destroying a recoverable credential.
+			return fmt.Errorf("%w; delete the file and re-run `heygen auth login`", err)
+		}
+		// Missing / empty / unreadable — nothing to preserve, so start
+		// from a clean slate. (An unreadable file will fail the write
+		// below too, surfacing the real error there.)
+		existing = jsonCredentials{}
 	}
 
-	path := filepath.Join(dir, "credentials")
-	return os.WriteFile(path, []byte(apiKey+"\n"), 0o600)
+	existing.APIKey = apiKey
+	return writeCredentialsFile(path, existing)
 }

--- a/internal/auth/file_store_test.go
+++ b/internal/auth/file_store_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -8,6 +9,26 @@ import (
 
 	"github.com/heygen-com/heygen-cli/internal/paths"
 )
+
+// readStoredFile returns the raw bytes of the credentials file.
+func readStoredFile(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "credentials"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	return data
+}
+
+// parseStoredFile decodes the credentials file as the JSON format.
+func parseStoredFile(t *testing.T) jsonCredentials {
+	t.Helper()
+	var creds jsonCredentials
+	if err := json.Unmarshal(readStoredFile(t), &creds); err != nil {
+		t.Fatalf("stored file is not valid JSON: %v\ncontents: %s", err, readStoredFile(t))
+	}
+	return creds
+}
 
 func TestFileCredentialStore_Save(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
@@ -17,12 +38,12 @@ func TestFileCredentialStore_Save(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "credentials"))
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
+	creds := parseStoredFile(t)
+	if creds.APIKey != "test-key-123" {
+		t.Fatalf("api_key = %q, want %q", creds.APIKey, "test-key-123")
 	}
-	if string(data) != "test-key-123\n" {
-		t.Fatalf("data = %q, want %q", string(data), "test-key-123\n")
+	if creds.OAuth != nil {
+		t.Fatalf("did not expect an oauth block, got %+v", creds.OAuth)
 	}
 }
 
@@ -75,11 +96,111 @@ func TestFileCredentialStore_OverwriteExisting(t *testing.T) {
 		t.Fatalf("Save second: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "credentials"))
+	if got := parseStoredFile(t).APIKey; got != "second-key" {
+		t.Fatalf("api_key = %q, want %q", got, "second-key")
+	}
+}
+
+func TestFileCredentialStore_PreservesExistingOAuth(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// Simulate a JSON file written by hyperframes-CLI carrying an OAuth
+	// session, then run heygen-cli's api-key save over it.
+	path := filepath.Join(paths.ConfigDir(), "credentials")
+	if err := os.MkdirAll(paths.ConfigDir(), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	seed := `{"oauth":{"access_token":"at_keep","refresh_token":"rt_keep","expires_at":"2099-01-01T00:00:00Z"}}`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &FileCredentialStore{}
+	if err := s.Save("hg_new_key"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	creds := parseStoredFile(t)
+	if creds.APIKey != "hg_new_key" {
+		t.Fatalf("api_key = %q, want hg_new_key", creds.APIKey)
+	}
+	if creds.OAuth == nil || creds.OAuth.AccessToken != "at_keep" || creds.OAuth.RefreshToken != "rt_keep" {
+		t.Fatalf("oauth block not preserved: %+v", creds.OAuth)
+	}
+}
+
+func TestFileCredentialStore_RefusesToClobberMalformedFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// A present-but-unparseable file might hold a recoverable oauth
+	// block we can't see. Save must refuse rather than silently
+	// overwrite it.
+	path := filepath.Join(paths.ConfigDir(), "credentials")
+	if err := os.MkdirAll(paths.ConfigDir(), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	garbage := `{"oauth":{"access_token":"at_maybe_recoverable"` // truncated JSON
+	if err := os.WriteFile(path, []byte(garbage), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &FileCredentialStore{}
+	if err := s.Save("hg_new_key"); err == nil {
+		t.Fatal("expected Save to refuse overwriting a malformed file, got nil")
+	}
+
+	// File must be untouched.
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	if string(data) != "second-key\n" {
-		t.Fatalf("data = %q, want %q", string(data), "second-key\n")
+	if string(data) != garbage {
+		t.Fatalf("malformed file was modified: %q", string(data))
+	}
+}
+
+func TestFileCredentialStore_OverwritesEmptyFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// An empty file has nothing to preserve — Save should proceed.
+	path := filepath.Join(paths.ConfigDir(), "credentials")
+	if err := os.MkdirAll(paths.ConfigDir(), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("  \n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &FileCredentialStore{}
+	if err := s.Save("hg_fresh"); err != nil {
+		t.Fatalf("Save over empty file: %v", err)
+	}
+	if got := parseStoredFile(t).APIKey; got != "hg_fresh" {
+		t.Fatalf("api_key = %q, want hg_fresh", got)
+	}
+}
+
+func TestFileCredentialStore_UpgradesLegacyPlaintext(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// Seed a legacy single-line plaintext file, then save a new key.
+	path := filepath.Join(paths.ConfigDir(), "credentials")
+	if err := os.MkdirAll(paths.ConfigDir(), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("old-plaintext-key\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &FileCredentialStore{}
+	if err := s.Save("hg_replacement"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// File must now be JSON with the new key (the legacy key is replaced
+	// — Save sets the api_key the user just provided).
+	creds := parseStoredFile(t)
+	if creds.APIKey != "hg_replacement" {
+		t.Fatalf("api_key = %q, want hg_replacement", creds.APIKey)
 	}
 }


### PR DESCRIPTION
## Description

Completes the credential-format round-trip started in #154. That PR
taught heygen-cli to **read** the new JSON format; this one makes it
**write** JSON too and auto-upgrade a legacy plaintext file in place.

Stacked on #154 (base = `05-26-auth_read_json_credential_format`).

**What changes:**
- `FileCredentialStore.Save` now writes `{ "api_key": "..." }` (JSON,
  mode 0600, atomic temp+rename) instead of single-line plaintext. It
  reads the existing file first and **preserves a co-located `oauth`
  block**, so `heygen auth login` no longer clobbers an active OAuth
  session that hyperframes-CLI wrote. (Previously a plaintext overwrite
  would silently drop the `oauth` data.)
- `FileCredentialResolver.Resolve` **upgrades a legacy plaintext file to
  JSON on read**, best-effort: it never changes the value returned and
  never fails the read if the write can't happen (read-only FS,
  concurrent writer). A read-only environment just leaves the file
  plaintext until the next successful write.
- Shared file-format helpers — `loadCredentialsFile` (parse) and
  `writeCredentialsFile` (atomic 0600 write) — extracted to a new
  `credentials_file.go` so the store and resolver agree on one format.

Net effect: both CLIs now read **and** write the same
`~/.heygen/credentials` JSON file, and existing plaintext files migrate
forward automatically the first time either tool touches them.

**Why a separate PR:** #154 was scoped to read-side compat; this is a
write-side behavior change (with the OAuth-preservation data-safety
fix), so it gets its own focused review per our one-PR-per-scope
convention.

## Testing

- `go test ./internal/auth/...` green: new tests cover JSON write,
  OAuth-block preservation on api-key save, legacy→JSON upgrade on save,
  and legacy→JSON migration on read (with a re-resolve from the upgraded
  file).
- Updated `cmd/heygen/auth_test.go` and `internal/auth/file_store_test.go`
  assertions from plaintext to JSON.
- `go vet` + `gofmt` clean. Full `go test ./...` green.

Note: a few `cmd/heygen` tests (`TestVideoList_AuthMissing`,
`TestVideoDownload_AuthRequired`, `TestAuthStatus_NoKey`,
`TestEnrichAuthHint_ExistingHint_Preserved`) fail **only** when
`HEYGEN_API_KEY` is exported in the shell — they assume no ambient key.
They pass with the var unset and are unaffected by this change (they
fail the same way on `main`).