### PR TITLE
feat(origin): detect parent agent/IDE and propagate to HeyGen API + PostHog

### DIFF
--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/heygen-com/heygen-cli/internal/origin"
 	"github.com/heygen-com/heygen-cli/internal/paths"
 	"github.com/posthog/posthog-go"
 )
@@ -22,11 +23,12 @@ type captureClient interface {
 
 // Client wraps PostHog event capture behind a small no-op-friendly surface.
 type Client struct {
-	ph         captureClient
-	enabled    bool
-	distinctID string
-	version    string
-	started    bool
+	ph           captureClient
+	enabled      bool
+	distinctID   string
+	version      string
+	clientOrigin string
+	started      bool
 }
 
 // New creates an analytics client. Disabled clients are inert no-ops.
@@ -48,10 +50,11 @@ func New(version string, enabled bool) *Client {
 
 func newWithCapture(version string, ph captureClient) *Client {
 	return &Client{
-		ph:         ph,
-		enabled:    true,
-		distinctID: distinctID(),
-		version:    version,
+		ph:           ph,
+		enabled:      true,
+		distinctID:   distinctID(),
+		version:      version,
+		clientOrigin: string(origin.Detect()),
 	}
 }
 
@@ -63,11 +66,7 @@ func (c *Client) CommandRun(command string) {
 	_ = c.ph.Enqueue(posthog.Capture{
 		DistinctId: c.distinctID,
 		Event:      "COMMAND_RUN",
-		Properties: posthog.NewProperties().
-			Set("command", command).
-			Set("cli_version", c.version).
-			Set("os", runtime.GOOS).
-			Set("arch", runtime.GOARCH),
+		Properties: c.baseProperties(command),
 	})
 }
 
@@ -78,16 +77,28 @@ func (c *Client) CommandRunComplete(command string, exitCode int, duration time.
 	_ = c.ph.Enqueue(posthog.Capture{
 		DistinctId: c.distinctID,
 		Event:      "COMMAND_RUN_COMPLETE",
-		Properties: posthog.NewProperties().
-			Set("command", command).
-			Set("cli_version", c.version).
-			Set("os", runtime.GOOS).
-			Set("arch", runtime.GOARCH).
+		Properties: c.baseProperties(command).
 			Set("exit_code", exitCode).
 			Set("duration_ms", duration.Milliseconds()).
 			Set("success", exitCode == 0).
 			Set("error_code", errorCode),
 	})
+}
+
+// baseProperties is the per-event property bundle every CLI event carries.
+// Kept in one place so client_origin / cli_version / os / arch can't drift
+// between COMMAND_RUN and COMMAND_RUN_COMPLETE — funnel queries break when
+// the start and complete events disagree on dimensions.
+func (c *Client) baseProperties(command string) posthog.Properties {
+	props := posthog.NewProperties().
+		Set("command", command).
+		Set("cli_version", c.version).
+		Set("os", runtime.GOOS).
+		Set("arch", runtime.GOARCH)
+	if c.clientOrigin != "" {
+		props = props.Set("client_origin", c.clientOrigin)
+	}
+	return props
 }
 
 func (c *Client) Close() {

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -89,6 +89,48 @@ func TestCommandRunComplete_Properties(t *testing.T) {
 	}
 }
 
+func TestCommandRun_IncludesClientOrigin(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+	client.clientOrigin = "cursor"
+
+	client.CommandRun("heygen video list")
+
+	msg := stub.messages[0].(posthog.Capture)
+	if got := msg.Properties["client_origin"]; got != "cursor" {
+		t.Fatalf("client_origin = %v, want %q", got, "cursor")
+	}
+}
+
+func TestCommandRunComplete_IncludesClientOrigin(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+	client.clientOrigin = "claude_code"
+
+	client.CommandRunComplete("heygen video create", 0, time.Second, "")
+
+	msg := stub.messages[0].(posthog.Capture)
+	if got := msg.Properties["client_origin"]; got != "claude_code" {
+		t.Fatalf("client_origin = %v, want %q", got, "claude_code")
+	}
+}
+
+// Origin "" must NOT land in PostHog as `client_origin: ""` — that would
+// pollute the property's value distribution (the empty bucket and the
+// unknown bucket are different cohorts in funnel analysis).
+func TestCommandRun_OmitsClientOriginWhenEmpty(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+	client.clientOrigin = ""
+
+	client.CommandRun("heygen video list")
+
+	msg := stub.messages[0].(posthog.Capture)
+	if _, present := msg.Properties["client_origin"]; present {
+		t.Fatalf("client_origin set to %v despite empty origin", msg.Properties["client_origin"])
+	}
+}
+
 func TestClose_DisabledNoop(t *testing.T) {
 	client := New("test", false)
 	client.Close()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"net/http"
 	"time"
+
+	"github.com/heygen-com/heygen-cli/internal/origin"
 )
 
 const (
@@ -15,11 +17,12 @@ const (
 // automatic x-api-key header injection, base URL resolution, and
 // User-Agent tagging. Use WithHTTPClient to inject a test transport.
 type Client struct {
-	httpClient *http.Client
-	baseURL    string
-	apiKey     string
-	userAgent  string
-	retry      RetryConfig
+	httpClient   *http.Client
+	baseURL      string
+	apiKey       string
+	userAgent    string
+	clientOrigin string
+	retry        RetryConfig
 }
 
 // Option configures the Client.
@@ -46,14 +49,23 @@ func WithUserAgent(ua string) Option {
 	return func(c *Client) { c.userAgent = ua }
 }
 
+// WithClientOrigin overrides the parent-agent string sent in the
+// X-HeyGen-Client-Origin header. Empty disables the header. By default the
+// constructor calls origin.Detect() once at startup; tests use this to
+// pin a deterministic value.
+func WithClientOrigin(o string) Option {
+	return func(c *Client) { c.clientOrigin = o }
+}
+
 // New creates a Client with the given API key and options.
 func New(apiKey string, opts ...Option) *Client {
 	c := &Client{
-		httpClient: &http.Client{Timeout: DefaultTimeout},
-		baseURL:    DefaultBaseURL,
-		apiKey:     apiKey,
-		userAgent:  DefaultUserAgent,
-		retry:      DefaultRetryConfig(),
+		httpClient:   &http.Client{Timeout: DefaultTimeout},
+		baseURL:      DefaultBaseURL,
+		apiKey:       apiKey,
+		userAgent:    DefaultUserAgent,
+		clientOrigin: string(origin.Detect()),
+		retry:        DefaultRetryConfig(),
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -78,6 +90,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("x-api-key", c.apiKey)
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("X-HeyGen-Source", "cli")
+	if c.clientOrigin != "" {
+		req.Header.Set("X-HeyGen-Client-Origin", c.clientOrigin)
+	}
 	if req.Header.Get("Content-Type") == "" && req.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -42,6 +42,62 @@ func TestClient_Do_InjectsHeaders(t *testing.T) {
 	}
 }
 
+func TestClient_Do_SetsClientOrigin(t *testing.T) {
+	var gotOrigin string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOrigin = r.Header.Get("X-HeyGen-Client-Origin")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key",
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithClientOrigin("claude_code"),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/v3/videos", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotOrigin != "claude_code" {
+		t.Errorf("X-HeyGen-Client-Origin = %q, want %q", gotOrigin, "claude_code")
+	}
+}
+
+// Empty origin must produce NO header at all — an empty header would still
+// land on the wire and downstream attribution would treat empty string as
+// "explicitly unknown" rather than "no signal". They're not the same thing
+// for funnel queries.
+func TestClient_Do_OmitsClientOriginWhenEmpty(t *testing.T) {
+	hadHeader := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadHeader = r.Header["X-Heygen-Client-Origin"]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key",
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithClientOrigin(""),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/v3/videos", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if hadHeader {
+		t.Error("X-HeyGen-Client-Origin header was set despite empty origin")
+	}
+}
+
 func TestClient_Do_SetsContentType(t *testing.T) {
 	var gotContentType string
 

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -1,0 +1,183 @@
+// Package origin identifies the parent agent / IDE / managed sandbox that
+// spawned this heygen-cli invocation, if any.
+//
+// The signal is propagated to the HeyGen API as an X-HeyGen-Client-Origin
+// header (see internal/client) and attached to PostHog analytics events
+// (see internal/analytics). Both surfaces are best-effort attribution —
+// downstream code must tolerate the empty string for "unknown".
+//
+// What we read: well-known environment variable existence (we never read
+// the *value* of an env var — some are API keys) plus filesystem markers
+// for a small number of vendors that don't propagate a unique env var.
+// What we never read: file contents (beyond known kernel/sandbox markers),
+// process arguments, or any user data.
+//
+// Detection rules are ported from the hyperframes-oss CLI's
+// agent_runtime.ts so the two surfaces stay in lockstep on which agent
+// names exist and how each is identified.
+package origin
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// Origin is the opaque identifier surfaced for the parent agent/IDE.
+// Empty string means "no parent detected" — keep this stable since the
+// backend keys on these strings to qualify the request-source label.
+type Origin string
+
+const (
+	None               Origin = ""
+	ClaudeCode         Origin = "claude_code"
+	Codex              Origin = "codex"
+	Cursor             Origin = "cursor"
+	Windsurf           Origin = "windsurf"
+	CopilotAgent       Origin = "copilot_agent"
+	Replit             Origin = "replit"
+	Hermes             Origin = "hermes"
+	Openclaw           Origin = "openclaw"
+	Pi                 Origin = "pi"
+	Cline              Origin = "cline"
+	GeminiCLI          Origin = "gemini_cli"
+	Crush              Origin = "crush"
+	GeminiManagedAgent Origin = "gemini_managed_agent"
+)
+
+// envChecker is a single rule. Order matters: first match wins, so place
+// more specific rules before more generic ones.
+type envChecker struct {
+	name  Origin
+	check func() bool
+}
+
+// envExists returns true iff the named env var is set to a non-empty string.
+// We deliberately key on existence rather than value because some markers
+// (e.g. GEMINI_API_KEY in similar detector packages) are secrets we must
+// never log or compare against.
+func envExists(key string) bool {
+	return os.Getenv(key) != ""
+}
+
+// vendorRules is the ordered env-var rule set, ported from hyperframes-oss
+// packages/cli/src/telemetry/agent_runtime.ts VENDOR_RULES.
+//
+// Each comment cites the source-of-truth in the agent's own code where the
+// marker is set. If you add a vendor, follow the same bar: a marker that the
+// agent provably sets in the spawned subprocess environment (not just a
+// nominal Dockerfile ENV — empirical absence in the published runtime image
+// is why OpenHands was rejected). Verify the rule before shipping.
+var vendorRules = []envChecker{
+	// Anthropic Claude Code — sets CLAUDECODE=1 on every Bash/PowerShell
+	// tool spawn (Shell.ts:321) and CLAUDE_CODE_ENTRYPOINT at startup
+	// (main.tsx:527). Both inherited by every child process.
+	{ClaudeCode, func() bool { return envExists("CLAUDECODE") || envExists("CLAUDE_CODE_ENTRYPOINT") }},
+	// OpenAI Codex. CODEX_THREAD_ID + CODEX_CI are set on every unified-exec
+	// child (codex-rs/protocol/src/shell_environment.rs, process_manager.rs).
+	// CODEX_SANDBOX_NETWORK_DISABLED is set when the network sandbox is
+	// active (default-on). CODEX_HOME is intentionally NOT a marker — it's a
+	// config override, not propagated to spawned children.
+	{Codex, func() bool {
+		return envExists("CODEX_THREAD_ID") || envExists("CODEX_CI") || envExists("CODEX_SANDBOX_NETWORK_DISABLED")
+	}},
+	// Cursor integrated terminal. Exact (case-sensitive) "cursor".
+	{Cursor, func() bool { return os.Getenv("TERM_PROGRAM") == "cursor" }},
+	// Windsurf (Codeium) integrated terminal. Case-INsensitive because
+	// independent detectors disagree on casing ("windsurf" vs "Windsurf").
+	// Marks the editor's integrated terminal, not specifically that the
+	// Cascade agent is driving.
+	{Windsurf, func() bool { return strings.ToLower(os.Getenv("TERM_PROGRAM")) == "windsurf" }},
+	// GitHub Copilot Coding Agent — runs inside GitHub Actions. The
+	// COPILOT_AGENT_ID + RUNNER_NAME markers should be verified against the
+	// public docs before relying on attribution.
+	{CopilotAgent, func() bool {
+		return os.Getenv("GITHUB_ACTIONS") == "true" && (envExists("COPILOT_AGENT_ID") || os.Getenv("RUNNER_NAME") == "Copilot")
+	}},
+	// Replit workspace. REPL_ID + REPLIT_USER are long-documented
+	// (https://docs.replit.com/replit-workspace/configuring-the-environment).
+	{Replit, func() bool { return envExists("REPL_ID") || envExists("REPLIT_USER") }},
+	// Nous Research Hermes Agent — cli.py:50 sets HERMES_QUIET="1"
+	// unconditionally at module load (https://github.com/NousResearch/hermes-agent).
+	{Hermes, func() bool { return envExists("HERMES_QUIET") }},
+	// openclaw multi-channel AI gateway — propagates OPENCLAW_STATE_DIR /
+	// OPENCLAW_CONFIG_PATH to every spawned CLI subprocess
+	// (https://github.com/openclaw/openclaw).
+	{Openclaw, func() bool { return envExists("OPENCLAW_STATE_DIR") || envExists("OPENCLAW_CONFIG_PATH") }},
+	// Pi coding agent (https://pi.dev) — packages/coding-agent/src/cli.ts:13
+	// sets PI_CODING_AGENT="true" at module entry.
+	{Pi, func() bool { return envExists("PI_CODING_AGENT") }},
+	// Cline VS Code extension — VscodeTerminalRegistry.ts:29 injects
+	// CLINE_ACTIVE=true via the integrated-terminal env.
+	{Cline, func() bool { return envExists("CLINE_ACTIVE") }},
+	// Google Gemini CLI (open-source @google/gemini-cli) — distinct from
+	// the Gemini managed-agent sandbox above. shellExecutionService.ts sets
+	// GEMINI_CLI=1 on every shell command's child env.
+	{GeminiCLI, func() bool { return envExists("GEMINI_CLI") }},
+	// Crush (charmbracelet/crush) — internal/shell/shell.go appends CRUSH=1
+	// to every shell it spawns. AGENT/AI_AGENT are too generic to key on.
+	{Crush, func() bool { return envExists("CRUSH") }},
+}
+
+// Detect identifies the parent agent/IDE for this heygen-cli invocation,
+// or returns None for a normal interactive shell. Cheap to call — the
+// filesystem branch only runs on Linux and only stat-checks two paths.
+//
+// Caller convention: call once at startup, cache the result for the
+// process lifetime (parent context doesn't change mid-invocation).
+func Detect() Origin {
+	// Filesystem-anchored detector ahead of the env-var loop: the Gemini
+	// managed-agent sandbox is identified by a /.agents/ mount + gVisor
+	// kernel pairing, not by env vars (GEMINI_API_KEY is user-settable on
+	// any host).
+	if isGeminiManagedAgent() {
+		return GeminiManagedAgent
+	}
+	for _, rule := range vendorRules {
+		if rule.check() {
+			return rule.name
+		}
+	}
+	return None
+}
+
+// isGeminiManagedAgent — Google Managed Agents platform. The runtime mounts
+// /.agents/ for agent definitions (instructions + skills) and runs the
+// sandbox under a gVisor kernel. We require BOTH signals to fire because
+// neither alone is unique: nothing on gVisor (Cloud Run gen2, GKE Sandbox,
+// Fly.io) mounts /.agents/ at the root, but a user could in principle
+// create /.agents/ on any host; gVisor rules out that edge.
+//
+// We key on the DIRECTORY (not /.agents/AGENTS.md) since AGENTS.md is
+// optional per Google's docs — an agent may declare its instructions
+// inline via agent.yaml system_instruction.
+func isGeminiManagedAgent() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	info, err := os.Stat("/.agents")
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	return isGVisor()
+}
+
+// isGVisor — gVisor reports kernel string "4.19.0-gvisor" (current) or
+// "4.4.0" (legacy Sentry). 4.19.0-gvisor is unambiguous; 4.4.0 collides
+// with Ubuntu 16.04 LTS and is only accepted when /proc/version also
+// contains the "gVisor" string.
+func isGVisor() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if uname, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
+		if strings.Contains(string(uname), "gvisor") {
+			return true
+		}
+	}
+	procVersion, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(procVersion), "gVisor")
+}

--- a/internal/origin/origin_test.go
+++ b/internal/origin/origin_test.go
@@ -1,0 +1,174 @@
+package origin
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// envKeysToClear lists every variable any vendor rule reads. We blank all of
+// them around each subtest so the host shell's environment can't make a
+// rule fire that the test didn't ask for (e.g. a developer running tests
+// from inside a Cursor terminal would otherwise see Cursor "leak" into an
+// unrelated subtest).
+var envKeysToClear = []string{
+	"CLAUDECODE",
+	"CLAUDE_CODE_ENTRYPOINT",
+	"CODEX_THREAD_ID",
+	"CODEX_CI",
+	"CODEX_SANDBOX_NETWORK_DISABLED",
+	"TERM_PROGRAM",
+	"GITHUB_ACTIONS",
+	"COPILOT_AGENT_ID",
+	"RUNNER_NAME",
+	"REPL_ID",
+	"REPLIT_USER",
+	"HERMES_QUIET",
+	"OPENCLAW_STATE_DIR",
+	"OPENCLAW_CONFIG_PATH",
+	"PI_CODING_AGENT",
+	"CLINE_ACTIVE",
+	"GEMINI_CLI",
+	"CRUSH",
+}
+
+func withCleanEnv(t *testing.T, set map[string]string) {
+	t.Helper()
+	for _, k := range envKeysToClear {
+		t.Setenv(k, "")
+	}
+	for k, v := range set {
+		t.Setenv(k, v)
+	}
+}
+
+func TestDetect_NoSignals(t *testing.T) {
+	withCleanEnv(t, nil)
+	if got := Detect(); got != None {
+		t.Fatalf("Detect() = %q, want %q (no env signals)", got, None)
+	}
+}
+
+func TestDetect_VendorRules(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want Origin
+	}{
+		// Claude Code — both markers fire the rule independently.
+		{"claude_code via CLAUDECODE", map[string]string{"CLAUDECODE": "1"}, ClaudeCode},
+		{"claude_code via CLAUDE_CODE_ENTRYPOINT", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, ClaudeCode},
+
+		// Codex — three markers, all fire the rule independently.
+		{"codex via CODEX_THREAD_ID", map[string]string{"CODEX_THREAD_ID": "abc"}, Codex},
+		{"codex via CODEX_CI", map[string]string{"CODEX_CI": "1"}, Codex},
+		{"codex via CODEX_SANDBOX_NETWORK_DISABLED", map[string]string{"CODEX_SANDBOX_NETWORK_DISABLED": "1"}, Codex},
+
+		// Cursor — case-sensitive match on TERM_PROGRAM.
+		{"cursor exact", map[string]string{"TERM_PROGRAM": "cursor"}, Cursor},
+		// Case-mismatch regression: "Cursor" must NOT match the Cursor rule.
+		// It does, however, satisfy the Windsurf rule's lowercase comparison
+		// — oh wait, no, "Cursor"→"cursor" ≠ "windsurf". So this returns None.
+		{"cursor wrong case → None", map[string]string{"TERM_PROGRAM": "Cursor"}, None},
+
+		// Windsurf — case-insensitive match on TERM_PROGRAM.
+		{"windsurf lowercase", map[string]string{"TERM_PROGRAM": "windsurf"}, Windsurf},
+		{"windsurf titlecase", map[string]string{"TERM_PROGRAM": "Windsurf"}, Windsurf},
+		{"windsurf uppercase", map[string]string{"TERM_PROGRAM": "WINDSURF"}, Windsurf},
+
+		// Copilot — needs both GITHUB_ACTIONS=true AND a Copilot marker.
+		{"copilot_agent via COPILOT_AGENT_ID", map[string]string{"GITHUB_ACTIONS": "true", "COPILOT_AGENT_ID": "x"}, CopilotAgent},
+		{"copilot_agent via RUNNER_NAME=Copilot", map[string]string{"GITHUB_ACTIONS": "true", "RUNNER_NAME": "Copilot"}, CopilotAgent},
+		// Without GITHUB_ACTIONS the rule must NOT fire — a hand-set
+		// COPILOT_AGENT_ID outside Actions is not the Copilot agent runner.
+		{"copilot_agent without GITHUB_ACTIONS → None", map[string]string{"COPILOT_AGENT_ID": "x"}, None},
+		// GITHUB_ACTIONS alone with a non-Copilot runner is just a normal CI job.
+		{"plain github actions → None", map[string]string{"GITHUB_ACTIONS": "true", "RUNNER_NAME": "ubuntu-22.04"}, None},
+
+		// Remaining single-marker rules.
+		{"replit via REPL_ID", map[string]string{"REPL_ID": "x"}, Replit},
+		{"replit via REPLIT_USER", map[string]string{"REPLIT_USER": "x"}, Replit},
+		{"hermes via HERMES_QUIET", map[string]string{"HERMES_QUIET": "1"}, Hermes},
+		{"openclaw via OPENCLAW_STATE_DIR", map[string]string{"OPENCLAW_STATE_DIR": "/x"}, Openclaw},
+		{"openclaw via OPENCLAW_CONFIG_PATH", map[string]string{"OPENCLAW_CONFIG_PATH": "/x"}, Openclaw},
+		{"pi via PI_CODING_AGENT", map[string]string{"PI_CODING_AGENT": "1"}, Pi},
+		{"cline via CLINE_ACTIVE", map[string]string{"CLINE_ACTIVE": "true"}, Cline},
+		{"gemini_cli via GEMINI_CLI", map[string]string{"GEMINI_CLI": "1"}, GeminiCLI},
+		{"crush via CRUSH", map[string]string{"CRUSH": "1"}, Crush},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withCleanEnv(t, tc.env)
+			if got := Detect(); got != tc.want {
+				t.Fatalf("Detect() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDetect_FirstMatchWins anchors the ordering invariant in vendorRules.
+// Claude Code is listed first, so when both CLAUDECODE and a Cursor-style
+// TERM_PROGRAM are set, the answer must be claude_code — not Cursor — and
+// must not depend on Go's map-iteration order.
+func TestDetect_FirstMatchWins(t *testing.T) {
+	withCleanEnv(t, map[string]string{
+		"CLAUDECODE":   "1",
+		"TERM_PROGRAM": "cursor",
+	})
+	if got := Detect(); got != ClaudeCode {
+		t.Fatalf("Detect() = %q, want %q (claude_code outranks cursor in vendorRules)", got, ClaudeCode)
+	}
+}
+
+func TestDetect_EmptyEnvVarIsNotSet(t *testing.T) {
+	// `CLAUDECODE=""` is how shells unset a var via os.Setenv. envExists must
+	// treat that as "not set" — otherwise every host with empty inherited
+	// shell vars would report claude_code.
+	withCleanEnv(t, map[string]string{"CLAUDECODE": ""})
+	if got := Detect(); got != None {
+		t.Fatalf("Detect() = %q, want %q (empty string must be treated as unset)", got, None)
+	}
+}
+
+// TestIsGeminiManagedAgent_NonLinuxShortCircuits — without this short-circuit
+// the macOS/Windows code path would hit os.ReadFile("/proc/version"), which
+// is fine (returns an error) but it's worth pinning the early return.
+func TestIsGeminiManagedAgent_NonLinuxShortCircuits(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("only meaningful on non-linux")
+	}
+	if isGeminiManagedAgent() {
+		t.Fatal("isGeminiManagedAgent() = true on non-linux, want false")
+	}
+}
+
+// TestIsGVisor_OnRealHost is a sanity guard: the test host is the dev
+// box, which is NOT gVisor. If this ever returns true on a non-gVisor
+// host the detector is over-eager and would mislabel real CI runs.
+func TestIsGVisor_OnRealHost(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("only runs on linux")
+	}
+	// If we ARE on a gVisor host (very unlikely in CI), skip — the test is
+	// guarding the false-positive direction.
+	if data, err := os.ReadFile("/proc/version"); err == nil {
+		if contains(data, "gVisor") {
+			t.Skip("running on gVisor; test guards the non-gVisor case")
+		}
+	}
+	if isGVisor() {
+		t.Fatal("isGVisor() = true on non-gVisor host")
+	}
+}
+
+func contains(haystack []byte, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if string(haystack[i:i+len(needle)]) == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description

Adds a new `internal/origin` package that detects which parent agent / IDE / managed sandbox launched the CLI, and wires the result into two outbound surfaces:

1. **`X-HeyGen-Client-Origin: <origin>`** header on every HTTP request from the CLI (`internal/client/client.go`). The header is omitted when origin is unknown so the backend can distinguish *unknown* from *explicit-empty*. This matches the existing self-declared-trust pattern of `X-HeyGen-Client-User-Agent`.
2. **`client_origin`** property on every PostHog event from the CLI (`internal/analytics/analytics.go`). Same omit-when-empty rule so funnel queries get clean cohorts.

`Detect()` is called once at startup from `client.New` and `analytics.newWithCapture` and the result is cached for the process lifetime — parent context doesn't change mid-invocation.

### Why

The backend's `compute_request_source` label scheme currently produces `cli` / `cli:api_key` for every CLI invocation, regardless of whether it came from a developer in `claude_code`, `cursor`, a CI runner, or a plain shell. User-agent matching server-side is fragile and our internal CLI ships a generic UA. A self-declared client header is honest about the trust model and lets the backend follow up with `cli:claude_code`, `cli:cursor`, etc., falling back to today's behavior when the header is absent.

This is the CLI half of the change. A follow-up backend PR (stacked on the in-flight one that just dropped server-side cli provider-qualification) will read the header.

### Detection rules

Ported from hyperframes-oss `packages/cli/src/telemetry/agent_runtime.ts` so the two CLIs stay in lockstep on which agent names exist and how each is identified. Existence checks only — we never read the *value* of an env var (some are secrets).

| Origin | Trigger |
|---|---|
| `claude_code` | `CLAUDECODE` or `CLAUDE_CODE_ENTRYPOINT` |
| `codex` | `CODEX_THREAD_ID` or `CODEX_CI` or `CODEX_SANDBOX_NETWORK_DISABLED` |
| `cursor` | `TERM_PROGRAM=cursor` (exact) |
| `windsurf` | `TERM_PROGRAM` ~ `windsurf` (case-insensitive) |
| `copilot_agent` | `GITHUB_ACTIONS=true` AND (`COPILOT_AGENT_ID` set OR `RUNNER_NAME=Copilot`) |
| `replit` | `REPL_ID` or `REPLIT_USER` |
| `hermes` | `HERMES_QUIET` |
| `openclaw` | `OPENCLAW_STATE_DIR` or `OPENCLAW_CONFIG_PATH` |
| `pi` | `PI_CODING_AGENT` |
| `cline` | `CLINE_ACTIVE` |
| `gemini_cli` | `GEMINI_CLI` |
| `crush` | `CRUSH` |
| `gemini_managed_agent` | `/.agents/` is a directory AND gVisor kernel detected (`4.19.0-gvisor` osrelease or `gVisor` in `/proc/version`) |

First match wins; ordering pinned by test (`TestDetect_FirstMatchWins`).

## Testing

- `go test ./internal/origin/...` — 25 subcases covering every vendor rule, empty-env baseline, case-sensitivity (cursor exact vs windsurf case-insensitive), first-match-wins ordering, Copilot's two-marker conjunction, and the non-Linux short-circuit on `isGeminiManagedAgent`.
- `go test ./internal/client/...` — added `TestClient_Do_SetsClientOrigin` (header present when origin set) and `TestClient_Do_OmitsClientOriginWhenEmpty` (no header at all when origin empty — `http.Header` map key absent, not empty string value).
- `go test ./internal/analytics/...` — added `TestCommandRun_IncludesClientOrigin`, `TestCommandRunComplete_IncludesClientOrigin`, and `TestCommandRun_OmitsClientOriginWhenEmpty`.
- `go test ./...` — full suite green.
- `make build` — builds locally.
- `golangci-lint run ./...` (v2.11.4, matching CI) — 0 issues.

Follow-up: backend PR will read `X-HeyGen-Client-Origin` from `compute_request_source` to produce `cli:<origin>` labels.

_PR by Jerrai_