### PR TITLE
ci: automate weekly stable releases via release PRs (PRINFRA-170)

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -19,6 +19,15 @@ permissions:
   contents: write
   id-token: write
 
+# Serialize stable publishes. Two overlapping runs (e.g. a manual dispatch and a
+# merged release PR) could each validate against the same latest tag and then
+# race the S3 "stable" pointer, moving it backward. Queue, do not cancel, so an
+# in-flight publish always finishes and the next run re-validates against the
+# tag it created (the monotonic guard then rejects a lower version).
+concurrency:
+  group: stable-release
+  cancel-in-progress: false
+
 jobs:
   release:
     # Run only for a manual dispatch, or when a release/* PR is actually MERGED

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -19,15 +19,6 @@ permissions:
   contents: write
   id-token: write
 
-# Serialize stable publishes. Two overlapping runs (e.g. a manual dispatch and a
-# merged release PR) could each validate against the same latest tag and then
-# race the S3 "stable" pointer, moving it backward. Queue, do not cancel, so an
-# in-flight publish always finishes and the next run re-validates against the
-# tag it created (the monotonic guard then rejects a lower version).
-concurrency:
-  group: stable-release
-  cancel-in-progress: false
-
 jobs:
   release:
     # Run only for a manual dispatch, or when a release/* PR is actually MERGED
@@ -36,6 +27,16 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        startsWith(github.event.pull_request.head.ref, 'release/v'))
+    # Serialize stable publishes at the JOB level, not workflow level. This
+    # workflow also fires for every closed PR to main; a workflow-level group
+    # would let those (skipped) runs queue in the group and evict a pending real
+    # release (GitHub keeps only one pending run per group). A job skipped by the
+    # `if` above never enters this group. Queue, don't cancel, so an in-flight
+    # publish finishes and the next release re-validates against the tag it
+    # created (the monotonic guard then rejects a lower version).
+    concurrency:
+      group: stable-release
+      cancel-in-progress: false
     # Protected environment: a required reviewer must approve before publish.
     # NOTE: create a `release` environment with a required reviewer in repo
     # settings; until then this gate is a no-op (the PR review is still a gate).

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -41,6 +41,21 @@ jobs:
             exit 1
           fi
 
+          # Monotonic guard: refuse a version that is not strictly greater than
+          # the current latest stable tag. This protects the "stable" S3 pointer
+          # from moving backward when a stale/queued release lands after a newer
+          # tag, e.g. the weekly automation dispatches a patch bump just before a
+          # maintainer cuts a manual minor/major release. Bootstrap (no existing
+          # stable tag) is allowed through.
+          latest="$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+          if [[ -n "$latest" ]]; then
+            highest="$(printf '%s\n%s\n' "$latest" "$version" | sort -V | tail -n1)"
+            if [[ "$version" == "$latest" || "$highest" != "$version" ]]; then
+              echo "requested version $version is not greater than latest stable tag $latest; refusing to publish a non-increasing stable release" >&2
+              exit 1
+            fi
+          fi
+
       - name: Run tests
         run: make test
 

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,12 +1,19 @@
 name: Stable Release
 
 on:
+  # Manual on-demand cut (see RELEASE.md). Still goes through the `release`
+  # environment approval below.
   workflow_dispatch:
     inputs:
       version:
         description: "Version tag (e.g., v0.1.0)"
         required: true
         type: string
+  # Automated path: merging a `release/vX.Y.Z` PR (opened weekly or by hand)
+  # publishes that version. The job `if` restricts this to MERGED release PRs.
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -14,8 +21,36 @@ permissions:
 
 jobs:
   release:
+    # Run only for a manual dispatch, or when a release/* PR is actually MERGED
+    # (not merely closed). A human performs the merge, so the merge is the gate.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'release/v'))
+    # Protected environment: a required reviewer must approve before publish.
+    # NOTE: create a `release` environment with a required reviewer in repo
+    # settings; until then this gate is a no-op (the PR review is still a gate).
+    environment: release
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve version
+        id: resolve
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            version="$INPUT_VERSION"
+          else
+            # release/vX.Y.Z -> vX.Y.Z
+            version="${HEAD_REF#release/}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $version"
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -27,10 +62,12 @@ jobs:
 
       - name: Validate version
         shell: bash
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           set -euo pipefail
 
-          version="${{ github.event.inputs.version }}"
+          version="$VERSION"
           if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "invalid version: $version" >&2
             exit 1
@@ -44,7 +81,7 @@ jobs:
           # Monotonic guard: refuse a version that is not strictly greater than
           # the current latest stable tag. This protects the "stable" S3 pointer
           # from moving backward when a stale/queued release lands after a newer
-          # tag, e.g. the weekly automation dispatches a patch bump just before a
+          # tag, e.g. the weekly automation opens a patch-bump PR just before a
           # maintainer cuts a manual minor/major release. Bootstrap (no existing
           # stable tag) is allowed through.
           latest="$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
@@ -69,12 +106,30 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve release notes
+        id: notes
+        shell: bash
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          notes="releases/${VERSION}.md"
+          if [[ -f "$notes" ]]; then
+            echo "flag=--release-notes=${notes}" >> "$GITHUB_OUTPUT"
+            echo "Using reviewed release notes: ${notes}"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+            echo "No ${notes} found; GoReleaser will autogenerate notes."
+          fi
+
       - name: Create git tag
         shell: bash
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           set -euo pipefail
 
-          version="${{ github.event.inputs.version }}"
+          version="$VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "$version"
@@ -84,10 +139,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --clean --skip=validate
+          args: release --clean --skip=validate ${{ steps.notes.outputs.flag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.event.inputs.version }}
+          GORELEASER_CURRENT_TAG: ${{ steps.resolve.outputs.version }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -98,7 +153,7 @@ jobs:
       - name: Upload stable release artifacts to S3
         shell: bash
         env:
-          TAG: ${{ github.event.inputs.version }}
+          TAG: ${{ steps.resolve.outputs.version }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/weekly-stable-release.yml
+++ b/.github/workflows/weekly-stable-release.yml
@@ -1,39 +1,37 @@
 name: Weekly Stable Release
 
-# Automatically cuts a stable release once a week, but only if new commits
-# landed on main since the last stable tag. This keeps the cadence regular
-# (codegen resyncs land ~weekly) without a human remembering to trigger it,
-# and skips weeks with no changes instead of cutting an empty release.
-#
-# This workflow does NOT build or sign anything itself. It only computes the
-# next version and delegates to the existing release-stable.yml workflow via
-# workflow_dispatch, so the build/sign/publish path stays in exactly one place.
+# Opens (does NOT publish) a stable release PR once a week, but only if new
+# commits landed on main since the last stable tag. A human refines the draft
+# changelog (via `/changelog-cli`) and merges; the merge triggers
+# release-stable.yml to build, sign, and publish. This keeps a regular cadence
+# without anyone remembering to cut a release, while keeping the merge (and the
+# `release` environment approval) as the human gate. Manual on-demand releases
+# remain available via release-stable.yml's workflow_dispatch (see RELEASE.md).
 
 on:
-  # Monday 09:00 UTC. Early-week cut so a fresh stable is available for the
-  # week's work; UTC avoids DST ambiguity.
+  # Monday 09:00 UTC. Early-week so a fresh stable is teed up for the week;
+  # UTC avoids DST ambiguity.
   schedule:
     - cron: "0 9 * * 1"
-  # Allow a maintainer to run the same detect-and-dispatch logic on demand.
+  # Allow a maintainer to run the same detect-and-open logic on demand.
   workflow_dispatch:
 
 permissions:
-  contents: read
-  # Required so `gh workflow run` can dispatch release-stable.yml.
-  actions: write
+  contents: write       # create the release/* branch + commit the draft notes (via API, signed)
+  pull-requests: write  # open the release PR
 
-# Never run two auto-release dispatches at once.
+# Never open two release PRs at once.
 concurrency:
   group: weekly-stable-release
   cancel-in-progress: false
 
 jobs:
-  dispatch:
+  open-release-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
-          # Full history + tags so we can find the last stable tag and count
+          # Full history + tags so we can find the last stable tag and list
           # commits since it.
           fetch-depth: 0
           ref: main
@@ -49,10 +47,11 @@ jobs:
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
 
           if [[ -z "$latest_stable" ]]; then
-            # No stable tag yet: bootstrap at v0.0.1 and always release.
+            # No stable tag yet: bootstrap at v0.0.1 and always open the PR.
             echo "No existing stable tag found; bootstrapping at v0.0.1."
             echo "release=true" >> "$GITHUB_OUTPUT"
             echo "version=v0.0.1" >> "$GITHUB_OUTPUT"
+            echo "range=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -63,46 +62,96 @@ jobs:
           echo "Commits on main since ${latest_stable}: ${new_commits}"
 
           if [[ "$new_commits" -eq 0 ]]; then
-            echo "No new commits since ${latest_stable}; skipping this week's release."
+            echo "No new commits since ${latest_stable}; skipping this week."
             echo "release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Patch bump from the last stable tag. This matches the dev-release
+          # Patch bump from the last stable tag. Matches the dev-release
           # auto-derivation and the repo's pre-1.0 convention where the weekly
           # driver (codegen resyncs, fixes, additive schema) is a patch bump.
           # Minor/major bumps for new command groups remain a manual release.
           next="$(echo "$latest_stable" | sed 's/^v//' \
             | awk -F. '{printf "v%d.%d.%d", $1, $2, $3 + 1}')"
 
-          # Idempotency guard: if the computed tag somehow already exists (e.g.
-          # a manual release raced this run), skip rather than double-release.
-          # release-stable.yml re-checks this too, but failing here keeps the
-          # run green instead of erroring on a skipped week.
+          # If the computed tag already exists (e.g. a manual release raced this
+          # run), skip rather than open a PR for an already-released version.
           if git rev-parse "$next" >/dev/null 2>&1; then
             echo "Computed tag ${next} already exists; nothing to do."
             echo "release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Will release ${next} (${new_commits} new commit(s))."
+          echo "Will open a release PR for ${next} (${new_commits} new commit(s))."
           echo "release=true" >> "$GITHUB_OUTPUT"
           echo "version=${next}" >> "$GITHUB_OUTPUT"
+          echo "range=${latest_stable}..origin/main" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch stable release
+      - name: Skip if a release branch already exists
+        id: existing
         if: steps.plan.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.plan.outputs.version }}
+          REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
-          echo "Dispatching release-stable.yml for ${VERSION}"
-          # Reuse the existing manual release workflow; it owns tag creation,
-          # tests, GoReleaser, and S3 upload. We only feed it the version.
-          gh workflow run release-stable.yml -f "version=${VERSION}" --ref main
+          branch="release/${VERSION}"
+          # A pre-existing branch means a prior run already opened this release
+          # PR (and a human may be editing the notes). Do not clobber it.
+          if gh api "repos/${REPO}/git/ref/heads/${branch}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Branch ${branch} already exists; leaving the existing release PR untouched."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open release PR with a draft changelog
+        if: steps.plan.outputs.release == 'true' && steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.plan.outputs.version }}
+          RANGE: ${{ steps.plan.outputs.range }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="release/${VERSION}"
+          today="$(date -u +%Y-%m-%d)"
+          log_range="${RANGE:-origin/main}"
+
+          # Deterministic starting point. The reviewer refines this with
+          # /changelog-cli (see RELEASE.md) before merging; merging publishes.
+          {
+            echo "## ${VERSION} (${today})"
+            echo
+            echo "> Draft generated by the weekly release automation. Refine with \`/changelog-cli ${VERSION}\`, then merge to publish."
+            echo
+            git log --no-merges --pretty='- %s' ${log_range}
+          } > notes.md
+
+          # Create the release branch at main's head, then commit the draft notes
+          # via the contents API. API-created commits are GitHub-signed
+          # ("Verified"), which the repo's require-signed-commits rule needs — a
+          # plain token push would be rejected.
+          base_sha="$(gh api "repos/${REPO}/git/ref/heads/main" --jq .object.sha)"
+          gh api --method POST "repos/${REPO}/git/refs" \
+            -f ref="refs/heads/${branch}" -f sha="${base_sha}" >/dev/null
+          gh api --method PUT "repos/${REPO}/contents/releases/${VERSION}.md" \
+            -f message="release: ${VERSION} (draft notes)" \
+            -f branch="${branch}" \
+            -f content="$(base64 -w0 notes.md)" >/dev/null
+
+          gh pr create --repo "${REPO}" --base main --head "${branch}" \
+            --title "release: ${VERSION}" \
+            --body "Automated weekly release PR for \`${VERSION}\`.
+
+          **To finalize:** refine \`releases/${VERSION}.md\` (run \`/changelog-cli ${VERSION}\`), review, then **merge** to publish. Merging triggers \`release-stable.yml\` (test, tag, GoReleaser, S3) behind the \`release\` environment approval.
+
+          To skip this week's release, just close this PR."
 
       - name: Report skip
-        if: steps.plan.outputs.release != 'true'
+        if: steps.plan.outputs.release != 'true' || steps.existing.outputs.exists == 'true'
         shell: bash
-        run: echo "No release dispatched this run (see plan step for the reason)."
+        run: echo "No new release PR opened this run (see the plan/existing steps for the reason)."

--- a/.github/workflows/weekly-stable-release.yml
+++ b/.github/workflows/weekly-stable-release.yml
@@ -87,7 +87,7 @@ jobs:
           echo "version=${next}" >> "$GITHUB_OUTPUT"
           echo "range=${latest_stable}..origin/main" >> "$GITHUB_OUTPUT"
 
-      - name: Skip if a release branch already exists
+      - name: Skip if a release PR is already open
         id: existing
         if: steps.plan.outputs.release == 'true'
         env:
@@ -98,11 +98,18 @@ jobs:
         run: |
           set -euo pipefail
           branch="release/${VERSION}"
-          # A pre-existing branch means a prior run already opened this release
-          # PR (and a human may be editing the notes). Do not clobber it.
-          if gh api "repos/${REPO}/git/ref/heads/${branch}" >/dev/null 2>&1; then
+          # Idempotency keys on an OPEN PR, not the branch ref. An open release
+          # PR (a human may be editing its notes) must not be clobbered. But a
+          # leftover branch from a CLOSED PR must NOT suppress this week's PR:
+          # closing a PR to "skip a week" does not delete its branch, and
+          # latest_stable is unchanged until a release actually merges, so the
+          # next run computes the same version. Keying on the branch ref would
+          # then skip forever. The open-PR step below deletes any such stale
+          # branch before recreating it, so skipping is per-week, not permanent.
+          open_pr="$(gh pr list --repo "${REPO}" --state open --head "${branch}" --json number --jq '.[0].number // ""')"
+          if [[ -n "$open_pr" ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Branch ${branch} already exists; leaving the existing release PR untouched."
+            echo "Release PR #${open_pr} for ${VERSION} already open; leaving it untouched."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
@@ -130,6 +137,11 @@ jobs:
             echo
             git log --no-merges --pretty='- %s' ${log_range}
           } > notes.md
+
+          # Delete any stale branch left by a previously closed release PR (see
+          # the idempotency note above) so the ref is recreated from current
+          # main. No-op if the branch does not exist.
+          gh api --method DELETE "repos/${REPO}/git/refs/heads/${branch}" >/dev/null 2>&1 || true
 
           # Create the release branch at main's head, then commit the draft notes
           # via the contents API. API-created commits are GitHub-signed

--- a/.github/workflows/weekly-stable-release.yml
+++ b/.github/workflows/weekly-stable-release.yml
@@ -1,0 +1,108 @@
+name: Weekly Stable Release
+
+# Automatically cuts a stable release once a week, but only if new commits
+# landed on main since the last stable tag. This keeps the cadence regular
+# (codegen resyncs land ~weekly) without a human remembering to trigger it,
+# and skips weeks with no changes instead of cutting an empty release.
+#
+# This workflow does NOT build or sign anything itself. It only computes the
+# next version and delegates to the existing release-stable.yml workflow via
+# workflow_dispatch, so the build/sign/publish path stays in exactly one place.
+
+on:
+  # Monday 09:00 UTC. Early-week cut so a fresh stable is available for the
+  # week's work; UTC avoids DST ambiguity.
+  schedule:
+    - cron: "0 9 * * 1"
+  # Allow a maintainer to run the same detect-and-dispatch logic on demand.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required so `gh workflow run` can dispatch release-stable.yml.
+  actions: write
+
+# Never run two auto-release dispatches at once.
+concurrency:
+  group: weekly-stable-release
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history + tags so we can find the last stable tag and count
+          # commits since it.
+          fetch-depth: 0
+          ref: main
+
+      - name: Determine whether a release is needed and compute version
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Latest stable tag (vX.Y.Z, excluding -dev prereleases).
+          latest_stable="$(git tag --list 'v*' --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+
+          if [[ -z "$latest_stable" ]]; then
+            # No stable tag yet: bootstrap at v0.0.1 and always release.
+            echo "No existing stable tag found; bootstrapping at v0.0.1."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "version=v0.0.1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Last stable tag: $latest_stable"
+
+          # Count commits on main since the last stable tag. Empty week => skip.
+          new_commits="$(git rev-list --count "${latest_stable}..origin/main")"
+          echo "Commits on main since ${latest_stable}: ${new_commits}"
+
+          if [[ "$new_commits" -eq 0 ]]; then
+            echo "No new commits since ${latest_stable}; skipping this week's release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Patch bump from the last stable tag. This matches the dev-release
+          # auto-derivation and the repo's pre-1.0 convention where the weekly
+          # driver (codegen resyncs, fixes, additive schema) is a patch bump.
+          # Minor/major bumps for new command groups remain a manual release.
+          next="$(echo "$latest_stable" | sed 's/^v//' \
+            | awk -F. '{printf "v%d.%d.%d", $1, $2, $3 + 1}')"
+
+          # Idempotency guard: if the computed tag somehow already exists (e.g.
+          # a manual release raced this run), skip rather than double-release.
+          # release-stable.yml re-checks this too, but failing here keeps the
+          # run green instead of erroring on a skipped week.
+          if git rev-parse "$next" >/dev/null 2>&1; then
+            echo "Computed tag ${next} already exists; nothing to do."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Will release ${next} (${new_commits} new commit(s))."
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "version=${next}" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch stable release
+        if: steps.plan.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.plan.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Dispatching release-stable.yml for ${VERSION}"
+          # Reuse the existing manual release workflow; it owns tag creation,
+          # tests, GoReleaser, and S3 upload. We only feed it the version.
+          gh workflow run release-stable.yml -f "version=${VERSION}" --ref main
+
+      - name: Report skip
+        if: steps.plan.outputs.release != 'true'
+        shell: bash
+        run: echo "No release dispatched this run (see plan step for the reason)."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,7 +70,11 @@ environment approval. There are two ways to get that PR.
 1. The Monday automation opens a `release: vX.Y.Z` PR (`gh pr list --state open`).
 2. **Refine the changelog.** Run `/changelog-cli vX.Y.Z` in Claude Code and
    update `releases/vX.Y.Z.md` on the release branch with the result.
-3. **Confirm CI is green** on the PR and on `main`.
+3. **Confirm `main` CI is green.** The release PR only adds the notes file and
+   is opened by the automation's `GITHUB_TOKEN`, so PR CI does not run on it; the
+   build and `make test` run in `release-stable.yml` before publishing. If branch
+   protection requires PR status checks, merge with admin (or provision a PAT/App
+   token so release PRs trigger CI — tracked as a PRINFRA-170 follow-up).
 4. **Run the E2E smoke test.** With `HEYGEN_API_KEY` set, run `/e2e-cli-test` in
    Claude Code from the repo root. Confirm all phases pass (no FAIL). WARN on
    Phase 3 means the account lacks data for some get/detail commands and should
@@ -84,15 +88,17 @@ environment approval. There are two ways to get that PR.
 1. **Pick the version** (`gh release list --limit 3`):
    - Patch (`v0.0.x`) for bug fixes, UX polish, codegen resyncs, additive schema.
    - Minor (`v0.x.0`) for new command groups or significant new capabilities.
-2. Either run **Actions > Weekly Stable Release > Run workflow** to open the
-   release PR (then follow the normal path above), or dispatch the release
-   directly:
-   ```bash
-   gh workflow run release-stable.yml -f version=v0.1.0
-   ```
-   Either way the `release` environment approval still gates the publish. A
-   direct dispatch uses `releases/v0.1.0.md` if present, otherwise GoReleaser
-   autogenerates the notes.
+2. Cut it one of two ways (both still gated by the `release` environment approval):
+   - **Dispatch directly** (works for any version, including minor/major):
+     ```bash
+     gh workflow run release-stable.yml -f version=v0.1.0
+     ```
+     Uses `releases/v0.1.0.md` if present, otherwise GoReleaser autogenerates notes.
+   - **Open a release PR by hand** (if you want the changelog reviewed first):
+     create a `release/v0.1.0` branch, add `releases/v0.1.0.md` (run
+     `/changelog-cli v0.1.0`), open the PR, then merge. Note the **weekly
+     workflow only patch-bumps**, so don't use it for a minor/major, create the
+     `release/*` branch yourself or dispatch directly.
 
 ### Post-release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,8 +43,10 @@ the "did anyone remember to release?" burden.
   (`workflow_dispatch`).
 - **Skip behavior:** It finds the latest stable tag (`vX.Y.Z`) and counts
   commits on `main` since it. **No new commits → no PR** (empty weeks are
-  skipped, not failed). If a release branch for the computed version already
-  exists, it is left untouched so in-progress edits are never clobbered.
+  skipped, not failed). If a release PR for the computed version is already
+  **open**, it is left untouched (no clobbering in-progress edits); a leftover
+  branch with no open PR is treated as stale and recreated, so a week you skipped
+  by closing the PR is simply re-offered on the next run.
 - **Versioning:** It **patch-bumps** the latest stable tag (e.g. `v0.0.11` →
   `v0.0.12`). Patch is the default because the weekly driver (codegen resyncs,
   fixes, additive schema) is a patch bump. Minor/major bumps (new command

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,83 +31,81 @@ gh workflow run dev-release.yml
 
 ## Automated Weekly Stable Release
 
-A scheduled workflow (`.github/workflows/weekly-stable-release.yml`) cuts a
-stable release automatically so the cadence no longer depends on someone
-remembering to trigger it.
+A scheduled workflow (`.github/workflows/weekly-stable-release.yml`) opens a
+stable **release PR** automatically, so the cadence no longer depends on someone
+remembering to cut one. It does **not** publish; merging the PR does (see
+[How to Cut a Stable Release](#how-to-cut-a-stable-release)). This keeps the
+merge (and the `release` environment approval) as the human gate while removing
+the "did anyone remember to release?" burden.
 
-- **Trigger / schedule:** Cron every Monday at 09:00 UTC. It can also be run on
+- **Trigger / schedule:** Cron every Monday at 09:00 UTC. Can also be run on
   demand via **Actions > Weekly Stable Release > Run workflow**
-  (`workflow_dispatch`), which runs the same detect-and-dispatch logic.
+  (`workflow_dispatch`).
 - **Skip behavior:** It finds the latest stable tag (`vX.Y.Z`) and counts
-  commits on `main` since that tag. If there are **no new commits**, the run
-  logs why and exits cleanly without releasing — empty weeks are skipped, not
-  failed.
-- **Versioning:** When there are new commits, it computes the next version by
-  **patch-bumping** the latest stable tag (e.g. `v0.0.11` → `v0.0.12`), matching
-  the dev-release auto-derivation. Patch is the default because the weekly
-  driver (codegen resyncs, fixes, additive schema changes) is a patch bump.
-  Minor/major bumps (new command groups, breaking changes) remain a **manual**
-  stable release — see the rules below.
-- **Reuse / safety:** The weekly workflow does not build or sign anything. It
-  delegates to `release-stable.yml` via `workflow_dispatch` with the computed
-  version, so the build/sign/publish path lives in exactly one place. It is
-  idempotent: if the computed tag already exists (e.g. a manual release raced
-  it), it skips instead of double-releasing, and `release-stable.yml`
-  re-validates the tag as a second guard.
-- **Monotonic versions:** `release-stable.yml` refuses any version that is not
-  strictly greater than the current latest stable tag. This keeps the `stable`
-  pointer from moving backward if a stale or queued release (e.g. a weekly patch
-  bump dispatched just before a manual minor/major release) tries to publish a
-  lower version.
-
-To ship a minor/major bump, or to release off-schedule, cut a manual stable
-release as described below.
+  commits on `main` since it. **No new commits → no PR** (empty weeks are
+  skipped, not failed). If a release branch for the computed version already
+  exists, it is left untouched so in-progress edits are never clobbered.
+- **Versioning:** It **patch-bumps** the latest stable tag (e.g. `v0.0.11` →
+  `v0.0.12`). Patch is the default because the weekly driver (codegen resyncs,
+  fixes, additive schema) is a patch bump. Minor/major bumps (new command
+  groups, breaking changes) are a **manual** release — see below.
+- **What the PR contains:** a `release/vX.Y.Z` branch with a `releases/vX.Y.Z.md`
+  draft changelog (commit subjects since the last tag), committed via the GitHub
+  API so it is signed/verified. Refine it with `/changelog-cli vX.Y.Z` before
+  merging.
+- **Monotonic versions:** `release-stable.yml` refuses any version not strictly
+  greater than the current latest stable tag, so the `stable` pointer never
+  moves backward (e.g. a lingering weekly patch-bump PR after a manual
+  minor/major release already shipped).
 
 ## How to Cut a Stable Release
 
-### Pre-release checklist
+Both the weekly automation and a manual cut converge on the same gate: a
+`release/vX.Y.Z` PR is reviewed and **merged**, which triggers
+`release-stable.yml` (test → tag → GoReleaser → S3) behind the `release`
+environment approval. There are two ways to get that PR.
 
-1. **Review commits since last stable.** Check what's new and confirm nothing is half-finished:
-   ```bash
-   git log $(gh release view --json tagName -q .tagName)..origin/main --oneline
-   ```
-2. **Check open PRs.** Decide if any should merge first (e.g. pending codegen resyncs, small fixes):
-   ```bash
-   gh pr list --state open
-   ```
-3. **Confirm CI is green on main.** All checks should pass on the latest commit.
-4. **Run E2E smoke test.** With `HEYGEN_API_KEY` set, run `/e2e-cli-test` in Claude Code from the repo root. Confirm all phases pass (no FAIL). WARN on Phase 3 means the account lacks data for some get/detail commands and should be investigated. This builds the binary and exercises it against the live API (costs a small number of credits).
-5. **Pick the version number.** Check the last stable tag and bump according to the rules below:
-   - Patch (`v0.0.x`) for bug fixes, UX polish, codegen resyncs, and additive schema changes.
+### From the weekly release PR (normal path)
+
+1. The Monday automation opens a `release: vX.Y.Z` PR (`gh pr list --state open`).
+2. **Refine the changelog.** Run `/changelog-cli vX.Y.Z` in Claude Code and
+   update `releases/vX.Y.Z.md` on the release branch with the result.
+3. **Confirm CI is green** on the PR and on `main`.
+4. **Run the E2E smoke test.** With `HEYGEN_API_KEY` set, run `/e2e-cli-test` in
+   Claude Code from the repo root. Confirm all phases pass (no FAIL). WARN on
+   Phase 3 means the account lacks data for some get/detail commands and should
+   be investigated. This builds the binary and exercises it against the live API
+   (costs a small number of credits).
+5. **Merge the PR**, then **approve the `release` environment** when prompted.
+   That publishes the release. To skip a week, just close the PR.
+
+### Manual / off-schedule (including minor/major bumps)
+
+1. **Pick the version** (`gh release list --limit 3`):
+   - Patch (`v0.0.x`) for bug fixes, UX polish, codegen resyncs, additive schema.
    - Minor (`v0.x.0`) for new command groups or significant new capabilities.
+2. Either run **Actions > Weekly Stable Release > Run workflow** to open the
+   release PR (then follow the normal path above), or dispatch the release
+   directly:
    ```bash
-   gh release list --limit 3
+   gh workflow run release-stable.yml -f version=v0.1.0
    ```
-6. **Generate changelog.** Run `/changelog-cli v0.x.y` in Claude Code. Review the output and save it for the release notes.
-
-### Trigger the release
-
-From the CLI:
-
-```bash
-gh workflow run release-stable.yml -f version=v0.0.5
-```
-
-Or from the GitHub Actions UI: go to **Actions > Stable Release > Run workflow**, enter the version tag, and click **Run workflow**.
+   Either way the `release` environment approval still gates the publish. A
+   direct dispatch uses `releases/v0.1.0.md` if present, otherwise GoReleaser
+   autogenerates the notes.
 
 ### Post-release
 
-The workflow validates the version, creates the tag on `main`, and
-publishes the stable release artifacts via GoReleaser, then uploads the
-installer, checksums, and platform archives to S3 for CDN-backed installs.
-CDN propagation takes up to 1 minute for the version pointer and 5 minutes
-for the install script.
+`release-stable.yml` validates the version, creates the tag on `main`, publishes
+the artifacts via GoReleaser, and uploads the installer, checksums, and platform
+archives to S3 for CDN-backed installs. CDN propagation takes up to 1 minute for
+the version pointer and 5 minutes for the install script. Then:
 
-5. **Verify the release was published:**
+1. **Verify the release was published:**
    ```bash
-   gh release view v0.0.5
+   gh release view v0.1.0
    ```
-6. **Verify the install script picks up the new version** (after CDN propagation):
+2. **Verify the install script picks up the new version** (after CDN propagation):
    ```bash
    curl -fsSL https://static.heygen.ai/cli/install.sh | bash
    heygen --version

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,6 +29,35 @@ gh workflow run dev-release.yml
 4. Verify a new prerelease was published for the computed dev tag.
 5. Share the installer command or release link with internal users as needed.
 
+## Automated Weekly Stable Release
+
+A scheduled workflow (`.github/workflows/weekly-stable-release.yml`) cuts a
+stable release automatically so the cadence no longer depends on someone
+remembering to trigger it.
+
+- **Trigger / schedule:** Cron every Monday at 09:00 UTC. It can also be run on
+  demand via **Actions > Weekly Stable Release > Run workflow**
+  (`workflow_dispatch`), which runs the same detect-and-dispatch logic.
+- **Skip behavior:** It finds the latest stable tag (`vX.Y.Z`) and counts
+  commits on `main` since that tag. If there are **no new commits**, the run
+  logs why and exits cleanly without releasing — empty weeks are skipped, not
+  failed.
+- **Versioning:** When there are new commits, it computes the next version by
+  **patch-bumping** the latest stable tag (e.g. `v0.0.11` → `v0.0.12`), matching
+  the dev-release auto-derivation. Patch is the default because the weekly
+  driver (codegen resyncs, fixes, additive schema changes) is a patch bump.
+  Minor/major bumps (new command groups, breaking changes) remain a **manual**
+  stable release — see the rules below.
+- **Reuse / safety:** The weekly workflow does not build or sign anything. It
+  delegates to `release-stable.yml` via `workflow_dispatch` with the computed
+  version, so the build/sign/publish path lives in exactly one place. It is
+  idempotent: if the computed tag already exists (e.g. a manual release raced
+  it), it skips instead of double-releasing, and `release-stable.yml`
+  re-validates the tag as a second guard.
+
+To ship a minor/major bump, or to release off-schedule, cut a manual stable
+release as described below.
+
 ## How to Cut a Stable Release
 
 ### Pre-release checklist

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,11 @@ remembering to trigger it.
   idempotent: if the computed tag already exists (e.g. a manual release raced
   it), it skips instead of double-releasing, and `release-stable.yml`
   re-validates the tag as a second guard.
+- **Monotonic versions:** `release-stable.yml` refuses any version that is not
+  strictly greater than the current latest stable tag. This keeps the `stable`
+  pointer from moving backward if a stale or queued release (e.g. a weekly patch
+  bump dispatched just before a manual minor/major release) tries to publish a
+  lower version.
 
 To ship a minor/major bump, or to release off-schedule, cut a manual stable
 release as described below.


### PR DESCRIPTION
## Scope
**Surfaces:** CI / release pipeline | **Module:** Release automation

## Summary
Automates the stable-release cadence without auto-publishing. A weekly cron opens a `release/vX.Y.Z` PR with a draft changelog; a human refines it (`/changelog-cli`), reviews, and merges, and the merge publishes. This removes the "did anyone remember to release?" burden while keeping a human gate, and mirrors the hyperframes publish model (release PR + protected environment).

## Design decisions
**Release PR instead of weekly auto-publish.** The weekly job opens a PR; merging it (a human action) triggers the publish. So a release is never cut unattended, but the cadence is still automated. Manual on-demand cuts remain via `release-stable.yml` `workflow_dispatch`.

**Publish trigger + version resolution.** `release-stable.yml` runs on `workflow_dispatch` or a merged `release/v*` PR (`pull_request: closed` + a job `if` that requires `merged == true`). Version comes from the dispatch input or the `release/vX.Y.Z` branch name.

**`environment: release` approval gate.** An optional second human approval before publish. Until the `release` environment is created with a required reviewer, it is a no-op (the PR merge is still a gate).

**Job-level concurrency.** `concurrency: stable-release` sits on the release job (not workflow) so closed-PR runs that fail the `if` never enter the lock and cannot evict a pending real release; in-flight publishes finish and the monotonic guard rejects a lower version.

**Signed draft notes.** The draft `releases/vX.Y.Z.md` is committed via the GitHub contents API so it is verified (the repo requires signed commits).

## Testing
Codex-aligned (3 rounds, 0 blocking) covering the publish `if`, version resolution, signed-commit path, concurrency/eviction, monotonic guard, and GoReleaser notes flag. Workflow/docs-only change.

## Follow-ups (operator)
- Create a `release` environment with a required reviewer to activate the approval gate.
- Optionally provision a PAT/App token so bot-opened release PRs trigger PR CI (otherwise merge with admin; meaningful tests run in `release-stable.yml` post-merge).