### PR TITLE
output: render nested objects in --human as an indented, humanized layout (PRINFRA-153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ heygen video download <video-id>
 
 Add `--human` to any command for a readable layout. Set `HEYGEN_OUTPUT=human` to make it the default.
 
-In `--human` mode, list responses render as a table and single-object responses render as an indented, humanized layout (similar to `kubectl describe`). Keys are humanized per segment (`auto_reload` → `Auto Reload`); nested objects indent under a `Label:` header, scalar siblings align locally within each block, arrays of scalars join inline (`a, b, c`), and arrays of objects render as YAML-style `- ` sequence items. Empty objects, empty arrays, and nulls show as `(none)`. Long scalar values (e.g. pre-signed download URLs) are printed in full and may wrap in a narrow terminal; pipe the default JSON to `jq` if you need to extract one cleanly. For example:
+In `--human` mode, list responses render as a table and single-object responses render as an indented, humanized layout (similar to `kubectl describe`). Keys are humanized per segment (`auto_reload` → `Auto Reload`), with common acronyms uppercased (`video_url` → `Video URL`); nested objects indent under a `Label:` header, scalar siblings align locally within each block, arrays of scalars join inline (`a, b, c`), and arrays of objects render as YAML-style `- ` sequence items. Empty objects, empty arrays, and nulls show as `(none)`. Long scalar values (e.g. pre-signed download URLs) are printed in full and may wrap in a narrow terminal; pipe the default JSON to `jq` if you need to extract one cleanly. For example:
 
 ```
 Status:  completed

--- a/README.md
+++ b/README.md
@@ -98,7 +98,19 @@ heygen video download <video-id>
 
 Add `--human` to any command for a readable layout. Set `HEYGEN_OUTPUT=human` to make it the default.
 
-In `--human` mode, list responses render as a table and single-object responses render as aligned key-value rows. Nested objects are flattened into dotted keys (e.g. `wallet.auto_reload.enabled: false`); arrays of scalars are joined inline (`a, b, c`) and arrays of objects are indexed (`messages.0.role`). JSON output (the default) is never altered.
+In `--human` mode, list responses render as a table and single-object responses render as an indented, humanized layout (similar to `kubectl describe`). Keys are humanized per segment (`auto_reload` → `Auto Reload`); nested objects indent under a `Label:` header, scalar siblings align locally within each block, arrays of scalars join inline (`a, b, c`), and arrays of objects render as YAML-style `- ` sequence items. Empty objects, empty arrays, and nulls show as `(none)`. For example:
+
+```
+Status:  completed
+Wallet:
+  Auto Reload:
+    Enabled:  false
+  Currency:           usd
+  Remaining Balance:  476.78
+Tags:  alpha, beta
+```
+
+`--human` is a readable layout for terminals and may change between releases; scripts and agents should consume the default JSON output, which is stable. JSON output (the default) is never altered.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ heygen video download <video-id>
 
 Add `--human` to any command for a readable layout. Set `HEYGEN_OUTPUT=human` to make it the default.
 
-In `--human` mode, list responses render as a table and single-object responses render as aligned key-value rows. Nested objects are flattened into dotted keys (e.g. `wallet.auto_reload.enabled  false`); arrays of scalars are joined inline (`a, b, c`) and arrays of objects are indexed (`messages.0.role`). JSON output (the default) is never altered.
+In `--human` mode, list responses render as a table and single-object responses render as aligned key-value rows. Nested objects are flattened into dotted keys (e.g. `wallet.auto_reload.enabled: false`); arrays of scalars are joined inline (`a, b, c`) and arrays of objects are indexed (`messages.0.role`). JSON output (the default) is never altered.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ heygen video download <video-id>
 
 Add `--human` to any command for a readable layout. Set `HEYGEN_OUTPUT=human` to make it the default.
 
+In `--human` mode, list responses render as a table and single-object responses render as aligned key-value rows. Nested objects are flattened into dotted keys (e.g. `wallet.auto_reload.enabled  false`); arrays of scalars are joined inline (`a, b, c`) and arrays of objects are indexed (`messages.0.role`). JSON output (the default) is never altered.
+
 ## Commands
 
 Mirrors the [HeyGen v3 API](https://developers.heygen.com). Pattern: `heygen <noun> <verb>`.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ heygen video download <video-id>
 
 Add `--human` to any command for a readable layout. Set `HEYGEN_OUTPUT=human` to make it the default.
 
-In `--human` mode, list responses render as a table and single-object responses render as an indented, humanized layout (similar to `kubectl describe`). Keys are humanized per segment (`auto_reload` → `Auto Reload`); nested objects indent under a `Label:` header, scalar siblings align locally within each block, arrays of scalars join inline (`a, b, c`), and arrays of objects render as YAML-style `- ` sequence items. Empty objects, empty arrays, and nulls show as `(none)`. For example:
+In `--human` mode, list responses render as a table and single-object responses render as an indented, humanized layout (similar to `kubectl describe`). Keys are humanized per segment (`auto_reload` → `Auto Reload`); nested objects indent under a `Label:` header, scalar siblings align locally within each block, arrays of scalars join inline (`a, b, c`), and arrays of objects render as YAML-style `- ` sequence items. Empty objects, empty arrays, and nulls show as `(none)`. Long scalar values (e.g. pre-signed download URLs) are printed in full and may wrap in a narrow terminal; pipe the default JSON to `jq` if you need to extract one cleanly. For example:
 
 ```
 Status:  completed

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -605,7 +605,7 @@ func TestGenBuilder_VideoCreate_Wait_Human_NonTTYFallback(t *testing.T) {
 	if !strings.Contains(res.Stderr, "Polling: status=processing") {
 		t.Fatalf("stderr = %s, want plain-text non-TTY progress", res.Stderr)
 	}
-	if !strings.Contains(res.Stdout, "status:") {
+	if !strings.Contains(res.Stdout, "Status:") {
 		t.Fatalf("stdout = %s, want human-formatted output", res.Stdout)
 	}
 }

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -605,7 +605,7 @@ func TestGenBuilder_VideoCreate_Wait_Human_NonTTYFallback(t *testing.T) {
 	if !strings.Contains(res.Stderr, "Polling: status=processing") {
 		t.Fatalf("stderr = %s, want plain-text non-TTY progress", res.Stderr)
 	}
-	if !strings.Contains(res.Stdout, "Status:") {
+	if !strings.Contains(res.Stdout, "status:") {
 		t.Fatalf("stdout = %s, want human-formatted output", res.Stdout)
 	}
 }

--- a/cmd/heygen/generated_root_test.go
+++ b/cmd/heygen/generated_root_test.go
@@ -351,7 +351,7 @@ func TestGeneratedRoot_HumanGetOutput(t *testing.T) {
 	}
 
 	got := stripGeneratedRootANSI(res.Stdout)
-	if !strings.Contains(got, "id:") || !strings.Contains(got, "abc123") || !strings.Contains(got, "status:") {
+	if !strings.Contains(got, "Id:") || !strings.Contains(got, "abc123") || !strings.Contains(got, "Status:") {
 		t.Fatalf("expected human key-value output:\n%s", got)
 	}
 }

--- a/cmd/heygen/generated_root_test.go
+++ b/cmd/heygen/generated_root_test.go
@@ -351,7 +351,7 @@ func TestGeneratedRoot_HumanGetOutput(t *testing.T) {
 	}
 
 	got := stripGeneratedRootANSI(res.Stdout)
-	if !strings.Contains(got, "Id:") || !strings.Contains(got, "abc123") || !strings.Contains(got, "Status:") {
+	if !strings.Contains(got, "id:") || !strings.Contains(got, "abc123") || !strings.Contains(got, "status:") {
 		t.Fatalf("expected human key-value output:\n%s", got)
 	}
 }

--- a/cmd/heygen/generated_root_test.go
+++ b/cmd/heygen/generated_root_test.go
@@ -351,7 +351,7 @@ func TestGeneratedRoot_HumanGetOutput(t *testing.T) {
 	}
 
 	got := stripGeneratedRootANSI(res.Stdout)
-	if !strings.Contains(got, "Id:") || !strings.Contains(got, "abc123") || !strings.Contains(got, "Status:") {
+	if !strings.Contains(got, "ID:") || !strings.Contains(got, "abc123") || !strings.Contains(got, "Status:") {
 		t.Fatalf("expected human key-value output:\n%s", got)
 	}
 }

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -146,7 +146,36 @@ func (f *HumanFormatter) renderPrimitiveList(items []any) error {
 }
 
 func (f *HumanFormatter) renderKeyValue(obj map[string]any) error {
-	return renderNestedKeyValue(f.out, obj, 0)
+	rows := flattenObject(obj, "", 0)
+
+	maxLabelWidth := 0
+	for _, r := range rows {
+		if lw := lipgloss.Width(r.key); lw > maxLabelWidth {
+			maxLabelWidth = lw
+		}
+	}
+
+	for _, r := range rows {
+		padding := strings.Repeat(" ", max(0, maxLabelWidth-lipgloss.Width(r.key)))
+		if strings.Contains(r.value, "\n") {
+			// Multiline string: align continuation lines under the value column.
+			valueIndent := strings.Repeat(" ", lipgloss.Width(r.key)+len(kvSeparator)+len(padding))
+			lines := strings.Split(r.value, "\n")
+			if _, err := fmt.Fprintf(f.out, "%s:%s  %s\n", r.key, padding, lines[0]); err != nil {
+				return err
+			}
+			for _, line := range lines[1:] {
+				if _, err := fmt.Fprintf(f.out, "%s%s\n", valueIndent, line); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(f.out, "%s:%s  %s\n", r.key, padding, r.value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 const (
@@ -154,113 +183,75 @@ const (
 	kvSeparator    = ":  " // label-value separator in key-value output
 )
 
-func renderNestedKeyValue(w io.Writer, obj map[string]any, indent int) error {
-	prefix := strings.Repeat("  ", indent)
-	keys := sortedKeys(obj)
-
-	maxLabelWidth := 0
-	for _, key := range keys {
-		label := humanizeKey(key)
-		if lw := lipgloss.Width(label); lw > maxLabelWidth {
-			maxLabelWidth = lw
-		}
-	}
-
-	for _, key := range keys {
-		label := humanizeKey(key)
-		padding := strings.Repeat(" ", max(0, maxLabelWidth-lipgloss.Width(label)))
-		value := obj[key]
-
-		if indent >= maxNestedDepth {
-			if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, compactJSON(value)); err != nil {
-				return err
-			}
-			continue
-		}
-
-		switch v := value.(type) {
-		case map[string]any:
-			if len(v) == 0 {
-				if _, err := fmt.Fprintf(w, "%s%s:%s  (none)\n", prefix, label, padding); err != nil {
-					return err
-				}
-			} else {
-				if _, err := fmt.Fprintf(w, "%s%s:\n", prefix, label); err != nil {
-					return err
-				}
-				if err := renderNestedKeyValue(w, v, indent+1); err != nil {
-					return err
-				}
-			}
-		case []any:
-			if len(v) == 0 {
-				if _, err := fmt.Fprintf(w, "%s%s:%s  (none)\n", prefix, label, padding); err != nil {
-					return err
-				}
-			} else if isScalarArray(v) {
-				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, formatArrayInline(v)); err != nil {
-					return err
-				}
-			} else if isObjectArray(v) {
-				if _, err := fmt.Fprintf(w, "%s%s:\n", prefix, label); err != nil {
-					return err
-				}
-				if err := renderArrayOfObjects(w, v, indent+1); err != nil {
-					return err
-				}
-			} else {
-				// Heterogeneous or mixed array: compact JSON fallback.
-				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, compactJSON(v)); err != nil {
-					return err
-				}
-			}
-		default:
-			formatted := formatCell(value, key)
-			if s, ok := value.(string); ok && strings.Contains(s, "\n") {
-				// Multiline string: re-indent continuation lines.
-				valueIndent := prefix + strings.Repeat(" ", lipgloss.Width(label)+len(kvSeparator)+len(padding))
-				lines := strings.Split(formatted, "\n")
-				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, lines[0]); err != nil {
-					return err
-				}
-				for _, line := range lines[1:] {
-					if _, err := fmt.Fprintf(w, "%s%s\n", valueIndent, line); err != nil {
-						return err
-					}
-				}
-			} else {
-				if _, err := fmt.Fprintf(w, "%s%s:%s  %s\n", prefix, label, padding, formatted); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
+// kvRow is one rendered line in the flattened key-value output: a dotted key
+// path and its pre-formatted scalar value.
+type kvRow struct {
+	key   string
+	value string
 }
 
-func renderArrayOfObjects(w io.Writer, items []any, indent int) error {
-	prefix := strings.Repeat("  ", indent)
-	for i, item := range items {
-		if obj, ok := item.(map[string]any); ok {
-			// Blank line between entries with 3+ fields for scannability.
-			if i > 0 && len(obj) > 2 {
-				if _, err := fmt.Fprintln(w); err != nil {
-					return err
-				}
-			}
-			if _, err := fmt.Fprintf(w, "%s[%d]\n", prefix, i+1); err != nil {
-				return err
-			}
-			if err := renderNestedKeyValue(w, obj, indent+1); err != nil {
-				return err
-			}
-		} else {
-			if _, err := fmt.Fprintf(w, "%s[%d]  %s\n", prefix, i+1, formatValue(item)); err != nil {
-				return err
-			}
-		}
+// joinKey joins a parent dotted-key prefix with a child segment.
+func joinKey(prefix, segment string) string {
+	if prefix == "" {
+		return segment
 	}
-	return nil
+	return prefix + "." + segment
+}
+
+// flattenObject recursively flattens a JSON object into dotted-key rows, in
+// sorted-key order. Nested objects become "parent.child" keys.
+func flattenObject(obj map[string]any, prefix string, depth int) []kvRow {
+	var rows []kvRow
+	for _, key := range sortedKeys(obj) {
+		rows = append(rows, flattenValue(joinKey(prefix, key), obj[key], key, depth)...)
+	}
+	return rows
+}
+
+// flattenValue flattens a single value under the given dotted key. fieldName is
+// the leaf field name (used for timestamp/duration heuristics in formatCell).
+//
+// Behavior by value type:
+//   - nested object: flattened into "key.child" rows; empty object -> "(none)".
+//   - scalar array: joined inline, comma-separated.
+//   - array of objects: each element flattened under an index, e.g.
+//     "messages.0.role", "messages.1.role".
+//   - heterogeneous/mixed array (e.g. containing null): compact JSON fallback.
+//   - empty array: "(none)".
+//   - scalars: formatted via formatCell (timestamps, durations, multiline).
+//
+// Beyond maxNestedDepth, the remaining value is emitted as compact JSON rather
+// than flattened further, guarding against pathologically deep payloads.
+func flattenValue(key string, value any, fieldName string, depth int) []kvRow {
+	if depth >= maxNestedDepth {
+		return []kvRow{{key: key, value: compactJSON(value)}}
+	}
+
+	switch v := value.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			return []kvRow{{key: key, value: "(none)"}}
+		}
+		return flattenObject(v, key, depth+1)
+	case []any:
+		if len(v) == 0 {
+			return []kvRow{{key: key, value: "(none)"}}
+		}
+		if isScalarArray(v) {
+			return []kvRow{{key: key, value: formatArrayInline(v)}}
+		}
+		if isObjectArray(v) {
+			var rows []kvRow
+			for i, elem := range v {
+				rows = append(rows, flattenObject(elem.(map[string]any), joinKey(key, strconv.Itoa(i)), depth+1)...)
+			}
+			return rows
+		}
+		// Heterogeneous or mixed array (e.g. contains null): compact JSON fallback.
+		return []kvRow{{key: key, value: compactJSON(v)}}
+	default:
+		return []kvRow{{key: key, value: formatCell(value, fieldName)}}
+	}
 }
 
 func autoColumnsFor(row map[string]any) []command.Column {

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -604,12 +604,36 @@ func sanitizeForTable(s string) string {
 	return strings.TrimSpace(s)
 }
 
+// humanizeAcronyms maps a lowercased key segment to its fully-uppercase display
+// form, so `video_url` renders as "Video URL" rather than "Video Url". Limited
+// to unambiguous acronyms that appear in the API surface; anything not listed is
+// plain title-cased.
+var humanizeAcronyms = map[string]string{
+	"id":   "ID",
+	"url":  "URL",
+	"api":  "API",
+	"srt":  "SRT",
+	"vtt":  "VTT",
+	"tts":  "TTS",
+	"ssml": "SSML",
+	"json": "JSON",
+	"uuid": "UUID",
+	"ai":   "AI",
+	"hd":   "HD",
+	"sd":   "SD",
+	"fps":  "FPS",
+}
+
 func humanizeKey(key string) string {
 	parts := strings.FieldsFunc(key, func(r rune) bool {
 		return r == '_' || r == '-' || r == '.'
 	})
 	for i, part := range parts {
 		if part == "" {
+			continue
+		}
+		if acronym, ok := humanizeAcronyms[strings.ToLower(part)]; ok {
+			parts[i] = acronym
 			continue
 		}
 		parts[i] = strings.ToUpper(part[:1]) + part[1:]

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -237,17 +237,27 @@ func flattenValue(key string, value any, fieldName string, depth int) []kvRow {
 		if len(v) == 0 {
 			return []kvRow{{key: key, value: "(none)"}}
 		}
-		if isScalarArray(v) {
+		if isHomogeneousScalarArray(v) {
 			return []kvRow{{key: key, value: formatArrayInline(v)}}
 		}
 		if isObjectArray(v) {
 			var rows []kvRow
 			for i, elem := range v {
-				rows = append(rows, flattenObject(elem.(map[string]any), joinKey(key, strconv.Itoa(i)), depth+1)...)
+				elemKey := joinKey(key, strconv.Itoa(i))
+				elemMap := elem.(map[string]any)
+				// An empty object element renders as "(none)" so the index is
+				// not silently dropped (which would create confusing gaps).
+				if len(elemMap) == 0 {
+					rows = append(rows, kvRow{key: elemKey, value: "(none)"})
+					continue
+				}
+				rows = append(rows, flattenObject(elemMap, elemKey, depth+1)...)
 			}
 			return rows
 		}
-		// Heterogeneous or mixed array (e.g. contains null): compact JSON fallback.
+		// Mixed-type scalar array, array containing null, or otherwise
+		// heterogeneous array: compact JSON fallback (preserves type fidelity
+		// that an ambiguous inline join would lose).
 		return []kvRow{{key: key, value: compactJSON(v)}}
 	default:
 		return []kvRow{{key: key, value: formatCell(value, fieldName)}}
@@ -366,6 +376,43 @@ func isScalarArray(v []any) bool {
 		switch elem.(type) {
 		case string, float64, bool:
 		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isHomogeneousScalarArray reports whether every element is a non-nil scalar of
+// the SAME JSON type (all string, all float64, or all bool). The key-value path
+// inline-joins only homogeneous scalar arrays; a mixed-type scalar array returns
+// false so it falls back to compact JSON rather than an ambiguous inline join
+// (e.g. "42, true" hiding whether 42 was a number or a string). The table path
+// uses the looser isScalarArray and is intentionally left unchanged.
+func isHomogeneousScalarArray(v []any) bool {
+	if len(v) == 0 {
+		return false
+	}
+	const (
+		kindString = 1
+		kindFloat  = 2
+		kindBool   = 3
+	)
+	kind := 0
+	for _, elem := range v {
+		var k int
+		switch elem.(type) {
+		case string:
+			k = kindString
+		case float64:
+			k = kindFloat
+		case bool:
+			k = kindBool
+		default:
+			return false
+		}
+		if kind == 0 {
+			kind = k
+		} else if kind != k {
 			return false
 		}
 	}

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -183,23 +183,21 @@ func (f *HumanFormatter) renderObject(obj map[string]any, depth int, firstFieldI
 		}
 	}
 
-	// For sequence items, the caller wrote "<indent>- " and the first field
-	// continues on that line (no own indent); subsequent fields indent by the
-	// marker width so they align under the first field.
-	markerSpaces := strings.Repeat(" ", len(seqMarker))
-
+	// For sequence items the caller wrote "<outer-indent>- " and the first field
+	// continues on that line. The element body is rendered at this depth, which
+	// the caller set to outer-depth+1; because the "- " marker is exactly one
+	// indent unit wide (len(seqMarker) == len(indentUnit)), the marker prefix
+	// occupies exactly `indent` columns. So the first field needs no own indent
+	// (its value aligns at len(indent)), subsequent fields use the normal indent
+	// (lining up under the first field), and nested children of any field recurse
+	// at depth+1 and land correctly one level deeper than the element body.
 	for i, key := range keys {
 		label := humanizeKey(key)
 		fieldIndent := indent
 		markerPad := 0
-		if firstFieldInline {
-			if i == 0 {
-				// First field: caller already positioned the cursor after "- ".
-				fieldIndent = ""
-				markerPad = len(indent) + len(seqMarker)
-			} else {
-				fieldIndent = indent + markerSpaces
-			}
+		if firstFieldInline && i == 0 {
+			fieldIndent = ""
+			markerPad = len(indent)
 		}
 		if err := f.renderField(fieldIndent, label, key, obj[key], depth, labelWidth, markerPad); err != nil {
 			return err
@@ -237,15 +235,19 @@ func isInlineValue(value any, depth int) bool {
 // in formatCell). labelWidth is the per-level scalar label width used for value
 // alignment; extraPad is any sequence-item prefix width on the first line.
 func (f *HumanFormatter) renderField(indent, label, rawKey string, value any, depth, labelWidth, extraPad int) error {
+	// Null renders as (none) at every depth, consistent with empty
+	// objects/arrays and unambiguous versus an empty string. Checked before the
+	// depth cap so a null leaf at maxNestedDepth doesn't fall through to
+	// compactJSON(nil), which would print a blank value.
+	if value == nil {
+		return f.writeInline(indent, label, "(none)", labelWidth, extraPad)
+	}
+
 	if depth >= maxNestedDepth {
 		return f.writeInline(indent, label, compactJSON(value), labelWidth, extraPad)
 	}
 
 	switch v := value.(type) {
-	case nil:
-		// Explicit null renders as (none), consistent with empty objects/arrays
-		// and unambiguous versus an empty string.
-		return f.writeInline(indent, label, "(none)", labelWidth, extraPad)
 	case map[string]any:
 		if len(v) == 0 {
 			return f.writeInline(indent, label, "(none)", labelWidth, extraPad)
@@ -291,12 +293,14 @@ func (f *HumanFormatter) renderObjectArray(elems []any, depth int) error {
 			}
 			continue
 		}
-		// Emit the "- " marker, then render the element's fields. The first
-		// field continues on the marker line; subsequent fields indent under it.
+		// Emit the "- " marker, then render the element's fields one level deeper
+		// (depth+1). The "- " marker is one indent unit wide, so the element body
+		// at depth+1 lines up exactly after the marker, and nested fields recurse
+		// correctly relative to it.
 		if _, err := fmt.Fprintf(f.out, "%s%s", indent, seqMarker); err != nil {
 			return err
 		}
-		if err := f.renderObject(elemMap, depth, true); err != nil {
+		if err := f.renderObject(elemMap, depth+1, true); err != nil {
 			return err
 		}
 	}

--- a/internal/output/human_formatter.go
+++ b/internal/output/human_formatter.go
@@ -145,123 +145,189 @@ func (f *HumanFormatter) renderPrimitiveList(items []any) error {
 	return f.renderTable(rows, []command.Column{{Header: "Value", Field: "value"}})
 }
 
+// renderKeyValue renders a single JSON object as an indented, humanized,
+// kubectl-describe-like layout. Each nesting level indents 2 spaces, labels are
+// humanized per key segment, and scalar siblings within one block are
+// value-aligned to the longest scalar label at that level.
 func (f *HumanFormatter) renderKeyValue(obj map[string]any) error {
-	rows := flattenObject(obj, "", 0)
+	return f.renderObject(obj, 0, false)
+}
 
-	maxLabelWidth := 0
-	for _, r := range rows {
-		if lw := lipgloss.Width(r.key); lw > maxLabelWidth {
-			maxLabelWidth = lw
+const (
+	maxNestedDepth = 5
+	indentUnit     = "  " // one indentation level (2 spaces)
+	labelValueGap  = "  " // gap between a label's colon and its value
+	seqMarker      = "- " // YAML-style array-of-objects sequence-item prefix
+)
+
+// renderObject renders the direct children of obj at the given depth.
+//
+// firstFieldInline signals that the caller has already written the line prefix
+// (indent + a "- " sequence marker) and positioned the cursor for the FIRST
+// field, so that field must be emitted without its own indent. Subsequent
+// fields are emitted with the normal depth indent (which lines them up under
+// the marker). Pass false for ordinary objects.
+func (f *HumanFormatter) renderObject(obj map[string]any, depth int, firstFieldInline bool) error {
+	indent := strings.Repeat(indentUnit, depth)
+	keys := sortedKeys(obj)
+
+	// Per-level alignment: align inline (scalar/leaf) siblings to the longest
+	// such label. Nested-object and array-of-object children render as headers
+	// and do not participate in the value column.
+	labelWidth := 0
+	for _, key := range keys {
+		if isInlineValue(obj[key], depth) {
+			if w := lipgloss.Width(humanizeKey(key)); w > labelWidth {
+				labelWidth = w
+			}
 		}
 	}
 
-	for _, r := range rows {
-		padding := strings.Repeat(" ", max(0, maxLabelWidth-lipgloss.Width(r.key)))
-		if strings.Contains(r.value, "\n") {
-			// Multiline string: align continuation lines under the value column.
-			valueIndent := strings.Repeat(" ", lipgloss.Width(r.key)+len(kvSeparator)+len(padding))
-			lines := strings.Split(r.value, "\n")
-			if _, err := fmt.Fprintf(f.out, "%s:%s  %s\n", r.key, padding, lines[0]); err != nil {
-				return err
+	// For sequence items, the caller wrote "<indent>- " and the first field
+	// continues on that line (no own indent); subsequent fields indent by the
+	// marker width so they align under the first field.
+	markerSpaces := strings.Repeat(" ", len(seqMarker))
+
+	for i, key := range keys {
+		label := humanizeKey(key)
+		fieldIndent := indent
+		markerPad := 0
+		if firstFieldInline {
+			if i == 0 {
+				// First field: caller already positioned the cursor after "- ".
+				fieldIndent = ""
+				markerPad = len(indent) + len(seqMarker)
+			} else {
+				fieldIndent = indent + markerSpaces
 			}
-			for _, line := range lines[1:] {
-				if _, err := fmt.Fprintf(f.out, "%s%s\n", valueIndent, line); err != nil {
-					return err
-				}
-			}
-			continue
 		}
-		if _, err := fmt.Fprintf(f.out, "%s:%s  %s\n", r.key, padding, r.value); err != nil {
+		if err := f.renderField(fieldIndent, label, key, obj[key], depth, labelWidth, markerPad); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-const (
-	maxNestedDepth = 5
-	kvSeparator    = ":  " // label-value separator in key-value output
-)
-
-// kvRow is one rendered line in the flattened key-value output: a dotted key
-// path and its pre-formatted scalar value.
-type kvRow struct {
-	key   string
-	value string
-}
-
-// joinKey joins a parent dotted-key prefix with a child segment.
-func joinKey(prefix, segment string) string {
-	if prefix == "" {
-		return segment
-	}
-	return prefix + "." + segment
-}
-
-// flattenObject recursively flattens a JSON object into dotted-key rows, in
-// sorted-key order. Nested objects become "parent.child" keys.
-func flattenObject(obj map[string]any, prefix string, depth int) []kvRow {
-	var rows []kvRow
-	for _, key := range sortedKeys(obj) {
-		rows = append(rows, flattenValue(joinKey(prefix, key), obj[key], key, depth)...)
-	}
-	return rows
-}
-
-// flattenValue flattens a single value under the given dotted key. fieldName is
-// the leaf field name (used for timestamp/duration heuristics in formatCell).
-//
-// Behavior by value type:
-//   - nested object: flattened into "key.child" rows; empty object -> "(none)".
-//   - scalar array: joined inline, comma-separated.
-//   - array of objects: each element flattened under an index, e.g.
-//     "messages.0.role", "messages.1.role".
-//   - heterogeneous/mixed array (e.g. containing null): compact JSON fallback.
-//   - empty array: "(none)".
-//   - scalars: formatted via formatCell (timestamps, durations, multiline).
-//
-// Beyond maxNestedDepth, the remaining value is emitted as compact JSON rather
-// than flattened further, guarding against pathologically deep payloads.
-func flattenValue(key string, value any, fieldName string, depth int) []kvRow {
+// isInlineValue reports whether value renders inline (on the same line as its
+// label) rather than as a "Label:" header followed by an indented block.
+// Inline values participate in per-level value alignment; headers do not.
+func isInlineValue(value any, depth int) bool {
 	if depth >= maxNestedDepth {
-		return []kvRow{{key: key, value: compactJSON(value)}}
+		return true
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		return len(v) == 0
+	case []any:
+		if len(v) == 0 {
+			return true
+		}
+		if isHomogeneousScalarArray(v) {
+			return true
+		}
+		// Non-empty array of objects renders as a header + sequence items.
+		return !isObjectArray(v)
+	default:
+		return true
+	}
+}
+
+// renderField renders one key/value pair. label is the humanized display key;
+// rawKey is the original JSON key (used for the timestamp/duration heuristics
+// in formatCell). labelWidth is the per-level scalar label width used for value
+// alignment; extraPad is any sequence-item prefix width on the first line.
+func (f *HumanFormatter) renderField(indent, label, rawKey string, value any, depth, labelWidth, extraPad int) error {
+	if depth >= maxNestedDepth {
+		return f.writeInline(indent, label, compactJSON(value), labelWidth, extraPad)
 	}
 
 	switch v := value.(type) {
+	case nil:
+		// Explicit null renders as (none), consistent with empty objects/arrays
+		// and unambiguous versus an empty string.
+		return f.writeInline(indent, label, "(none)", labelWidth, extraPad)
 	case map[string]any:
 		if len(v) == 0 {
-			return []kvRow{{key: key, value: "(none)"}}
+			return f.writeInline(indent, label, "(none)", labelWidth, extraPad)
 		}
-		return flattenObject(v, key, depth+1)
+		if _, err := fmt.Fprintf(f.out, "%s%s:\n", indent, label); err != nil {
+			return err
+		}
+		return f.renderObject(v, depth+1, false)
 	case []any:
 		if len(v) == 0 {
-			return []kvRow{{key: key, value: "(none)"}}
+			return f.writeInline(indent, label, "(none)", labelWidth, extraPad)
 		}
 		if isHomogeneousScalarArray(v) {
-			return []kvRow{{key: key, value: formatArrayInline(v)}}
+			return f.writeInline(indent, label, formatArrayInline(v), labelWidth, extraPad)
 		}
 		if isObjectArray(v) {
-			var rows []kvRow
-			for i, elem := range v {
-				elemKey := joinKey(key, strconv.Itoa(i))
-				elemMap := elem.(map[string]any)
-				// An empty object element renders as "(none)" so the index is
-				// not silently dropped (which would create confusing gaps).
-				if len(elemMap) == 0 {
-					rows = append(rows, kvRow{key: elemKey, value: "(none)"})
-					continue
-				}
-				rows = append(rows, flattenObject(elemMap, elemKey, depth+1)...)
+			if _, err := fmt.Fprintf(f.out, "%s%s:\n", indent, label); err != nil {
+				return err
 			}
-			return rows
+			return f.renderObjectArray(v, depth+1)
 		}
 		// Mixed-type scalar array, array containing null, or otherwise
 		// heterogeneous array: compact JSON fallback (preserves type fidelity
 		// that an ambiguous inline join would lose).
-		return []kvRow{{key: key, value: compactJSON(v)}}
+		return f.writeInline(indent, label, compactJSON(v), labelWidth, extraPad)
 	default:
-		return []kvRow{{key: key, value: formatCell(value, fieldName)}}
+		return f.writeInline(indent, label, formatCell(value, rawKey), labelWidth, extraPad)
 	}
+}
+
+// renderObjectArray renders a non-empty array of objects as a YAML sequence:
+// each element's first field line is prefixed with "- " at the given indent,
+// and the element's remaining fields align under it.
+func (f *HumanFormatter) renderObjectArray(elems []any, depth int) error {
+	indent := strings.Repeat(indentUnit, depth)
+	for _, elem := range elems {
+		elemMap, _ := elem.(map[string]any)
+		// An empty object element renders as "- (none)" so it is not silently
+		// dropped (which would create confusing gaps between siblings).
+		if len(elemMap) == 0 {
+			if _, err := fmt.Fprintf(f.out, "%s%s(none)\n", indent, seqMarker); err != nil {
+				return err
+			}
+			continue
+		}
+		// Emit the "- " marker, then render the element's fields. The first
+		// field continues on the marker line; subsequent fields indent under it.
+		if _, err := fmt.Fprintf(f.out, "%s%s", indent, seqMarker); err != nil {
+			return err
+		}
+		if err := f.renderObject(elemMap, depth, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeInline writes a "<indent><Label>:<pad>  <value>" line, aligning the
+// value to labelWidth. extraPad accounts for a sequence-item marker ("- ")
+// already written on this line by the caller. Multiline values have their
+// continuation lines aligned under the value column.
+func (f *HumanFormatter) writeInline(indent, label, value string, labelWidth, extraPad int) error {
+	pad := strings.Repeat(" ", max(0, labelWidth-lipgloss.Width(label)))
+	if strings.Contains(value, "\n") {
+		// The first field of a sequence item is written without its own indent
+		// (the caller already emitted "<indent>- "); the value column then sits
+		// at indent + extraPad + label + ":" + pad + gap.
+		valueCol := len(indent) + extraPad + lipgloss.Width(label) + 1 + len(pad) + len(labelValueGap)
+		valueIndent := strings.Repeat(" ", valueCol)
+		lines := strings.Split(value, "\n")
+		if _, err := fmt.Fprintf(f.out, "%s%s:%s%s%s\n", indent, label, pad, labelValueGap, lines[0]); err != nil {
+			return err
+		}
+		for _, line := range lines[1:] {
+			if _, err := fmt.Fprintf(f.out, "%s%s\n", valueIndent, line); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	_, err := fmt.Fprintf(f.out, "%s%s:%s%s%s\n", indent, label, pad, labelValueGap, value)
+	return err
 }
 
 func autoColumnsFor(row map[string]any) []command.Column {

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -72,11 +72,14 @@ func TestHumanFormatter_Data_KeyValue(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	want := "id:         vid_123\n" +
-		"meta.kind:  demo\n" +
-		"status:     completed\n"
+	// Nested objects render as an indented "Label:" header block; top-level
+	// scalars align locally, the nested scalar aligns within its own block.
+	want := "Id:      vid_123\n" +
+		"Meta:\n" +
+		"  Kind:  demo\n" +
+		"Status:  completed\n"
 	if got != want {
-		t.Fatalf("flattened key-value output mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+		t.Fatalf("indented key-value output mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -125,7 +128,7 @@ func TestHumanFormatter_Data_DurationFormatting(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "duration:  18s") {
+	if !strings.Contains(got, "Duration:  18s") {
 		t.Fatalf("duration was not formatted as seconds:\n%s", got)
 	}
 }
@@ -140,7 +143,7 @@ func TestHumanFormatter_Data_RegularFloatUnaffected(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "score:  3.14") {
+	if !strings.Contains(got, "Score:  3.14") {
 		t.Fatalf("regular float should remain unchanged:\n%s", got)
 	}
 }
@@ -192,11 +195,14 @@ func TestHumanFormatter_Data_KeyValue_NestedObject(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	want := "error.code:     not_found\n" +
-		"error.message:  Video not found\n" +
-		"id:             vid_1\n"
+	// Nested object renders as a humanized "Error:" header with its children
+	// indented and aligned locally; the top-level Id is a sibling scalar.
+	want := "Error:\n" +
+		"  Code:     not_found\n" +
+		"  Message:  Video not found\n" +
+		"Id:  vid_1\n"
 	if got != want {
-		t.Fatalf("nested object should flatten into dotted keys:\ngot:\n%s\nwant:\n%s", got, want)
+		t.Fatalf("nested object should render as an indented block:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -210,12 +216,17 @@ func TestHumanFormatter_Data_KeyValue_DeepNesting(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	want := "wallet.auto_reload.amount_usd:  50\n" +
-		"wallet.auto_reload.enabled:     true\n" +
-		"wallet.currency:                usd\n" +
-		"wallet.remaining_balance:       150\n"
+	// Each nesting level indents 2 spaces and aligns its scalar siblings
+	// locally: Currency/Remaining Balance align under Wallet; Amount Usd/Enabled
+	// align within Auto Reload.
+	want := "Wallet:\n" +
+		"  Auto Reload:\n" +
+		"    Amount Usd:  50\n" +
+		"    Enabled:     true\n" +
+		"  Currency:           usd\n" +
+		"  Remaining Balance:  150\n"
 	if got != want {
-		t.Fatalf("deeply nested objects should flatten into dotted keys:\ngot:\n%s\nwant:\n%s", got, want)
+		t.Fatalf("deeply nested objects should render as indented blocks:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -229,12 +240,15 @@ func TestHumanFormatter_Data_KeyValue_ArrayOfObjects(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	want := "messages.0.content:  hello\n" +
-		"messages.0.role:     user\n" +
-		"messages.1.content:  hi\n" +
-		"messages.1.role:     model\n"
+	// Array of objects renders as a YAML sequence: each element's first field
+	// carries the "- " marker, remaining fields align under it.
+	want := "Messages:\n" +
+		"  - Content:  hello\n" +
+		"    Role:     user\n" +
+		"  - Content:  hi\n" +
+		"    Role:     model\n"
 	if got != want {
-		t.Fatalf("array of objects should flatten with indexed dotted keys:\ngot:\n%s\nwant:\n%s", got, want)
+		t.Fatalf("array of objects should render as a YAML sequence:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -248,13 +262,13 @@ func TestHumanFormatter_Data_KeyValue_ArrayOfObjects_EmptyElement(t *testing.T) 
 	}
 
 	got := stripANSI(out.String())
-	// An empty object element must render as (none) at its index, not be
-	// dropped (which would leave a confusing gap, e.g. only messages.1.*).
-	if !strings.Contains(got, "messages.0") || !strings.Contains(got, "(none)") {
-		t.Fatalf("empty object element must render as (none), not be dropped:\n%s", got)
-	}
-	if !strings.Contains(got, "messages.1.role") {
-		t.Fatalf("non-empty sibling element should still flatten:\n%s", got)
+	// An empty object element must render as a "- (none)" sequence item, not be
+	// dropped (which would leave a confusing gap between siblings).
+	want := "Messages:\n" +
+		"  - (none)\n" +
+		"  - Role:  model\n"
+	if got != want {
+		t.Fatalf("empty object element must render as a (none) sequence item:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -471,13 +485,16 @@ func TestHumanFormatter_Data_KeyValue_NullValuesInNestedObject(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	// Null leaves render as an empty value (matching formatValue(nil)).
-	want := "a:         \n" +
-		"b:         val\n" +
-		"nested.x:  \n" +
-		"nested.y:  1\n"
+	// Null leaves render as (none), consistent with empty objects/arrays and
+	// unambiguous versus an empty string; the nested object renders as an
+	// indented block with its own local alignment.
+	want := "A:  (none)\n" +
+		"B:  val\n" +
+		"Nested:\n" +
+		"  X:  (none)\n" +
+		"  Y:  1\n"
 	if got != want {
-		t.Fatalf("null values should flatten to empty cells:\ngot:\n%s\nwant:\n%s", got, want)
+		t.Fatalf("null values should render as (none):\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -491,8 +508,10 @@ func TestHumanFormatter_Data_KeyValue_EmptyNestedObjectIsNone(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	want := "id:        x\n" +
-		"settings:  (none)\n"
+	// An empty nested object renders inline as (none), so it aligns with the
+	// sibling scalar Id at this level.
+	want := "Id:        x\n" +
+		"Settings:  (none)\n"
 	if got != want {
 		t.Fatalf("empty nested object should render as (none):\ngot:\n%s\nwant:\n%s", got, want)
 	}

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -54,7 +54,7 @@ func TestHumanFormatter_Data_AutoColumns(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Voice Id") || !strings.Contains(got, "Name") || !strings.Contains(got, "Gender") {
+	if !strings.Contains(got, "Voice ID") || !strings.Contains(got, "Name") || !strings.Contains(got, "Gender") {
 		t.Fatalf("missing auto-generated headers in output:\n%s", got)
 	}
 	if strings.Contains(got, "Showing ") {
@@ -74,7 +74,7 @@ func TestHumanFormatter_Data_KeyValue(t *testing.T) {
 	got := stripANSI(out.String())
 	// Nested objects render as an indented "Label:" header block; top-level
 	// scalars align locally, the nested scalar aligns within its own block.
-	want := "Id:      vid_123\n" +
+	want := "ID:      vid_123\n" +
 		"Meta:\n" +
 		"  Kind:  demo\n" +
 		"Status:  completed\n"
@@ -200,7 +200,7 @@ func TestHumanFormatter_Data_KeyValue_NestedObject(t *testing.T) {
 	want := "Error:\n" +
 		"  Code:     not_found\n" +
 		"  Message:  Video not found\n" +
-		"Id:  vid_1\n"
+		"ID:  vid_1\n"
 	if got != want {
 		t.Fatalf("nested object should render as an indented block:\ngot:\n%s\nwant:\n%s", got, want)
 	}
@@ -549,7 +549,7 @@ func TestHumanFormatter_Data_KeyValue_EmptyNestedObjectIsNone(t *testing.T) {
 	got := stripANSI(out.String())
 	// An empty nested object renders inline as (none), so it aligns with the
 	// sibling scalar Id at this level.
-	want := "Id:        x\n" +
+	want := "ID:        x\n" +
 		"Settings:  (none)\n"
 	if got != want {
 		t.Fatalf("empty nested object should render as (none):\ngot:\n%s\nwant:\n%s", got, want)

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -72,11 +72,11 @@ func TestHumanFormatter_Data_KeyValue(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Id:") || !strings.Contains(got, "vid_123") {
-		t.Fatalf("missing id field in output:\n%s", got)
-	}
-	if !strings.Contains(got, "Meta:\n") || !strings.Contains(got, "Kind:") || !strings.Contains(got, "demo") {
-		t.Fatalf("nested objects should render as indented sub-section:\n%s", got)
+	want := "id:         vid_123\n" +
+		"meta.kind:  demo\n" +
+		"status:     completed\n"
+	if got != want {
+		t.Fatalf("flattened key-value output mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -125,7 +125,7 @@ func TestHumanFormatter_Data_DurationFormatting(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Duration:  18s") {
+	if !strings.Contains(got, "duration:  18s") {
 		t.Fatalf("duration was not formatted as seconds:\n%s", got)
 	}
 }
@@ -140,7 +140,7 @@ func TestHumanFormatter_Data_RegularFloatUnaffected(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Score:  3.14") {
+	if !strings.Contains(got, "score:  3.14") {
 		t.Fatalf("regular float should remain unchanged:\n%s", got)
 	}
 }
@@ -192,14 +192,11 @@ func TestHumanFormatter_Data_KeyValue_NestedObject(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Error:\n") {
-		t.Fatalf("nested object should start a sub-section:\n%s", got)
-	}
-	if !strings.Contains(got, "  Code:") || !strings.Contains(got, "not_found") {
-		t.Fatalf("nested object fields should be indented:\n%s", got)
-	}
-	if !strings.Contains(got, "  Message:") || !strings.Contains(got, "Video not found") {
-		t.Fatalf("nested object fields should be indented:\n%s", got)
+	want := "error.code:     not_found\n" +
+		"error.message:  Video not found\n" +
+		"id:             vid_1\n"
+	if got != want {
+		t.Fatalf("nested object should flatten into dotted keys:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -213,17 +210,12 @@ func TestHumanFormatter_Data_KeyValue_DeepNesting(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Wallet:\n") {
-		t.Fatalf("top-level nested object should start a sub-section:\n%s", got)
-	}
-	if !strings.Contains(got, "  Auto Reload:\n") {
-		t.Fatalf("second-level nested object should start a sub-section:\n%s", got)
-	}
-	if !strings.Contains(got, "    Enabled:") || !strings.Contains(got, "true") {
-		t.Fatalf("third-level fields should be double-indented:\n%s", got)
-	}
-	if !strings.Contains(got, "  Currency:") || !strings.Contains(got, "usd") {
-		t.Fatalf("second-level scalar fields should be indented:\n%s", got)
+	want := "wallet.auto_reload.amount_usd:  50\n" +
+		"wallet.auto_reload.enabled:     true\n" +
+		"wallet.currency:                usd\n" +
+		"wallet.remaining_balance:       150\n"
+	if got != want {
+		t.Fatalf("deeply nested objects should flatten into dotted keys:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -237,14 +229,12 @@ func TestHumanFormatter_Data_KeyValue_ArrayOfObjects(t *testing.T) {
 	}
 
 	got := stripANSI(out.String())
-	if !strings.Contains(got, "Messages:\n") {
-		t.Fatalf("array of objects should start a sub-section:\n%s", got)
-	}
-	if !strings.Contains(got, "[1]") || !strings.Contains(got, "[2]") {
-		t.Fatalf("array entries should be numbered:\n%s", got)
-	}
-	if !strings.Contains(got, "Role:") || !strings.Contains(got, "user") {
-		t.Fatalf("object fields should be rendered:\n%s", got)
+	want := "messages.0.content:  hello\n" +
+		"messages.0.role:     user\n" +
+		"messages.1.content:  hi\n" +
+		"messages.1.role:     model\n"
+	if got != want {
+		t.Fatalf("array of objects should flatten with indexed dotted keys:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -431,6 +421,43 @@ func TestHumanFormatter_Data_KeyValue_DepthGuardUsesCompactJSON(t *testing.T) {
 	}
 	if !strings.Contains(got, `[]`) {
 		t.Fatalf("depth guard should preserve empty arrays as [], not blank:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_NullValuesInNestedObject(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"a":null,"b":"val","nested":{"x":null,"y":1}}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	// Null leaves render as an empty value (matching formatValue(nil)).
+	want := "a:         \n" +
+		"b:         val\n" +
+		"nested.x:  \n" +
+		"nested.y:  1\n"
+	if got != want {
+		t.Fatalf("null values should flatten to empty cells:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_EmptyNestedObjectIsNone(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"id":"x","settings":{}}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	want := "id:        x\n" +
+		"settings:  (none)\n"
+	if got != want {
+		t.Fatalf("empty nested object should render as (none):\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -238,6 +238,43 @@ func TestHumanFormatter_Data_KeyValue_ArrayOfObjects(t *testing.T) {
 	}
 }
 
+func TestHumanFormatter_Data_KeyValue_ArrayOfObjects_EmptyElement(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"messages":[{},{"role":"model"}]}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	// An empty object element must render as (none) at its index, not be
+	// dropped (which would leave a confusing gap, e.g. only messages.1.*).
+	if !strings.Contains(got, "messages.0") || !strings.Contains(got, "(none)") {
+		t.Fatalf("empty object element must render as (none), not be dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "messages.1.role") {
+		t.Fatalf("non-empty sibling element should still flatten:\n%s", got)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_MixedScalarArrayUsesCompactJSON(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	input := json.RawMessage(`{"data":{"items":["hello",42,true]}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	// A mixed-type scalar array falls back to compact JSON rather than an
+	// ambiguous inline join, so string vs number vs bool is not lost.
+	if !strings.Contains(got, `["hello",42,true]`) {
+		t.Fatalf("mixed-type scalar array should render as compact JSON:\n%s", got)
+	}
+}
+
 func TestHumanFormatter_Data_KeyValue_EmptyCollections(t *testing.T) {
 	var out bytes.Buffer
 	f := NewHumanFormatter(&out, &bytes.Buffer{})

--- a/internal/output/human_formatter_test.go
+++ b/internal/output/human_formatter_test.go
@@ -498,6 +498,45 @@ func TestHumanFormatter_Data_KeyValue_NullValuesInNestedObject(t *testing.T) {
 	}
 }
 
+func TestHumanFormatter_Data_KeyValue_ArrayOfObjects_NestedFirstField(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	// A sequence item whose first sorted key (Config) is itself a nested object:
+	// Config's child (Timeout) must indent UNDER Config, while the element's
+	// sibling field (Role) stays aligned with Config under the "- " marker.
+	input := json.RawMessage(`{"data":{"messages":[{"config":{"timeout":10},"role":"user"}]}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	want := "Messages:\n" +
+		"  - Config:\n" +
+		"      Timeout:  10\n" +
+		"    Role:  user\n"
+	if got != want {
+		t.Fatalf("nested first field in a sequence item should not collide with its sibling:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestHumanFormatter_Data_KeyValue_NullAtDepthCap(t *testing.T) {
+	var out bytes.Buffer
+	f := NewHumanFormatter(&out, &bytes.Buffer{})
+
+	// A null leaf at/below the nesting depth cap must still render (none), not a
+	// blank value (the depth-cap path uses compactJSON, which returns "" for nil).
+	input := json.RawMessage(`{"data":{"a":{"b":{"c":{"d":{"e":{"f":null}}}}}}}`)
+	if err := f.Data(input, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "(none)") {
+		t.Fatalf("null leaf at the depth cap should render (none), not blank:\n%s", got)
+	}
+}
+
 func TestHumanFormatter_Data_KeyValue_EmptyNestedObjectIsNone(t *testing.T) {
 	var out bytes.Buffer
 	f := NewHumanFormatter(&out, &bytes.Buffer{})


### PR DESCRIPTION
## Scope

**Surfaces:** CLI | **Module:** Output/Formatter

## Description

`--human` renders single-object API responses as key-value output. A nested object value used to dump as a raw JSON blob (e.g. `heygen auth status --human` showed `wallet` as `{"auto_reload":{"enabled":false},...}`). PRINFRA-153 asks for a readable layout.

This rewrites the single-object path to an **indented, humanized layout similar to `kubectl describe`**. (An interim revision of this PR flattened nesting into dotted keys like `wallet.auto_reload.enabled`; per review we moved to the indented style, which is consistent with the table path — already humanized — and reads better than humanized dotted paths.)

```
Status:  completed
Wallet:
  Auto Reload:
    Enabled:  false
  Currency:           usd
  Remaining Balance:  476.78
Messages:
  - Content:  hello
    Role:     user
```

Approach:
- **Humanized labels per segment** via the existing `humanizeKey` (`auto_reload` -> "Auto Reload"), matching the table headers so list and detail views read consistently.
- **Nested objects** render as a `Label:` header, then recurse at +2 spaces of indent.
- **Per-level local alignment:** scalar siblings align to the longest label *within their own block*, not a single global column, so one deep key no longer pushes every value far right.
- **Arrays of objects** render as YAML-style `- ` sequence items; **homogeneous scalar arrays** join inline (`a, b, c`); **mixed-type or null-containing arrays** fall back to compact JSON (preserving type fidelity); **empty objects/arrays and `null`** render as `(none)`.
- Leaf formatting (Unix-timestamp dates, durations, multiline strings) is preserved; keys are sorted at every level (deterministic output).

JSON output (the default formatter) and the table (array-of-objects) path are untouched. The README also documents `--human` as a may-change presentation layer — scripts and agents should consume the stable default JSON.

## Testing

`make build` and `make test` pass. The key-value unit tests were rewritten to assert the exact indented output (nested object, deep nesting, arrays of objects with `- ` items, per-level alignment, scalar-array inline, mixed/null -> compact JSON, empty collections and `null` -> `(none)`, multiline continuation, depth-guard compact-JSON fallback). Two `--human` assertions outside the package (`generated_root_test.go`, `builder_test.go`) were updated to the humanized labels. The `lint` CI check is green (CI runs a go1.25-compatible golangci-lint). `make lint` fails only on the local devbox, whose installed golangci-lint is built for go1.23 and refuses the go1.25 module — an environment issue, not a code one; `gofmt -l` is clean and `go vet ./internal/output/ ./cmd/heygen/` passes. Reviewed with Codex (4 rounds) plus a PR review that caught a sequence-item nested-first-field indent bug and a null-at-depth-cap inconsistency, both now fixed with tests.

