### PR TITLE
docs: document shell completion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ You only need a HeyGen API key — see [Authenticate](#authenticate) below.
 heygen update            # install the latest version
 ```
 
+## Shell completion
+
+Tab-completion for commands, subcommands, and flags is available for bash, zsh, fish, and PowerShell:
+
+```bash
+source <(heygen completion zsh)     # current shell (bash/zsh/fish)
+heygen completion zsh > "${fpath[1]}/_heygen"   # persist (zsh; adjust path per shell)
+```
+
+Run `heygen completion --help` for per-shell install instructions.
+
 ## Authenticate
 
 Choose one of the three options below. The first two are agent- and CI-friendly; the third is for humans.


### PR DESCRIPTION
## Scope
**Surfaces:** CLI (docs) | **Module:** Distribution / DX

## Description
Cobra's `completion` command is already wired into the CLI but kept hidden from `--help` (via `CompletionOptions.HiddenDefaultCmd`) to keep the agent-facing command list clean. It is fully functional today (`heygen completion {bash,zsh,fish,powershell}`), just undocumented, so humans have no way to discover it.

This adds a short "Shell completion" section to the README with source/persist snippets and a pointer to `heygen completion --help` for per-shell instructions. No code change; the command stays hidden in help. Dynamic value completion (e.g. avatar IDs) is intentionally not pursued.

## Testing
Verified against the freshly built binary: `completion {bash,zsh,fish,powershell}` and `completion --help` all emit valid scripts/help and exit 0; `completion` remains absent from `heygen --help`. Docs-only change, no automated tests affected.