### PR TITLE
codegen: drop --min-score from asset search example

### DIFF
--- a/codegen/examples/asset.yaml
+++ b/codegen/examples/asset.yaml
@@ -4,8 +4,8 @@
 "GET /v3/assets/search":
   - desc: "Search the asset library by natural-language description"
     cmd: "heygen asset search --query 'pepperoni pizza on a wooden table'"
-  - desc: "Search for icons only, with a relevance floor and a page size"
-    cmd: "heygen asset search --query 'minimalist rocket icon' --type icon --min-score 0.3 --limit 10"
+  - desc: "Search for icons only, with a page size"
+    cmd: "heygen asset search --query 'minimalist rocket icon' --type icon --limit 10"
 "GET /v3/assets/{asset_id}":
   - desc: "Get metadata for an asset"
     cmd: "heygen asset get <asset-id>"


### PR DESCRIPTION
## Summary
Removes `--min-score` from the `GET /v3/assets/search` codegen example so the next `gen/` resync doesn't ship a `--help` example referencing a flag the parser no longer accepts.

## Context
experiment-framework is dropping the public `min_score` query param from `/v3/assets/search` (relevance gating moves server-side). Codegen examples are stored as plain strings and are NOT validated against the regenerated flag set, so once the EF spec change deploys and the next `codegen: resync gen/ from EF` runs, the regenerated binary would advertise `heygen asset search ... --min-score 0.3` in `--help` while the argv parser rejects `--min-score`. Fixing the source example here pre-empts that regression; `gen/asset.go` regenerates from this source on the next resync.

## Testing
Example-only change (`codegen/examples/asset.yaml`). No flag/behavior change in the current binary.
