### PR TITLE
feat: add deprecated command alias framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,19 @@ Generated commands are pure data. To add behavior on top:
 
 **Custom commands** (not in the API spec) — add a new file in `cmd/heygen/` and register in `root.go`. See `video_download.go` for an example.
 
+**Deprecated aliases** (backward compatibility after a spec-driven rename) — register in `cmd/heygen/aliases.go`. Command names are derived from the upstream OpenAPI spec, so an upstream tag or path change can rename a command that already shipped in a stable release. An `Alias` re-registers the canonical `Spec` at its old path, hidden from help and marked deprecated, so the old invocation still resolves to the same handler while a stderr notice points to the new name:
+
+```go
+var DeprecatedAliases = []Alias{
+    {
+        OldParentPath: []string{"brand-kit"}, // old "heygen brand-kit list"
+        Spec:          gen.BrandKitsList,     // canonical "heygen brand kits list"
+        NewPath:       "brand kits list",
+        RemoveBy:      "v0.2.0",
+    },
+}
+```
+
 ## Git Conventions
 
 See [.github/GIT_CONVENTIONS.md](.github/GIT_CONVENTIONS.md) for branch names, commit messages, and PR title format.

--- a/cmd/heygen/aliases.go
+++ b/cmd/heygen/aliases.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/heygen-com/heygen-cli/internal/command"
+	"github.com/spf13/cobra"
+)
+
+// Alias re-registers a previously shipped command path that a spec-driven
+// rename has since moved, so existing scripts keep working.
+//
+// The command tree is derived from the OpenAPI spec, and that spec is owned
+// upstream (experiment-framework). When a tag or path changes upstream, the
+// generated command name changes with it. An Alias points the old invocation
+// at the canonical command's Spec, registering it hidden and deprecated: the
+// old path still resolves to the exact same handler, while a deprecation
+// notice nudges callers to the new name.
+//
+// Aliases are hand-maintained here, not in gen/, because they encode naming
+// history that the current spec has no knowledge of. They survive
+// regeneration for the same reason curated --human columns do.
+type Alias struct {
+	// OldParentPath is the pre-rename parent command path from the root,
+	// excluding the leaf verb. For the old "heygen brand-kit list" this is
+	// {"brand-kit"}; the leaf ("list") comes from Spec.
+	OldParentPath []string
+	// Spec is the canonical command this alias delegates to. The leaf verb,
+	// flags, and args all come from the Spec, so the alias can never drift
+	// from the real command.
+	Spec *command.Spec
+	// NewPath is the canonical invocation shown in the deprecation notice,
+	// without the "heygen " prefix. Example: "brand kits list".
+	NewPath string
+	// RemoveBy is the release in which this alias should be deleted. Purely
+	// informational; surfaced in the deprecation notice.
+	RemoveBy string
+}
+
+// DeprecatedAliases is the registry of backward-compatible command aliases.
+// Add an entry when a spec-driven rename changes a command path that shipped
+// in a stable release.
+var DeprecatedAliases []Alias
+
+func (a Alias) deprecationNotice() string {
+	msg := fmt.Sprintf("use %q instead", "heygen "+a.NewPath)
+	if a.RemoveBy != "" {
+		msg += fmt.Sprintf("; this alias will be removed in %s", a.RemoveBy)
+	}
+	return msg
+}
+
+// attachDeprecatedAliases registers the package-level DeprecatedAliases onto
+// the command tree. Call it after the generated groups are registered so the
+// canonical commands the aliases delegate to already exist.
+func attachDeprecatedAliases(root *cobra.Command, ctx *cmdContext) {
+	attachAliases(root, ctx, DeprecatedAliases)
+}
+
+// attachAliases registers each alias as a hidden, deprecated command that
+// delegates to its canonical Spec. Split from attachDeprecatedAliases so tests
+// can pass a synthetic alias set without mutating the package global.
+func attachAliases(root *cobra.Command, ctx *cmdContext, aliases []Alias) {
+	for _, alias := range aliases {
+		if alias.Spec == nil {
+			continue
+		}
+		parent := root
+		for _, token := range alias.OldParentPath {
+			parent = ensureHiddenGroup(parent, token)
+		}
+		leaf := buildCobraCommand(alias.Spec, ctx)
+		leaf.Hidden = true
+		leaf.Deprecated = alias.deprecationNotice()
+		parent.AddCommand(leaf)
+	}
+}
+
+// ensureHiddenGroup returns the child group named token under parent, creating
+// it hidden if absent. Unlike ensureIntermediateCommand it marks newly created
+// groups hidden, since alias parents must not appear in help.
+func ensureHiddenGroup(parent *cobra.Command, token string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == token {
+			return child
+		}
+	}
+	child := newCommandGroup(token, humanizeCommandToken(token)+" commands")
+	child.Hidden = true
+	parent.AddCommand(child)
+	return child
+}

--- a/cmd/heygen/aliases_test.go
+++ b/cmd/heygen/aliases_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/heygen-com/heygen-cli/internal/command"
+	"github.com/heygen-com/heygen-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func testCmdContext() *cmdContext {
+	return &cmdContext{
+		formatter: output.NewJSONFormatter(io.Discard, io.Discard),
+		version:   "test",
+	}
+}
+
+func findChild(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestAliasDeprecationNotice(t *testing.T) {
+	cases := []struct {
+		name  string
+		alias Alias
+		want  string
+	}{
+		{
+			name:  "with remove-by",
+			alias: Alias{NewPath: "brand kits list", RemoveBy: "v0.2.0"},
+			want:  `use "heygen brand kits list" instead; this alias will be removed in v0.2.0`,
+		},
+		{
+			name:  "without remove-by",
+			alias: Alias{NewPath: "brand kits list"},
+			want:  `use "heygen brand kits list" instead`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.alias.deprecationNotice(); got != tc.want {
+				t.Errorf("deprecationNotice() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAttachAliasesRegistersHiddenDeprecatedLeaf(t *testing.T) {
+	root := &cobra.Command{Use: "heygen"}
+	spec := &command.Spec{
+		Group:    "brand",
+		Name:     "kits list",
+		Method:   "GET",
+		Endpoint: "/v3/brand-kits",
+		Summary:  "List Brand Kits",
+	}
+	aliases := []Alias{{
+		OldParentPath: []string{"brand-kit"},
+		Spec:          spec,
+		NewPath:       "brand kits list",
+		RemoveBy:      "v0.2.0",
+	}}
+
+	attachAliases(root, testCmdContext(), aliases)
+
+	parent := findChild(root, "brand-kit")
+	if parent == nil {
+		t.Fatal(`expected hidden parent group "brand-kit" to be registered`)
+	}
+	if !parent.Hidden {
+		t.Error("alias parent group should be hidden from help")
+	}
+
+	leaf := findChild(parent, "list")
+	if leaf == nil {
+		t.Fatal(`expected alias leaf "list" under "brand-kit"`)
+	}
+	if !leaf.Hidden {
+		t.Error("alias leaf should be hidden from help")
+	}
+	if leaf.Deprecated == "" {
+		t.Error("alias leaf should carry a deprecation notice")
+	}
+	if leaf.RunE == nil {
+		t.Error("alias leaf should delegate to the canonical command's RunE")
+	}
+}
+
+func TestAttachAliasesSkipsNilSpec(t *testing.T) {
+	root := &cobra.Command{Use: "heygen"}
+	attachAliases(root, testCmdContext(), []Alias{{OldParentPath: []string{"ghost"}, Spec: nil}})
+	if findChild(root, "ghost") != nil {
+		t.Error("alias with a nil Spec should be skipped, not registered")
+	}
+}
+
+func TestAttachAliasesSharesParentGroup(t *testing.T) {
+	root := &cobra.Command{Use: "heygen"}
+	specList := &command.Spec{Group: "brand", Name: "kits list", Method: "GET", Endpoint: "/v3/brand-kits"}
+	specGet := &command.Spec{
+		Group:    "brand",
+		Name:     "kits get",
+		Method:   "GET",
+		Endpoint: "/v3/brand-kits/{id}",
+		Args:     []command.ArgSpec{{Name: "id", Param: "id"}},
+	}
+	attachAliases(root, testCmdContext(), []Alias{
+		{OldParentPath: []string{"brand-kit"}, Spec: specList, NewPath: "brand kits list"},
+		{OldParentPath: []string{"brand-kit"}, Spec: specGet, NewPath: "brand kits get"},
+	})
+
+	parents := 0
+	for _, c := range root.Commands() {
+		if c.Name() == "brand-kit" {
+			parents++
+		}
+	}
+	if parents != 1 {
+		t.Fatalf(`expected a single shared "brand-kit" parent group, got %d`, parents)
+	}
+}

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -49,6 +49,7 @@ func newRootCmd(version string, formatter output.Formatter, analyticsClient *ana
 	root.AddCommand(newUpdateCmd(ctx))
 	registerGroups(root, ctx, gen.Groups)
 	attachCustomCommands(root, ctx)
+	attachDeprecatedAliases(root, ctx)
 	installFlattenedHelp(root)
 	installRootHelpFooter(root)
 
@@ -115,6 +116,7 @@ func newRootCmdWithSpecs(version string, formatter output.Formatter, analyticsCl
 	root.AddCommand(newUpdateCmd(ctx))
 	registerGroups(root, ctx, groups)
 	attachCustomCommands(root, ctx)
+	attachDeprecatedAliases(root, ctx)
 	installFlattenedHelp(root)
 
 	return root


### PR DESCRIPTION
## Scope
**Surfaces:** CLI (command tree) | **Module:** codegen runtime / command builder

## Summary
Adds a small framework for backward-compatible command aliases. Command names in this CLI are derived from the upstream OpenAPI spec (owned by experiment-framework), so an upstream tag or path change can rename a command that already shipped in a stable release. This gives us a first-class way to keep the old invocation working while steering callers to the new name. No aliases are registered yet; this is the mechanism only. The first consumer (the `brand-kit` → `brand kits` rename) lands with the codegen resync PR that performs that rename.

## Context
The first real case is the brand resync: `GET /v3/brand-kits` was retagged from `Brand Kit` to `Brand` upstream, which moves `heygen brand-kit list` (shipped in v0.0.9–v0.0.11) to `heygen brand kits list`. Without a compat path, that silently breaks existing scripts.

## Design decisions
**Aliases live in hand-written code (`cmd/heygen/aliases.go`), not `gen/`.** An alias encodes naming *history* (the old name), which the current spec has no knowledge of, so codegen can't emit it. This matches how curated `--human` columns and poll configs already live as hand-maintained lookup data that survives regeneration.

**An alias re-registers the canonical `Spec`, it does not reimplement the command.** The leaf verb, flags, args, and `RunE` all come from the same `buildCobraCommand` the real command uses, so an alias can never drift from its target.

**Cobra's native `Aliases` field can't express this.** It aliases a name among siblings; the brand case changes both the parent and the depth (`brand-kit list` → `brand kits list`), so a registration shim is required regardless.

**Hidden + deprecated.** Alias commands are hidden from `--help` (keeping the agent-facing tree clean and unambiguous) and carry Cobra's `Deprecated` notice, which prints to stderr on use, so stdout stays clean for JSON consumers piping to `jq`.

## Testing
4 unit tests in `cmd/heygen/aliases_test.go`: deprecation-notice formatting (with/without `RemoveBy`), hidden+deprecated leaf registration delegating to the canonical `RunE`, nil-Spec skip, and shared-parent reuse across multiple aliases. Full suite, `go vet`, and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)