### PR TITLE
feat(cli): add --headers flag with allowlist validation

### DIFF
--- a/cmd/heygen/context.go
+++ b/cmd/heygen/context.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"net/textproto"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/heygen-com/heygen-cli/internal/auth"
 	"github.com/heygen-com/heygen-cli/internal/client"
@@ -123,10 +126,18 @@ func initContext(cmd *cobra.Command, version string, ctx *cmdContext) error {
 		return clierrors.NewUsage("HEYGEN_API_BASE uses HTTP which transmits API keys in plaintext. Set HEYGEN_ALLOW_HTTP=1 to allow.")
 	}
 
-	ctx.client = client.New(result.Key,
+	opts := []client.Option{
 		client.WithBaseURL(baseURL),
-		client.WithUserAgent("heygen-cli/"+version),
-	)
+		client.WithUserAgent("heygen-cli/" + version),
+	}
+	if hdrs, _ := cmd.Flags().GetStringArray("headers"); len(hdrs) > 0 {
+		parsed, err := parseAndValidateHeaders(hdrs)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, client.WithExtraHeaders(parsed))
+	}
+	ctx.client = client.New(result.Key, opts...)
 
 	human, _ := cmd.Flags().GetBool("human")
 	if human {
@@ -134,4 +145,32 @@ func initContext(cmd *cobra.Command, version string, ctx *cmdContext) error {
 	}
 
 	return nil
+}
+
+// allowedHeaders is the set of header names that --headers accepts.
+// Add new entries here as new attribution or routing headers are defined.
+var allowedHeaders = map[string]bool{
+	"x-heygen-client-source": true,
+}
+
+var headerValueRe = regexp.MustCompile(`^[a-zA-Z0-9_\-\.]+$`)
+
+func parseAndValidateHeaders(raw []string) (map[string]string, error) {
+	parsed := make(map[string]string, len(raw))
+	for _, h := range raw {
+		k, v, ok := strings.Cut(h, ":")
+		if !ok {
+			return nil, clierrors.NewUsage("invalid --headers format: " + h + " (expected Key:Value)")
+		}
+		key := strings.ToLower(strings.TrimSpace(k))
+		val := strings.TrimSpace(v)
+		if !allowedHeaders[key] {
+			return nil, clierrors.NewUsage("header " + key + " is not in the allowlist")
+		}
+		if !headerValueRe.MatchString(val) {
+			return nil, clierrors.NewUsage("header value must be alphanumeric, hyphens, underscores, and dots only")
+		}
+		parsed[textproto.CanonicalMIMEHeaderKey(key)] = val
+	}
+	return parsed, nil
 }

--- a/cmd/heygen/headers_test.go
+++ b/cmd/heygen/headers_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseAndValidateHeaders_Valid(t *testing.T) {
+	hdrs, err := parseAndValidateHeaders([]string{"X-HeyGen-Client-Source: media-use"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hdrs["X-Heygen-Client-Source"] != "media-use" {
+		t.Errorf("got %q, want %q", hdrs["X-Heygen-Client-Source"], "media-use")
+	}
+}
+
+func TestParseAndValidateHeaders_CaseNormalization(t *testing.T) {
+	hdrs, err := parseAndValidateHeaders([]string{"x-heygen-client-source: my-tool"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hdrs["X-Heygen-Client-Source"] != "my-tool" {
+		t.Errorf("got %q, want %q", hdrs["X-Heygen-Client-Source"], "my-tool")
+	}
+}
+
+func TestParseAndValidateHeaders_NotAllowlisted(t *testing.T) {
+	_, err := parseAndValidateHeaders([]string{"Authorization: Bearer token"})
+	if err == nil {
+		t.Fatal("expected error for non-allowlisted header")
+	}
+}
+
+func TestParseAndValidateHeaders_MalformedNoColon(t *testing.T) {
+	_, err := parseAndValidateHeaders([]string{"garbage"})
+	if err == nil {
+		t.Fatal("expected error for malformed header")
+	}
+}
+
+func TestParseAndValidateHeaders_InvalidValueChars(t *testing.T) {
+	_, err := parseAndValidateHeaders([]string{"X-HeyGen-Client-Source: bad value!!"})
+	if err == nil {
+		t.Fatal("expected error for invalid value chars")
+	}
+}
+
+func TestParseAndValidateHeaders_DuplicateCaseCollapse(t *testing.T) {
+	hdrs, err := parseAndValidateHeaders([]string{
+		"X-HeyGen-Client-Source: first",
+		"x-heygen-client-source: second",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hdrs["X-Heygen-Client-Source"] != "second" {
+		t.Errorf("duplicate collapse: got %q, want last-wins %q", hdrs["X-Heygen-Client-Source"], "second")
+	}
+}

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -38,7 +38,7 @@ func newRootCmd(version string, formatter output.Formatter, analyticsClient *ana
 		return clierrors.NewUsage(err.Error())
 	})
 	root.CompletionOptions.HiddenDefaultCmd = true
-	root.PersistentFlags().Bool("human", false, "Display output as a formatted table instead of JSON")
+	addGlobalFlags(root)
 
 	// Move examples after flags in help output (matches gh, aws, gcloud convention).
 	// Cobra's default puts examples before flags; most CLIs do the opposite.
@@ -55,6 +55,13 @@ func newRootCmd(version string, formatter output.Formatter, analyticsClient *ana
 	installRootHelpFooter(root)
 
 	return root
+}
+
+// addGlobalFlags registers persistent flags shared by both newRootCmd and
+// newRootCmdWithSpecs, keeping the two builders in sync.
+func addGlobalFlags(root *cobra.Command) {
+	root.PersistentFlags().Bool("human", false, "Display output as a formatted table instead of JSON")
+	root.PersistentFlags().StringArray("headers", nil, "Extra HTTP header(s) sent with every request (repeatable, format: Key:Value). Only allowlisted header names are accepted.")
 }
 
 // installRootHelpFooter appends environment variables, exit codes, and hints
@@ -108,7 +115,7 @@ func newRootCmdWithSpecs(version string, formatter output.Formatter, analyticsCl
 		return clierrors.NewUsage(err.Error())
 	})
 	root.CompletionOptions.HiddenDefaultCmd = true
-	root.PersistentFlags().Bool("human", false, "Display output as a formatted table instead of JSON")
+	addGlobalFlags(root)
 
 	root.SetUsageTemplate(usageTemplateExamplesLast)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -22,6 +22,7 @@ type Client struct {
 	apiKey       string
 	userAgent    string
 	clientOrigin string
+	extraHeaders map[string]string
 	retry        RetryConfig
 }
 
@@ -57,6 +58,11 @@ func WithClientOrigin(o string) Option {
 	return func(c *Client) { c.clientOrigin = o }
 }
 
+// WithExtraHeaders adds custom headers sent with every request.
+func WithExtraHeaders(h map[string]string) Option {
+	return func(c *Client) { c.extraHeaders = h }
+}
+
 // New creates a Client with the given API key and options.
 func New(apiKey string, opts ...Option) *Client {
 	c := &Client{
@@ -86,7 +92,13 @@ func New(apiKey string, opts ...Option) *Client {
 }
 
 // Do executes an HTTP request, injecting auth and User-Agent headers.
+// Extra headers are applied FIRST so the client's own reserved headers
+// always win and cannot be overridden by user input.
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	for k, v := range c.extraHeaders {
+		req.Header.Set(k, v)
+	}
+	// Reserved headers set AFTER extraHeaders — these always win.
 	req.Header.Set("x-api-key", c.apiKey)
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("X-HeyGen-Source", "cli")

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -226,3 +226,67 @@ func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		Request:    req,
 	}, nil
 }
+
+func TestClient_Do_SetsExtraHeaders(t *testing.T) {
+	var gotSource string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSource = r.Header.Get("X-HeyGen-Client-Source")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("key",
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithExtraHeaders(map[string]string{"X-HeyGen-Client-Source": "media-use"}),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/v3/test", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotSource != "media-use" {
+		t.Errorf("X-HeyGen-Client-Source = %q, want %q", gotSource, "media-use")
+	}
+}
+
+func TestClient_Do_ExtraHeadersCannotOverrideReserved(t *testing.T) {
+	var gotKey, gotUA, gotSource string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("x-api-key")
+		gotUA = r.Header.Get("User-Agent")
+		gotSource = r.Header.Get("X-HeyGen-Source")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("real-key",
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithExtraHeaders(map[string]string{
+			"x-api-key":      "evil",
+			"User-Agent":     "evil-agent",
+			"X-HeyGen-Source": "evil",
+		}),
+	)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/v3/test", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotKey != "real-key" {
+		t.Errorf("x-api-key = %q, want %q (reserved must not be overridden)", gotKey, "real-key")
+	}
+	if gotUA == "evil-agent" {
+		t.Error("User-Agent was overridden by extraHeaders")
+	}
+	if gotSource != "cli" {
+		t.Errorf("X-HeyGen-Source = %q, want %q", gotSource, "cli")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a persistent `--headers` flag that sends extra HTTP headers on every API request. Headers are validated against an allowlist to prevent arbitrary header injection.

### Usage

```bash
heygen --headers "X-HeyGen-Client-Source: media-use" audio sounds list --query "upbeat tech"
```

### Validation

- **Allowlisted names only** — rejects headers not in the allowlist (currently: `X-HeyGen-Client-Source`)
- **Value validation** — must match `[a-zA-Z0-9_\-\.]+` (no spaces, special chars, or injection)
- **Format validation** — must be `Key:Value` (rejects malformed input)

```bash
# Allowed
heygen --headers "X-HeyGen-Client-Source: media-use" ...     # ✅

# Rejected
heygen --headers "Authorization: Bearer token" ...            # ❌ not in allowlist
heygen --headers "X-HeyGen-Client-Source: bad value!!" ...    # ❌ invalid characters
heygen --headers "garbage" ...                                # ❌ missing colon
```

### How it works

The flag is orthogonal to `X-HeyGen-Client-Origin` (auto-detected parent agent). Both coexist:
- `X-HeyGen-Client-Origin` → WHO spawned the CLI (e.g. `claude_code`, `cursor`)
- `X-HeyGen-Client-Source` (via `--headers`) → WHAT TOOL is calling (e.g. `media-use`)

To add new allowed headers, add an entry to `allowedHeaders` in `context.go`.

### Changes

| File | Change |
|------|--------|
| `root.go` | Register `--headers` as `PersistentFlags` `StringArray` |
| `context.go` | Parse `Key:Value`, validate name against allowlist, validate value charset |
| `client.go` | Add `extraHeaders` map, `WithExtraHeaders` option, set headers in `Do()` |

### Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Valid header accepted, request succeeds
- [x] Non-allowlisted header name rejected with clear error
- [x] Invalid value characters rejected with clear error
- [x] Malformed format (no colon) rejected with clear error
- [x] Without `--headers`, no extra headers sent (backward compatible)