### PR TITLE
feat(cli): hide under-development commands from help via a hard-coded list

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -21,6 +21,25 @@ import (
 	"golang.org/x/term"
 )
 
+// hiddenCommands lists generated commands that remain fully functional but are omitted from
+// `--help` listings (Cobra Hidden) — for endpoints that exist in the OpenAPI spec but aren't
+// announced yet (still under development). The spec is the source of truth for what exists; this
+// hard-coded list is the CLI-side decision of what's discoverable. A hidden command still runs if
+// invoked directly, and its own `--help` works. Keyed by "METHOD /path" so it survives command
+// renames (e.g. an x-cli-action verb change).
+// To surface a command in --help, remove its entry here. This list is transitional, for endpoints
+// under development pre-launch; for a permanent hidden-from-help posture, plumb an `x-cli-hidden`
+// extension from the OpenAPI spec instead of hard-coding it here, so the spec stays the source of
+// truth.
+var hiddenCommands = map[string]bool{
+	"GET /v3/assets/search": true, // asset search — pre-launch, not yet announced
+}
+
+// isHiddenCommand reports whether the command for this spec should be omitted from help listings.
+func isHiddenCommand(spec *command.Spec) bool {
+	return hiddenCommands[strings.ToUpper(spec.Method)+" "+spec.Endpoint]
+}
+
 // buildCobraCommand creates a Cobra command from a command.Spec.
 // It registers typed flags, sets up positional arg validation, and wires
 // RunE to build an Invocation and execute it through the HTTP client.
@@ -37,6 +56,7 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 		Short:   spec.Summary,
 		Long:    description,
 		Example: strings.Join(spec.Examples, "\n"),
+		Hidden:  isHiddenCommand(spec),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if isSchemaRequest(cmd) {
 				return nil

--- a/cmd/heygen/help_flatten.go
+++ b/cmd/heygen/help_flatten.go
@@ -176,3 +176,20 @@ func visibleChildren(cmd *cobra.Command) []*cobra.Command {
 func isLeafCommand(cmd *cobra.Command) bool {
 	return len(visibleChildren(cmd)) == 0
 }
+
+// hideEmptyGroups hides any group command left with no visible children — e.g. an intermediate
+// group whose only leaf is in hiddenCommands. Without this, such a group reads as a leaf to the
+// flattened help and renders as a phantom entry. Runs bottom-up so a group whose children all
+// become hidden is itself hidden. The underlying command stays reachable and runnable; only its
+// help listing is suppressed.
+func hideEmptyGroups(cmd *cobra.Command) {
+	for _, child := range cmd.Commands() {
+		hideEmptyGroups(child)
+	}
+	// A command with subcommands but no visible ones is an empty group (e.g. its only leaf is in
+	// hiddenCommands). Hide it. Leaves have no subcommands, so they're unaffected; intermediate
+	// groups carry a help-showing RunE, so we must not gate on Runnable().
+	if cmd.HasSubCommands() && len(visibleChildren(cmd)) == 0 {
+		cmd.Hidden = true
+	}
+}

--- a/cmd/heygen/hidden_commands_test.go
+++ b/cmd/heygen/hidden_commands_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/heygen-com/heygen-cli/internal/command"
+	"github.com/spf13/cobra"
+)
+
+func TestIsHiddenCommand(t *testing.T) {
+	hidden := &command.Spec{Group: "asset", Name: "search", Method: "GET", Endpoint: "/v3/assets/search"}
+	if !isHiddenCommand(hidden) {
+		t.Error("GET /v3/assets/search should be hidden")
+	}
+	// Method match is case-insensitive (specs may carry a lowercased method).
+	lower := &command.Spec{Group: "asset", Name: "search", Method: "get", Endpoint: "/v3/assets/search"}
+	if !isHiddenCommand(lower) {
+		t.Error("method match should be case-insensitive")
+	}
+	visible := &command.Spec{Group: "video", Name: "list", Method: "GET", Endpoint: "/v3/videos"}
+	if isHiddenCommand(visible) {
+		t.Error("GET /v3/videos should not be hidden")
+	}
+}
+
+func TestBuildCobraCommand_HiddenWiring(t *testing.T) {
+	ctx := testCmdContext()
+
+	hidden := buildCobraCommand(&command.Spec{
+		Group: "asset", Name: "search", Method: "GET", Endpoint: "/v3/assets/search",
+		Summary: "Search assets", Examples: []string{"heygen asset search --query x"},
+	}, ctx)
+	if !hidden.Hidden {
+		t.Error("asset search should be Cobra-Hidden (functional but omitted from help listings)")
+	}
+	// A hidden command must still be runnable and have its own help.
+	if hidden.RunE == nil {
+		t.Error("hidden command should still be runnable (RunE wired)")
+	}
+
+	visible := buildCobraCommand(&command.Spec{
+		Group: "video", Name: "list", Method: "GET", Endpoint: "/v3/videos",
+		Summary: "List videos", Examples: []string{"heygen video list"},
+	}, ctx)
+	if visible.Hidden {
+		t.Error("video list should not be hidden")
+	}
+}
+
+// TestHideEmptyGroups covers the multi-word case: when a hidden leaf's only sibling-set under an
+// intermediate group is itself, the intermediate group must also be hidden so it doesn't leak into
+// help as a phantom entry. The leaf stays runnable.
+func TestHideEmptyGroups(t *testing.T) {
+	asset := &cobra.Command{Use: "asset"}
+	create := &cobra.Command{Use: "create", RunE: func(*cobra.Command, []string) error { return nil }}
+	search := &cobra.Command{Use: "search"}
+	list := &cobra.Command{Use: "list", Hidden: true, RunE: func(*cobra.Command, []string) error { return nil }}
+	search.AddCommand(list)
+	asset.AddCommand(create, search)
+
+	hideEmptyGroups(asset)
+
+	if !search.Hidden {
+		t.Error("intermediate 'search' group with only a hidden leaf should be hidden")
+	}
+	if asset.Hidden {
+		t.Error("'asset' group with a visible child should stay visible")
+	}
+	if !list.Hidden || list.RunE == nil {
+		t.Error("hidden leaf should remain hidden and runnable")
+	}
+}

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -50,6 +50,7 @@ func newRootCmd(version string, formatter output.Formatter, analyticsClient *ana
 	registerGroups(root, ctx, gen.Groups)
 	attachCustomCommands(root, ctx)
 	attachDeprecatedAliases(root, ctx)
+	hideEmptyGroups(root)
 	installFlattenedHelp(root)
 	installRootHelpFooter(root)
 
@@ -117,6 +118,7 @@ func newRootCmdWithSpecs(version string, formatter output.Formatter, analyticsCl
 	registerGroups(root, ctx, groups)
 	attachCustomCommands(root, ctx)
 	attachDeprecatedAliases(root, ctx)
+	hideEmptyGroups(root)
 	installFlattenedHelp(root)
 
 	return root

--- a/codegen/examples/asset.yaml
+++ b/codegen/examples/asset.yaml
@@ -3,9 +3,9 @@
     cmd: "heygen asset create --file ./video.mp4"
 "GET /v3/assets/search":
   - desc: "Search the asset library by natural-language description"
-    cmd: "heygen asset search list --query 'pepperoni pizza on a wooden table'"
+    cmd: "heygen asset search --query 'pepperoni pizza on a wooden table'"
   - desc: "Search for icons only, with a relevance floor and a page size"
-    cmd: "heygen asset search list --query 'minimalist rocket icon' --type icon --min-score 0.3 --limit 10"
+    cmd: "heygen asset search --query 'minimalist rocket icon' --type icon --min-score 0.3 --limit 10"
 "GET /v3/assets/{asset_id}":
   - desc: "Get metadata for an asset"
     cmd: "heygen asset get <asset-id>"


### PR DESCRIPTION
## Summary
Adds a hard-coded `hiddenCommands` allowlist so a generated command can be omitted from `--help` listings while staying fully functional , for endpoints that exist in the OpenAPI spec but aren't announced yet (under development). This is the CLI analog of the API's `x-excluded` (reachable, not advertised).

## Motivation
The codegen is binary today: a command is either generated (visible in help + functional) or excluded (`x-cli-visible: false`, not generated at all). There was no "works if you know it, hidden from help" posture.

## How it works
- A hard-coded `hiddenCommands` map keyed by `METHOD /path` (stable across command renames) sets Cobra `Hidden`. The spec stays the source of truth for what exists; this list is the CLI-side decision of what is discoverable.
- A hidden command is omitted from help listings but runs if invoked, and its own `--help` works.
- `hideEmptyGroups` also hides an intermediate group left empty when its only leaf is hidden, so a multi-word command doesn't leak a phantom group entry into help.
- Hides `GET /v3/assets/search` (asset search) pre-launch.

## Testing
Unit tests for the allowlist match (case-insensitive method), the Cobra `Hidden` wiring, and `hideEmptyGroups`. Verified on a real build that `asset search` is absent from `heygen asset --help` for both the single-leaf and multi-word command shapes, while remaining reachable and runnable with a working `--help`.
