### PR TITLE
fix(cli): serialize string-slice query params as repeated keys

### DIFF
--- a/internal/command/spec.go
+++ b/internal/command/spec.go
@@ -210,7 +210,19 @@ func (s *Spec) BuildInvocation(cmd *cobra.Command, args []string, data map[strin
 
 		switch flag.Source {
 		case "query":
-			inv.QueryParams.Add(flag.JSONName, getFlagAsString(cmd, flag))
+			if flag.Type == "string-slice" {
+				// Repeatable query param: emit one key per value (?type=image&type=icon,
+				// style=form/explode=true). getFlagAsString can't express this (a single
+				// string), and GetString on a slice flag returns "", which silently drops
+				// the filter. GetStringSlice also splits a comma form, so both
+				// `--type image,icon` and `--type image --type icon` expand the same way.
+				vals, _ := cmd.Flags().GetStringSlice(flag.Name)
+				for _, v := range vals {
+					inv.QueryParams.Add(flag.JSONName, v)
+				}
+			} else {
+				inv.QueryParams.Add(flag.JSONName, getFlagAsString(cmd, flag))
+			}
 		case "body":
 			if inv.Body == nil {
 				inv.Body = make(map[string]any)

--- a/internal/command/spec_test.go
+++ b/internal/command/spec_test.go
@@ -57,6 +57,45 @@ func TestBuildInvocation_QueryParamFlag(t *testing.T) {
 	}
 }
 
+func TestBuildInvocation_StringSliceQueryParamRepeatsKeys(t *testing.T) {
+	// A string-slice query param serializes as repeated keys (?type=image&type=icon),
+	// NOT a single comma-joined value and NOT an empty value (the old GetString-on-slice bug).
+	spec := &Spec{
+		Flags: []FlagSpec{
+			{Name: "type", Type: "string-slice", Source: "query", JSONName: "type"},
+		},
+	}
+	cmd := helperCmd(t, spec, []string{"--type", "image", "--type", "icon"})
+
+	inv, err := spec.BuildInvocation(cmd, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := inv.QueryParams["type"]
+	if len(got) != 2 || got[0] != "image" || got[1] != "icon" {
+		t.Errorf("QueryParams[type] = %v, want [image icon] (repeated keys)", got)
+	}
+}
+
+func TestBuildInvocation_StringSliceQueryParamCommaForm(t *testing.T) {
+	// The comma form (--type image,icon) also expands to repeated keys, since Cobra's
+	// GetStringSlice splits on commas.
+	spec := &Spec{
+		Flags: []FlagSpec{
+			{Name: "type", Type: "string-slice", Source: "query", JSONName: "type"},
+		},
+	}
+	cmd := helperCmd(t, spec, []string{"--type", "image,icon"})
+
+	inv, err := spec.BuildInvocation(cmd, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := inv.QueryParams["type"]; len(got) != 2 || got[0] != "image" || got[1] != "icon" {
+		t.Errorf("QueryParams[type] = %v, want [image icon]", got)
+	}
+}
+
 func TestBuildInvocation_BodyFieldFlag(t *testing.T) {
 	spec := &Spec{
 		Flags: []FlagSpec{


### PR DESCRIPTION
## Summary
Fix string-slice query-param serialization so a repeatable query flag (e.g. `--type` on `assets search`) is sent as repeated keys (`?type=image&type=icon`) instead of being silently dropped.

## Root cause
`getFlagAsString` has no `string-slice` case, so a slice query flag fell to the `default` branch and called `GetString` on a `StringSlice` flag, which returns `""`. The CLI therefore sent an empty `type=` and the API ignored the filter entirely. `heygen assets search --type icon` returned all media types.

## Fix
In the `query` branch of `BuildInvocation`, for `string-slice` flags, add one query value per slice element. `url.Values` serializes these as repeated keys (`style=form`, `explode=true`), matching the API wire format (the backend now reads `request.args.getlist`). Both `--type image --type icon` and `--type image,icon` expand identically via Cobra's `GetStringSlice`. The scalar path (`getFlagAsString`) and body-source slices (`getFlagValue`) are unchanged.

## Testing
- Unit tests for both invocation forms (repeated flags and comma form) asserting two query values.
- Verified live against prod: `assets search --type icon` now correctly filters to icons (previously returned all types).
