### PR TITLE
feat(cli): hide --headers flag from help output

### DIFF
--- a/cmd/heygen/headers_test.go
+++ b/cmd/heygen/headers_test.go
@@ -1,8 +1,25 @@
 package main
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/heygen-com/heygen-cli/internal/analytics"
+	"github.com/heygen-com/heygen-cli/internal/output"
 )
+
+func TestHeadersFlagHiddenButRegistered(t *testing.T) {
+	var out, errOut bytes.Buffer
+	root := newRootCmd("test", output.NewJSONFormatter(&out, &errOut), analytics.New("test", false))
+
+	flag := root.PersistentFlags().Lookup("headers")
+	if flag == nil {
+		t.Fatal("--headers flag should still be registered (media-use relies on it)")
+	}
+	if !flag.Hidden {
+		t.Error("--headers flag should be hidden from help output")
+	}
+}
 
 func TestParseAndValidateHeaders_Valid(t *testing.T) {
 	hdrs, err := parseAndValidateHeaders([]string{"X-HeyGen-Client-Source: media-use"})

--- a/cmd/heygen/root.go
+++ b/cmd/heygen/root.go
@@ -62,6 +62,10 @@ func newRootCmd(version string, formatter output.Formatter, analyticsClient *ana
 func addGlobalFlags(root *cobra.Command) {
 	root.PersistentFlags().Bool("human", false, "Display output as a formatted table instead of JSON")
 	root.PersistentFlags().StringArray("headers", nil, "Extra HTTP header(s) sent with every request (repeatable, format: Key:Value). Only allowlisted header names are accepted.")
+	// --headers is an internal flag the media-use skill uses for caller
+	// attribution. Keep it functional but hidden from help until it becomes a
+	// supported user-facing feature.
+	_ = root.PersistentFlags().MarkHidden("headers")
 }
 
 // installRootHelpFooter appends environment variables, exit codes, and hints


### PR DESCRIPTION
## Scope
**Surfaces:** CLI | **Module:** Client / global flags

## Summary
The `--headers` flag (added in #188) is an internal mechanism the media-use skill uses to send the `X-HeyGen-Client-Source` attribution header for caller identification. It is not a supported user-facing feature yet, so this hides it from `--help` via `MarkHidden` while keeping it fully functional. This matches the existing convention for under-development surface (see the prior "hide under-development commands from help" change).

## Testing
- `make test` (full suite) and `make lint` pass.
- Added a unit test asserting the flag stays registered (media-use depends on it) but is hidden from help.
- Manually verified `heygen --help` no longer lists `--headers`, and that passing `--headers "garbage"` still reaches validation (usage error), confirming the hidden flag is still parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
