### PR TITLE
auth: add internal OAuth + PKCE + loopback driver (PR 1 of OAuth stack)

### DIFF
--- a/internal/auth/oauth/browser.go
+++ b/internal/auth/oauth/browser.go
@@ -33,15 +33,24 @@ var printOut io.Writer = os.Stdout
 // genuine launch failures the caller may want to log; callers should
 // still proceed to wait on the loopback callback either way.
 //
-// Two env-var escape hatches mirror the hyperframes-CLI driver:
+// Env-var precedence on Linux/BSD:
 //
-//   - BROWSER=none     — never try to open a browser; print the URL.
-//   - HEYGEN_NO_BROWSER=1 — same, scoped to this CLI.
+//  1. HEYGEN_NO_BROWSER=1 — never try to open a browser; print the URL.
+//  2. BROWSER=none — same, mirrors the cross-distro convention.
+//  3. BROWSER=<command> (any other non-empty value) — invoke <command>
+//     with the URL as a single argument, per the de-facto Linux
+//     convention sketched in freedesktop.org and adopted by Python's
+//     webbrowser module, Git, etc.
+//  4. Fallback: xdg-open <url>.
+//
+// On macOS and Windows the platform-native opener is used regardless of
+// $BROWSER, since the conventional values there ("Safari", "Chrome",
+// "msedge") aren't shell commands.
 func OpenBrowser(url string) error {
 	if url == "" {
 		return errors.New("oauth: OpenBrowser called with empty URL")
 	}
-	if os.Getenv("BROWSER") == "none" || os.Getenv("HEYGEN_NO_BROWSER") == "1" {
+	if os.Getenv("HEYGEN_NO_BROWSER") == "1" || os.Getenv("BROWSER") == "none" {
 		printManualURL(url, "")
 		return nil
 	}
@@ -58,25 +67,38 @@ func OpenBrowser(url string) error {
 
 // openWithSystem dispatches to the platform-native command.
 func openWithSystem(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "windows":
-		// rundll32 is the most reliable way to launch a URL on Windows
-		// without needing a specific app association.
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	default:
-		// Linux + BSD: xdg-open is the conventional dispatcher.
-		cmd = exec.Command("xdg-open", url)
-	}
+	cmd := platformOpenCmd(url)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("oauth: launch browser via %s: %w", cmd.Path, err)
 	}
-	// Don't wait on the child — `open` / `xdg-open` may stay attached to
-	// the launched browser for the user's whole session.
+	// Don't wait on the child — `open` / `xdg-open` / $BROWSER may stay
+	// attached to the launched browser for the user's whole session.
 	go func() { _ = cmd.Wait() }()
 	return nil
+}
+
+// platformOpenCmd builds the platform-native exec.Cmd that opens url.
+// Factored out so the env-var precedence is testable without spawning
+// real processes.
+func platformOpenCmd(url string) *exec.Cmd {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url)
+	case "windows":
+		// rundll32 is the most reliable way to launch a URL on Windows
+		// without needing a specific app association.
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		// Linux + BSD: honor the user's $BROWSER preference (non-empty,
+		// not the "none" sentinel handled in OpenBrowser) before
+		// falling back to xdg-open. $BROWSER is the user's own shell
+		// env — the documented Linux convention is to invoke its value
+		// as a command, so the "taint" is exactly the contract.
+		if b := os.Getenv("BROWSER"); b != "" && b != "none" {
+			return exec.Command(b, url) //nolint:gosec // $BROWSER is the user's documented preference; invoking it as a command is the convention.
+		}
+		return exec.Command("xdg-open", url)
+	}
 }
 
 func printManualURL(url, reason string) {

--- a/internal/auth/oauth/browser.go
+++ b/internal/auth/oauth/browser.go
@@ -1,0 +1,87 @@
+package oauth
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"golang.org/x/term"
+)
+
+// browserOpener is overridable in tests so we don't actually spawn `open`
+// / `xdg-open` / `rundll32` during unit runs.
+var browserOpener = openWithSystem
+
+// noTTY is overridable in tests so we can simulate a non-TTY stdin
+// without re-plumbing os.Stdin.
+var noTTY = func() bool {
+	return !term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// printOut is overridable in tests so we can capture the headless-
+// fallback URL print without competing for os.Stdout.
+var printOut io.Writer = os.Stdout
+
+// OpenBrowser launches the user's default browser at the given URL.
+//
+// When stdin is not a TTY (headless / CI / SSH session), or when the
+// platform "open" command fails, the URL is printed to stdout instead
+// so the user can copy/paste it manually. The error return covers
+// genuine launch failures the caller may want to log; callers should
+// still proceed to wait on the loopback callback either way.
+//
+// Two env-var escape hatches mirror the hyperframes-CLI driver:
+//
+//   - BROWSER=none     — never try to open a browser; print the URL.
+//   - HEYGEN_NO_BROWSER=1 — same, scoped to this CLI.
+func OpenBrowser(url string) error {
+	if url == "" {
+		return errors.New("oauth: OpenBrowser called with empty URL")
+	}
+	if os.Getenv("BROWSER") == "none" || os.Getenv("HEYGEN_NO_BROWSER") == "1" {
+		printManualURL(url, "")
+		return nil
+	}
+	if noTTY() {
+		printManualURL(url, "")
+		return nil
+	}
+	if err := browserOpener(url); err != nil {
+		printManualURL(url, err.Error())
+		return err
+	}
+	return nil
+}
+
+// openWithSystem dispatches to the platform-native command.
+func openWithSystem(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		// rundll32 is the most reliable way to launch a URL on Windows
+		// without needing a specific app association.
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		// Linux + BSD: xdg-open is the conventional dispatcher.
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("oauth: launch browser via %s: %w", cmd.Path, err)
+	}
+	// Don't wait on the child — `open` / `xdg-open` may stay attached to
+	// the launched browser for the user's whole session.
+	go func() { _ = cmd.Wait() }()
+	return nil
+}
+
+func printManualURL(url, reason string) {
+	if reason != "" {
+		fmt.Fprintf(printOut, "Could not open browser automatically (%s).\n", reason)
+	}
+	fmt.Fprintf(printOut, "Open this URL manually to continue:\n  %s\n", url)
+}

--- a/internal/auth/oauth/browser_test.go
+++ b/internal/auth/oauth/browser_test.go
@@ -1,0 +1,138 @@
+package oauth
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func withTestOpener(t *testing.T, fn func(string) error) {
+	t.Helper()
+	orig := browserOpener
+	browserOpener = fn
+	t.Cleanup(func() { browserOpener = orig })
+}
+
+func withNoTTY(t *testing.T, headless bool) {
+	t.Helper()
+	orig := noTTY
+	noTTY = func() bool { return headless }
+	t.Cleanup(func() { noTTY = orig })
+}
+
+func withPrintBuf(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	orig := printOut
+	printOut = buf
+	t.Cleanup(func() { printOut = orig })
+	return buf
+}
+
+func TestOpenBrowser_TTYInvokesOpener(t *testing.T) {
+	withNoTTY(t, false)
+	called := ""
+	withTestOpener(t, func(u string) error {
+		called = u
+		return nil
+	})
+	buf := withPrintBuf(t)
+
+	if err := OpenBrowser("https://example.test/oauth/authorize?x=1"); err != nil {
+		t.Fatalf("OpenBrowser: %v", err)
+	}
+	if called != "https://example.test/oauth/authorize?x=1" {
+		t.Errorf("opener called with %q", called)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no print on TTY success, got %q", buf.String())
+	}
+}
+
+func TestOpenBrowser_NonTTYPrintsAndSkips(t *testing.T) {
+	withNoTTY(t, true)
+	called := false
+	withTestOpener(t, func(u string) error {
+		called = true
+		return nil
+	})
+	buf := withPrintBuf(t)
+
+	if err := OpenBrowser("https://example.test/x"); err != nil {
+		t.Fatalf("OpenBrowser: %v", err)
+	}
+	if called {
+		t.Error("opener should not be called when stdin is non-TTY")
+	}
+	if !strings.Contains(buf.String(), "https://example.test/x") {
+		t.Errorf("expected URL in print output, got %q", buf.String())
+	}
+}
+
+func TestOpenBrowser_OpenerFailureFallsBack(t *testing.T) {
+	withNoTTY(t, false)
+	withTestOpener(t, func(u string) error {
+		return errors.New("no display")
+	})
+	buf := withPrintBuf(t)
+
+	err := OpenBrowser("https://example.test/x")
+	if err == nil {
+		t.Fatal("expected opener error to surface")
+	}
+	if !strings.Contains(buf.String(), "https://example.test/x") {
+		t.Errorf("expected fallback print, got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "Could not open browser") {
+		t.Errorf("expected reason in print, got %q", buf.String())
+	}
+}
+
+func TestOpenBrowser_HEYGEN_NO_BROWSEREnvSkips(t *testing.T) {
+	withNoTTY(t, false)
+	t.Setenv("HEYGEN_NO_BROWSER", "1")
+	called := false
+	withTestOpener(t, func(u string) error {
+		called = true
+		return nil
+	})
+	buf := withPrintBuf(t)
+
+	if err := OpenBrowser("https://example.test/x"); err != nil {
+		t.Fatalf("OpenBrowser: %v", err)
+	}
+	if called {
+		t.Error("opener should not run when HEYGEN_NO_BROWSER=1")
+	}
+	if !strings.Contains(buf.String(), "https://example.test/x") {
+		t.Errorf("expected URL in print, got %q", buf.String())
+	}
+}
+
+func TestOpenBrowser_BROWSERNoneEnvSkips(t *testing.T) {
+	withNoTTY(t, false)
+	t.Setenv("BROWSER", "none")
+	called := false
+	withTestOpener(t, func(u string) error {
+		called = true
+		return nil
+	})
+	buf := withPrintBuf(t)
+
+	if err := OpenBrowser("https://example.test/x"); err != nil {
+		t.Fatalf("OpenBrowser: %v", err)
+	}
+	if called {
+		t.Error("opener should not run when BROWSER=none")
+	}
+	if !strings.Contains(buf.String(), "https://example.test/x") {
+		t.Errorf("expected URL in print, got %q", buf.String())
+	}
+}
+
+func TestOpenBrowser_RejectsEmptyURL(t *testing.T) {
+	if err := OpenBrowser(""); err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+}

--- a/internal/auth/oauth/browser_test.go
+++ b/internal/auth/oauth/browser_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"bytes"
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -30,7 +31,18 @@ func withPrintBuf(t *testing.T) *bytes.Buffer {
 	return buf
 }
 
+// neutralizeBrowserEnv clears the env vars OpenBrowser reads so a
+// developer's outer $BROWSER / $HEYGEN_NO_BROWSER doesn't bleed into
+// tests that assert opener invocation. Tests that *want* to exercise
+// either branch should set them explicitly AFTER calling this.
+func neutralizeBrowserEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("BROWSER", "")
+	t.Setenv("HEYGEN_NO_BROWSER", "")
+}
+
 func TestOpenBrowser_TTYInvokesOpener(t *testing.T) {
+	neutralizeBrowserEnv(t)
 	withNoTTY(t, false)
 	called := ""
 	withTestOpener(t, func(u string) error {
@@ -51,6 +63,7 @@ func TestOpenBrowser_TTYInvokesOpener(t *testing.T) {
 }
 
 func TestOpenBrowser_NonTTYPrintsAndSkips(t *testing.T) {
+	neutralizeBrowserEnv(t)
 	withNoTTY(t, true)
 	called := false
 	withTestOpener(t, func(u string) error {
@@ -71,6 +84,7 @@ func TestOpenBrowser_NonTTYPrintsAndSkips(t *testing.T) {
 }
 
 func TestOpenBrowser_OpenerFailureFallsBack(t *testing.T) {
+	neutralizeBrowserEnv(t)
 	withNoTTY(t, false)
 	withTestOpener(t, func(u string) error {
 		return errors.New("no display")
@@ -90,6 +104,7 @@ func TestOpenBrowser_OpenerFailureFallsBack(t *testing.T) {
 }
 
 func TestOpenBrowser_HEYGEN_NO_BROWSEREnvSkips(t *testing.T) {
+	neutralizeBrowserEnv(t)
 	withNoTTY(t, false)
 	t.Setenv("HEYGEN_NO_BROWSER", "1")
 	called := false
@@ -111,6 +126,7 @@ func TestOpenBrowser_HEYGEN_NO_BROWSEREnvSkips(t *testing.T) {
 }
 
 func TestOpenBrowser_BROWSERNoneEnvSkips(t *testing.T) {
+	neutralizeBrowserEnv(t)
 	withNoTTY(t, false)
 	t.Setenv("BROWSER", "none")
 	called := false
@@ -134,5 +150,44 @@ func TestOpenBrowser_BROWSERNoneEnvSkips(t *testing.T) {
 func TestOpenBrowser_RejectsEmptyURL(t *testing.T) {
 	if err := OpenBrowser(""); err == nil {
 		t.Fatal("expected error for empty URL")
+	}
+}
+
+// platformOpenCmd's $BROWSER precedence is a Linux/BSD convention — on
+// darwin/windows we always dispatch to the native opener regardless of
+// $BROWSER, so these tests are skipped there.
+func TestPlatformOpenCmd_HonorsBROWSEROnLinux(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("$BROWSER precedence is Linux/BSD only")
+	}
+	t.Setenv("BROWSER", "firefox")
+	cmd := platformOpenCmd("https://example.test/x")
+	if len(cmd.Args) < 2 || cmd.Args[0] != "firefox" || cmd.Args[1] != "https://example.test/x" {
+		t.Errorf("expected [firefox <url>], got %v", cmd.Args)
+	}
+}
+
+func TestPlatformOpenCmd_BROWSERNoneFallsThroughOnLinux(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("$BROWSER precedence is Linux/BSD only")
+	}
+	// "none" is handled by OpenBrowser itself, never reaching
+	// platformOpenCmd — but defend the invariant: if it ever did,
+	// don't try to exec "none".
+	t.Setenv("BROWSER", "none")
+	cmd := platformOpenCmd("https://example.test/x")
+	if len(cmd.Args) < 1 || cmd.Args[0] != "xdg-open" {
+		t.Errorf("expected xdg-open fallback when BROWSER=none, got %v", cmd.Args)
+	}
+}
+
+func TestPlatformOpenCmd_EmptyBROWSERFallsThroughOnLinux(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("$BROWSER precedence is Linux/BSD only")
+	}
+	t.Setenv("BROWSER", "")
+	cmd := platformOpenCmd("https://example.test/x")
+	if len(cmd.Args) < 1 || cmd.Args[0] != "xdg-open" {
+		t.Errorf("expected xdg-open fallback when BROWSER empty, got %v", cmd.Args)
 	}
 }

--- a/internal/auth/oauth/loopback.go
+++ b/internal/auth/oauth/loopback.go
@@ -5,12 +5,19 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
-	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
+
+// ErrInvalidRedirectPath is returned by StartLoopbackServer when the
+// supplied redirect path is malformed (does not start with '/', contains
+// '?' or '#', etc.). Surfacing a typed error makes the misuse obvious to
+// callers and pinable in tests.
+var ErrInvalidRedirectPath = errors.New("oauth: invalid redirect path")
 
 // DefaultLoopbackTimeout is how long StartLoopbackServer waits for the
 // browser to hit the redirect URI before giving up.
@@ -58,7 +65,14 @@ func StartLoopbackServer(
 	redirectPath, expectedState string,
 ) (*LoopbackServer, <-chan LoopbackResult, func(), error) {
 	if redirectPath == "" || redirectPath[0] != '/' {
-		return nil, nil, nil, fmt.Errorf("oauth: redirectPath must start with '/', got %q", redirectPath)
+		return nil, nil, nil, fmt.Errorf("%w: must start with '/', got %q", ErrInvalidRedirectPath, redirectPath)
+	}
+	// `?` and `#` would silently register a dead route — net/http's mux
+	// matches only on the path component, so a "callback?source=cli" path
+	// never receives the IdP's bare `/callback` redirect. Reject early so
+	// the misuse surfaces at boot, not as a timeout.
+	if strings.ContainsAny(redirectPath, "?#") {
+		return nil, nil, nil, fmt.Errorf("%w: must not contain '?' or '#', got %q", ErrInvalidRedirectPath, redirectPath)
 	}
 	if expectedState == "" {
 		return nil, nil, nil, errors.New("oauth: expectedState must be non-empty")
@@ -91,10 +105,13 @@ func StartLoopbackServer(
 	go func() {
 		// Serve returns ErrServerClosed on graceful shutdown — not an
 		// error worth surfacing. Any other error is propagated to the
-		// caller via the results channel.
+		// caller via the results channel AND the watchdog is signalled
+		// to exit so we don't leak a goroutine for the full 5-min
+		// DefaultLoopbackTimeout window.
 		err := lb.server.Serve(listener)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			lb.deliver(LoopbackResult{Err: fmt.Errorf("oauth: loopback server: %w", err)})
+			lb.shutdown()
 		}
 	}()
 
@@ -203,16 +220,6 @@ func (lb *LoopbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 	go lb.shutdown()
 }
 
-// joinPath helper used by tests to construct full redirect URLs.
-func joinPath(base, path string) string {
-	u, err := url.Parse(base)
-	if err != nil {
-		return base + path
-	}
-	u.Path = path
-	return u.String()
-}
-
 func writeSuccessPage(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
@@ -228,31 +235,8 @@ func writeErrorPage(w http.ResponseWriter, status int, code, description string)
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Connection", "close")
 	w.WriteHeader(status)
-	body := fmt.Sprintf(errorPageHTMLTemplate, htmlEscape(code), htmlEscape(description))
+	body := fmt.Sprintf(errorPageHTMLTemplate, html.EscapeString(code), html.EscapeString(description))
 	_, _ = w.Write([]byte(body))
-}
-
-func htmlEscape(s string) string {
-	// Tiny escaper — sufficient for the few fields we render and avoids
-	// pulling in html/template for a single string slot.
-	var out []byte
-	for _, r := range s {
-		switch r {
-		case '&':
-			out = append(out, []byte("&amp;")...)
-		case '<':
-			out = append(out, []byte("&lt;")...)
-		case '>':
-			out = append(out, []byte("&gt;")...)
-		case '"':
-			out = append(out, []byte("&quot;")...)
-		case '\'':
-			out = append(out, []byte("&#39;")...)
-		default:
-			out = append(out, []byte(string(r))...)
-		}
-	}
-	return string(out)
 }
 
 const successPageHTML = `<!doctype html><html><head><meta charset="utf-8"><title>Signed in to HeyGen</title>

--- a/internal/auth/oauth/loopback.go
+++ b/internal/auth/oauth/loopback.go
@@ -1,0 +1,264 @@
+package oauth
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// DefaultLoopbackTimeout is how long StartLoopbackServer waits for the
+// browser to hit the redirect URI before giving up.
+const DefaultLoopbackTimeout = 5 * time.Minute
+
+// LoopbackResult carries the OAuth callback parameters captured by the
+// loopback server. Either Code is populated (success) or Err is
+// populated (state mismatch, IdP error, timeout, etc.) — never both.
+type LoopbackResult struct {
+	Code        string
+	State       string
+	RedirectURI string
+	Err         error
+}
+
+// LoopbackServer is a one-shot HTTP server bound to 127.0.0.1 on an
+// ephemeral port. It serves a single GET on the configured redirect
+// path, captures the OAuth callback parameters, renders a small
+// "you can close this tab" page, and shuts down.
+type LoopbackServer struct {
+	Port          int
+	RedirectURI   string
+	ExpectedState string
+
+	results   chan LoopbackResult
+	server    *http.Server
+	once      sync.Once
+	done      chan struct{}
+	deliverMu sync.Mutex
+	delivered bool
+}
+
+// StartLoopbackServer binds 127.0.0.1:0, serves redirectPath on a single
+// GET, and returns the captured code via the result channel. The
+// returned cancel function tears the server down; it is safe to call
+// more than once.
+//
+// The supplied context governs the lifetime of the server: cancelling
+// it (or the 5-minute timeout firing) closes the listener and emits an
+// error result. Pass the expected `state` value generated alongside the
+// PKCE pair — the server rejects mismatched callbacks with a constant-
+// time comparison.
+func StartLoopbackServer(
+	ctx context.Context,
+	redirectPath, expectedState string,
+) (*LoopbackServer, <-chan LoopbackResult, func(), error) {
+	if redirectPath == "" || redirectPath[0] != '/' {
+		return nil, nil, nil, fmt.Errorf("oauth: redirectPath must start with '/', got %q", redirectPath)
+	}
+	if expectedState == "" {
+		return nil, nil, nil, errors.New("oauth: expectedState must be non-empty")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("oauth: bind loopback listener: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", port, redirectPath)
+
+	results := make(chan LoopbackResult, 1)
+	lb := &LoopbackServer{
+		Port:          port,
+		RedirectURI:   redirectURI,
+		ExpectedState: expectedState,
+		results:       results,
+		done:          make(chan struct{}),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(redirectPath, lb.handleCallback)
+
+	lb.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		// Serve returns ErrServerClosed on graceful shutdown — not an
+		// error worth surfacing. Any other error is propagated to the
+		// caller via the results channel.
+		err := lb.server.Serve(listener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			lb.deliver(LoopbackResult{Err: fmt.Errorf("oauth: loopback server: %w", err)})
+		}
+	}()
+
+	// Wire up timeout + context cancellation. The driver-level timeout is
+	// belt-and-braces alongside the caller-supplied context, so the
+	// browser-side hang never wedges a CLI shell longer than ~5 min.
+	timer := time.NewTimer(DefaultLoopbackTimeout)
+	go func() {
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			lb.deliver(LoopbackResult{Err: fmt.Errorf("oauth: loopback cancelled: %w", ctx.Err())})
+			lb.shutdown()
+		case <-timer.C:
+			lb.deliver(LoopbackResult{Err: fmt.Errorf("oauth: loopback timed out after %s", DefaultLoopbackTimeout)})
+			lb.shutdown()
+		case <-lb.done:
+			timer.Stop()
+		}
+	}()
+
+	cancel := func() {
+		timer.Stop()
+		lb.shutdown()
+	}
+	return lb, results, cancel, nil
+}
+
+// deliver sends a result on the channel exactly once, dropping later
+// calls so a stray callback can't double-deliver.
+func (lb *LoopbackServer) deliver(r LoopbackResult) {
+	lb.deliverMu.Lock()
+	defer lb.deliverMu.Unlock()
+	if lb.delivered {
+		return
+	}
+	lb.delivered = true
+	select {
+	case lb.results <- r:
+	default:
+	}
+}
+
+// shutdown closes the server exactly once. The results channel is
+// deliberately left open: any goroutine that already passed the
+// `delivered` guard but hasn't yet sent would panic on a close, so the
+// channel is allowed to be garbage-collected with the LoopbackServer.
+func (lb *LoopbackServer) shutdown() {
+	lb.once.Do(func() {
+		close(lb.done)
+		// Best-effort close; the listener may already be torn down. Use
+		// a short timeout so we don't hang on idle keep-alive sockets
+		// (browsers default to keep-alive and Chrome holds them open
+		// for minutes).
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = lb.server.Shutdown(shutdownCtx)
+		// Close existing connections that survived Shutdown's grace
+		// period (keep-alive sockets). Without this the CLI process can
+		// hang for minutes waiting for a browser to release its idle
+		// socket.
+		_ = lb.server.Close()
+	})
+}
+
+// handleCallback serves the OAuth redirect. Only GET requests on the
+// expected path are honored; anything else gets a 404 without revealing
+// that a CLI is listening.
+func (lb *LoopbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := r.URL.Query()
+	if oauthErr := q.Get("error"); oauthErr != "" {
+		desc := q.Get("error_description")
+		writeErrorPage(w, http.StatusBadRequest, oauthErr, desc)
+		err := fmt.Errorf("oauth: authorize returned error: %s", oauthErr)
+		if desc != "" {
+			err = fmt.Errorf("%w — %s", err, desc)
+		}
+		lb.deliver(LoopbackResult{Err: err, RedirectURI: lb.RedirectURI})
+		go lb.shutdown()
+		return
+	}
+
+	state := q.Get("state")
+	if state == "" || subtle.ConstantTimeCompare([]byte(state), []byte(lb.ExpectedState)) != 1 {
+		writeErrorPage(w, http.StatusBadRequest, "invalid_state", "State parameter did not match.")
+		lb.deliver(LoopbackResult{Err: errors.New("oauth: state mismatch — possible CSRF, aborting"), RedirectURI: lb.RedirectURI})
+		go lb.shutdown()
+		return
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		writeErrorPage(w, http.StatusBadRequest, "missing_code", "Authorization code is missing from the redirect.")
+		lb.deliver(LoopbackResult{Err: errors.New("oauth: redirect did not include `code`"), RedirectURI: lb.RedirectURI})
+		go lb.shutdown()
+		return
+	}
+
+	writeSuccessPage(w)
+	lb.deliver(LoopbackResult{Code: code, State: state, RedirectURI: lb.RedirectURI})
+	go lb.shutdown()
+}
+
+// joinPath helper used by tests to construct full redirect URLs.
+func joinPath(base, path string) string {
+	u, err := url.Parse(base)
+	if err != nil {
+		return base + path
+	}
+	u.Path = path
+	return u.String()
+}
+
+func writeSuccessPage(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	// Browsers default to keep-alive; without an explicit close hint
+	// Shutdown waits on the idle socket and the CLI lingers for minutes.
+	w.Header().Set("Connection", "close")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(successPageHTML))
+}
+
+func writeErrorPage(w http.ResponseWriter, status int, code, description string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Connection", "close")
+	w.WriteHeader(status)
+	body := fmt.Sprintf(errorPageHTMLTemplate, htmlEscape(code), htmlEscape(description))
+	_, _ = w.Write([]byte(body))
+}
+
+func htmlEscape(s string) string {
+	// Tiny escaper — sufficient for the few fields we render and avoids
+	// pulling in html/template for a single string slot.
+	var out []byte
+	for _, r := range s {
+		switch r {
+		case '&':
+			out = append(out, []byte("&amp;")...)
+		case '<':
+			out = append(out, []byte("&lt;")...)
+		case '>':
+			out = append(out, []byte("&gt;")...)
+		case '"':
+			out = append(out, []byte("&quot;")...)
+		case '\'':
+			out = append(out, []byte("&#39;")...)
+		default:
+			out = append(out, []byte(string(r))...)
+		}
+	}
+	return string(out)
+}
+
+const successPageHTML = `<!doctype html><html><head><meta charset="utf-8"><title>Signed in to HeyGen</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#0b0f14;color:#e6e8eb}main{max-width:480px;text-align:center;padding:32px;border-radius:12px;background:#11161d;border:1px solid #1f2630}h1{font-weight:600;margin:0 0 8px;color:#3CE6AC}p{margin:0;color:#9aa3ad}</style>
+</head><body><main><h1>You're signed in.</h1><p>You can close this tab and return to your terminal.</p></main></body></html>`
+
+const errorPageHTMLTemplate = `<!doctype html><html><head><meta charset="utf-8"><title>Sign-in failed</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#1a0b0b;color:#e6e8eb}main{max-width:480px;text-align:center;padding:32px;border-radius:12px;background:#1d1111;border:1px solid #301f1f}h1{font-weight:600;margin:0 0 8px;color:#ff7a7a}code{background:#2a1414;padding:2px 6px;border-radius:4px}p{margin:8px 0 0;color:#9aa3ad}</style>
+</head><body><main><h1>Sign-in failed</h1><p><code>%s</code></p><p>%s</p></main></body></html>`

--- a/internal/auth/oauth/loopback.go
+++ b/internal/auth/oauth/loopback.go
@@ -178,8 +178,10 @@ func (lb *LoopbackServer) shutdown() {
 }
 
 // handleCallback serves the OAuth redirect. Only GET requests on the
-// expected path are honored; anything else gets a 404 without revealing
-// that a CLI is listening.
+// expected path are honored: non-GET requests on the matched path
+// return 405 (Method Not Allowed) via the branch below, while unknown
+// paths fall through to the mux's default 404 — together these avoid
+// revealing that a CLI is listening on any particular route.
 func (lb *LoopbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)

--- a/internal/auth/oauth/loopback_test.go
+++ b/internal/auth/oauth/loopback_test.go
@@ -208,10 +208,13 @@ func TestStartLoopbackServer_RejectsNonGet(t *testing.T) {
 func TestStartLoopbackServer_ValidatesArgs(t *testing.T) {
 	tests := []struct {
 		name, path, state string
+		wantSentinel      bool
 	}{
-		{"empty path", "", "s"},
-		{"path missing slash", "callback", "s"},
-		{"empty state", "/cb", ""},
+		{"empty path", "", "s", true},
+		{"path missing slash", "callback", "s", true},
+		{"path with question mark", "/cb?source=cli", "s", true},
+		{"path with fragment", "/cb#frag", "s", true},
+		{"empty state", "/cb", "", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -219,17 +222,12 @@ func TestStartLoopbackServer_ValidatesArgs(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error")
 			}
+			if tc.wantSentinel && !errors.Is(err, ErrInvalidRedirectPath) {
+				t.Errorf("expected ErrInvalidRedirectPath, got %v", err)
+			}
+			if !tc.wantSentinel && errors.Is(err, ErrInvalidRedirectPath) {
+				t.Errorf("did not expect ErrInvalidRedirectPath, got %v", err)
+			}
 		})
-	}
-}
-
-// Sanity: helper is exercised so it stays maintained.
-func TestJoinPath_Helper(t *testing.T) {
-	if got := joinPath("http://127.0.0.1:8080", "/cb"); got != "http://127.0.0.1:8080/cb" {
-		t.Errorf("joinPath = %q", got)
-	}
-	// Fallback path: malformed base.
-	if got := joinPath("::::", "/cb"); got != "::::/cb" {
-		t.Errorf("joinPath fallback = %q", got)
 	}
 }

--- a/internal/auth/oauth/loopback_test.go
+++ b/internal/auth/oauth/loopback_test.go
@@ -1,0 +1,235 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartLoopbackServer_HappyPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lb, results, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "the-state")
+	if err != nil {
+		t.Fatalf("StartLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	if lb.Port == 0 {
+		t.Error("Port should be assigned")
+	}
+	if !strings.HasPrefix(lb.RedirectURI, "http://127.0.0.1:") {
+		t.Errorf("RedirectURI = %q", lb.RedirectURI)
+	}
+
+	cbURL := lb.RedirectURI + "?" + url.Values{
+		"code":  {"the-code"},
+		"state": {"the-state"},
+	}.Encode()
+	resp, err := http.Get(cbURL) //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "Signed in") {
+		t.Errorf("expected success page, got %s", body)
+	}
+
+	select {
+	case r := <-results:
+		if r.Err != nil {
+			t.Fatalf("unexpected Err: %v", r.Err)
+		}
+		if r.Code != "the-code" {
+			t.Errorf("Code = %q", r.Code)
+		}
+		if r.State != "the-state" {
+			t.Errorf("State = %q", r.State)
+		}
+		if r.RedirectURI != lb.RedirectURI {
+			t.Errorf("RedirectURI = %q, want %q", r.RedirectURI, lb.RedirectURI)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}
+
+func TestStartLoopbackServer_StateMismatchRejects(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lb, results, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "expected-state")
+	if err != nil {
+		t.Fatalf("StartLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	cbURL := lb.RedirectURI + "?" + url.Values{
+		"code":  {"the-code"},
+		"state": {"different-state"},
+	}.Encode()
+	resp, err := http.Get(cbURL) //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+
+	select {
+	case r := <-results:
+		if r.Err == nil {
+			t.Fatal("expected error result")
+		}
+		if !strings.Contains(r.Err.Error(), "state mismatch") {
+			t.Errorf("err = %v, want state-mismatch message", r.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}
+
+func TestStartLoopbackServer_PropagatesIdPError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lb, results, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "the-state")
+	if err != nil {
+		t.Fatalf("StartLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	cbURL := lb.RedirectURI + "?" + url.Values{
+		"error":             {"access_denied"},
+		"error_description": {"user said no"},
+	}.Encode()
+	resp, err := http.Get(cbURL) //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case r := <-results:
+		if r.Err == nil {
+			t.Fatal("expected error result")
+		}
+		if !strings.Contains(r.Err.Error(), "access_denied") {
+			t.Errorf("err = %v, want to include error code", r.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}
+
+func TestStartLoopbackServer_MissingCodeRejects(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lb, results, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "the-state")
+	if err != nil {
+		t.Fatalf("StartLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	cbURL := lb.RedirectURI + "?state=the-state"
+	resp, err := http.Get(cbURL) //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+
+	select {
+	case r := <-results:
+		if r.Err == nil {
+			t.Fatal("expected error result")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}
+
+func TestStartLoopbackServer_ContextCancelDelivers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	_, results, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "the-state")
+	if err != nil {
+		t.Fatalf("StartLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	cancel()
+
+	select {
+	case r := <-results:
+		if r.Err == nil {
+			t.Fatal("expected error result on cancel")
+		}
+		if !errors.Is(r.Err, context.Canceled) {
+			t.Errorf("want context.Canceled in chain, got %v", r.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancel result")
+	}
+}
+
+func TestStartLoopbackServer_RejectsNonGet(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	lb, _, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "the-state")
+	if err != nil {
+		t.Fatalf("StartLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	resp, err := http.Post(lb.RedirectURI, "text/plain", strings.NewReader("nope")) //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("POST callback: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestStartLoopbackServer_ValidatesArgs(t *testing.T) {
+	tests := []struct {
+		name, path, state string
+	}{
+		{"empty path", "", "s"},
+		{"path missing slash", "callback", "s"},
+		{"empty state", "/cb", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := StartLoopbackServer(context.Background(), tc.path, tc.state)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+// Sanity: helper is exercised so it stays maintained.
+func TestJoinPath_Helper(t *testing.T) {
+	if got := joinPath("http://127.0.0.1:8080", "/cb"); got != "http://127.0.0.1:8080/cb" {
+		t.Errorf("joinPath = %q", got)
+	}
+	// Fallback path: malformed base.
+	if got := joinPath("::::", "/cb"); got != "::::/cb" {
+		t.Errorf("joinPath fallback = %q", got)
+	}
+}

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -114,7 +114,22 @@ func NewClient(opts ...Option) *Client {
 // state, PKCE code challenge, redirect URI, and scope.
 //
 // The challenge must be the S256-hashed verifier (see GeneratePKCEPair).
-func (c *Client) BuildAuthorizationURL(state, codeChallenge, redirectURI, scope string) string {
+//
+// state, codeChallenge, and redirectURI MUST be non-empty — an empty
+// value would silently produce an unusable authorize URL (state mismatch
+// on callback, PKCE rejection at token exchange, IdP returns the user
+// to the wrong place). Returns an error rather than papering over the
+// caller bug.
+func (c *Client) BuildAuthorizationURL(state, codeChallenge, redirectURI, scope string) (string, error) {
+	if state == "" {
+		return "", errors.New("oauth: BuildAuthorizationURL: state must be non-empty")
+	}
+	if codeChallenge == "" {
+		return "", errors.New("oauth: BuildAuthorizationURL: codeChallenge must be non-empty")
+	}
+	if redirectURI == "" {
+		return "", errors.New("oauth: BuildAuthorizationURL: redirectURI must be non-empty")
+	}
 	if scope == "" {
 		scope = DefaultScopes
 	}
@@ -128,9 +143,9 @@ func (c *Client) BuildAuthorizationURL(state, codeChallenge, redirectURI, scope 
 		"code_challenge_method": {"S256"},
 	}
 	if strings.Contains(c.AuthorizeURL, "?") {
-		return c.AuthorizeURL + "&" + q.Encode()
+		return c.AuthorizeURL + "&" + q.Encode(), nil
 	}
-	return c.AuthorizeURL + "?" + q.Encode()
+	return c.AuthorizeURL + "?" + q.Encode(), nil
 }
 
 // ExchangeAuthorizationCode POSTs the authorization code + PKCE verifier
@@ -222,6 +237,14 @@ func (c *Client) postTokenForm(
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
+	// Stamp IssuedAt at request-send time, not after the response is
+	// parsed: the IdP's `expires_in` is relative to *its* clock when it
+	// minted the token, which is closer to the moment the request hit
+	// the wire than to whenever we finish JSON-decoding. Bias toward
+	// "expired slightly sooner than ideal" rather than the opposite —
+	// a stale-cached refresh costs a round trip; a stale-cached access
+	// token costs an API failure.
+	requestSent := c.Now()
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("oauth: %s request: %w", grant, err)
@@ -258,7 +281,7 @@ func (c *Client) postTokenForm(
 	if err != nil {
 		return nil, fmt.Errorf("oauth: %s response invalid: %w", grant, err)
 	}
-	tok.IssuedAt = c.Now()
+	tok.IssuedAt = requestSent
 	return tok, nil
 }
 
@@ -327,15 +350,12 @@ func numericField(obj map[string]any, key string) (float64, bool) {
 	if !ok {
 		return 0, false
 	}
+	// We decode with the default json package settings (no
+	// Decoder.UseNumber), so every JSON number arrives as float64 — no
+	// json.Number branch needed.
 	switch n := v.(type) {
 	case float64:
 		return n, true
-	case json.Number:
-		f, err := n.Float64()
-		if err != nil {
-			return 0, false
-		}
-		return f, true
 	case string:
 		// Spec says expires_in is numeric, but defend against IdPs that
 		// send it as a quoted string.

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -1,0 +1,369 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Shared OAuth client_id with hyperframes-CLI. Both CLIs are public
+// clients on the same HeyGen IdP and use the same baked-in id; the
+// HyperFrames CLI's value is the authoritative one and must not drift.
+//
+// Source: hyperframes-oss packages/cli/src/auth/oauth.ts:DEFAULT_CLIENT_ID.
+const DefaultClientID = "q2A2QRSke2LrFTPJhoDbHtXh"
+
+// Default scopes requested on the authorize URL. Matches the
+// hyperframes-CLI default; the heygen-cli surface needs the same
+// minimal openid/profile/email set for now.
+const DefaultScopes = "openid profile email"
+
+// Default endpoints. The authorize endpoint lives on the consumer
+// origin (app.heygen.com — same origin as the user's web session
+// cookies); token + revoke live on the api2.heygen.com server-to-server
+// API. See hyperframes-CLI's oauth.ts for the live verification notes.
+const (
+	DefaultAuthorizeURL = "https://app.heygen.com/oauth/authorize"
+	DefaultTokenURL     = "https://api2.heygen.com/v1/oauth/token"
+	DefaultRevokeURL    = "https://api2.heygen.com/v1/oauth/revoke"
+)
+
+// DefaultExchangeTimeout caps each token-endpoint round trip.
+const DefaultExchangeTimeout = 30 * time.Second
+
+// DefaultRevokeTimeout caps the best-effort revoke call. RFC 7009
+// allows servers to be slow; we don't want logout to hang on it.
+const DefaultRevokeTimeout = 5 * time.Second
+
+// Client drives the OAuth 2.0 + PKCE flow against the HeyGen IdP.
+//
+// All four endpoints (Authorize/Token/Revoke) and the client_id are
+// overridable so tests can swap in an httptest.Server. Production
+// callers should call NewClient() with no options.
+type Client struct {
+	ClientID     string
+	AuthorizeURL string
+	TokenURL     string
+	RevokeURL    string
+
+	// HTTPClient is used for the token + revoke round trips. Defaults
+	// to an http.Client with sensible timeouts.
+	HTTPClient *http.Client
+	// Now is the wall-clock source, overridable for deterministic tests.
+	Now func() time.Time
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithClientID overrides the OAuth client_id.
+func WithClientID(id string) Option {
+	return func(c *Client) { c.ClientID = id }
+}
+
+// WithAuthorizeURL overrides the authorize endpoint URL.
+func WithAuthorizeURL(u string) Option {
+	return func(c *Client) { c.AuthorizeURL = u }
+}
+
+// WithTokenURL overrides the token endpoint URL.
+func WithTokenURL(u string) Option {
+	return func(c *Client) { c.TokenURL = u }
+}
+
+// WithRevokeURL overrides the revoke endpoint URL.
+func WithRevokeURL(u string) Option {
+	return func(c *Client) { c.RevokeURL = u }
+}
+
+// WithHTTPClient injects a custom *http.Client (required for httptest).
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) { c.HTTPClient = hc }
+}
+
+// WithNow overrides the wall-clock source. Tests use this so
+// TokenResponse.IssuedAt is deterministic.
+func WithNow(now func() time.Time) Option {
+	return func(c *Client) { c.Now = now }
+}
+
+// NewClient returns a Client with sensible defaults, optionally
+// overridden by opts.
+func NewClient(opts ...Option) *Client {
+	c := &Client{
+		ClientID:     DefaultClientID,
+		AuthorizeURL: DefaultAuthorizeURL,
+		TokenURL:     DefaultTokenURL,
+		RevokeURL:    DefaultRevokeURL,
+		HTTPClient:   &http.Client{Timeout: DefaultExchangeTimeout},
+		Now:          time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// BuildAuthorizationURL composes the consent-screen URL with the given
+// state, PKCE code challenge, redirect URI, and scope.
+//
+// The challenge must be the S256-hashed verifier (see GeneratePKCEPair).
+func (c *Client) BuildAuthorizationURL(state, codeChallenge, redirectURI, scope string) string {
+	if scope == "" {
+		scope = DefaultScopes
+	}
+	q := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {c.ClientID},
+		"redirect_uri":          {redirectURI},
+		"scope":                 {scope},
+		"state":                 {state},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+	if strings.Contains(c.AuthorizeURL, "?") {
+		return c.AuthorizeURL + "&" + q.Encode()
+	}
+	return c.AuthorizeURL + "?" + q.Encode()
+}
+
+// ExchangeAuthorizationCode POSTs the authorization code + PKCE verifier
+// to the token endpoint, returning the parsed TokenResponse.
+//
+// RFC 6749 §4.1.3 requires the redirect_uri here be byte-identical to
+// the value used on the authorize hop, so callers should pass the URI
+// the loopback server bound to (see LoopbackResult.RedirectURI), not
+// reconstruct it from the local socket later.
+func (c *Client) ExchangeAuthorizationCode(
+	ctx context.Context,
+	code, codeVerifier, redirectURI string,
+) (*TokenResponse, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {c.ClientID},
+		"code_verifier": {codeVerifier},
+	}
+	return c.postTokenForm(ctx, form, "authorization_code")
+}
+
+// RefreshAccessToken POSTs grant_type=refresh_token to the token
+// endpoint. Returns the new TokenResponse; per RFC 6749 §6 the server
+// may omit refresh_token (no rotation), so callers should preserve the
+// prior refresh_token in that case.
+func (c *Client) RefreshAccessToken(ctx context.Context, refreshToken string) (*TokenResponse, error) {
+	if refreshToken == "" {
+		return nil, errors.New("oauth: refresh token must be non-empty")
+	}
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {c.ClientID},
+	}
+	return c.postTokenForm(ctx, form, "refresh_token")
+}
+
+// RevokeToken POSTs a best-effort revoke (RFC 7009) for the supplied
+// token. A hung or unreachable IdP MUST NOT block local logout, so this
+// method swallows network/transport failures and returns nil for them.
+// Only programmer-error inputs (empty token, malformed URL) return a
+// non-nil error.
+func (c *Client) RevokeToken(ctx context.Context, token string) error {
+	if token == "" {
+		return errors.New("oauth: token must be non-empty")
+	}
+	form := url.Values{
+		"token":     {token},
+		"client_id": {c.ClientID},
+	}
+
+	revokeCtx, cancel := context.WithTimeout(ctx, DefaultRevokeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(revokeCtx, http.MethodPost, c.RevokeURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("oauth: build revoke request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		// Best-effort: network/timeout/cancel — swallow.
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Even on non-2xx we consider the local logout authoritative; the
+	// caller will wipe the on-disk credentials regardless. We drain the
+	// body to allow connection reuse.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// postTokenForm is the shared POST + decode for the token endpoint.
+// `grant` is used only for error context.
+func (c *Client) postTokenForm(
+	ctx context.Context,
+	form url.Values,
+	grant string,
+) (*TokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.TokenURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("oauth: build %s request: %w", grant, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: %s request: %w", grant, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("oauth: read %s response: %w", grant, err)
+	}
+
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		// 400/401 here is the "the code/refresh was rejected" path. The
+		// PR-2 CLI surface will map this to a "log in again" UX; for now
+		// we surface a typed error with the server detail attached.
+		return nil, &TokenError{
+			Status:  resp.StatusCode,
+			Grant:   grant,
+			Body:    truncate(string(body), 500),
+			Wrapped: errRejected,
+		}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("oauth: %s endpoint returned HTTP %d: %s",
+			grant, resp.StatusCode, truncate(string(body), 500))
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("oauth: decode %s response: %w (body: %s)",
+			grant, err, truncate(string(body), 500))
+	}
+	tok, err := parseTokenResponse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: %s response invalid: %w", grant, err)
+	}
+	tok.IssuedAt = c.Now()
+	return tok, nil
+}
+
+// errRejected wraps 400/401 from the token endpoint. Exposed via
+// errors.Is so the PR-2 caller can detect "user needs to log in again"
+// without string-matching server bodies.
+var errRejected = errors.New("oauth: credential rejected by token endpoint")
+
+// TokenError is returned by ExchangeAuthorizationCode / RefreshAccessToken
+// when the IdP returns 400 or 401. Callers can use errors.Is(err, ErrRejected)
+// to drive a re-login UX.
+type TokenError struct {
+	Status  int
+	Grant   string
+	Body    string
+	Wrapped error
+}
+
+func (e *TokenError) Error() string {
+	return fmt.Sprintf("oauth: %s rejected (HTTP %d): %s", e.Grant, e.Status, e.Body)
+}
+
+func (e *TokenError) Unwrap() error { return e.Wrapped }
+
+// ErrRejected is the sentinel for a 400/401 from the token endpoint.
+var ErrRejected = errRejected
+
+func parseTokenResponse(obj map[string]any) (*TokenResponse, error) {
+	accessToken, ok := stringField(obj, "access_token")
+	if !ok || accessToken == "" {
+		return nil, errors.New("missing access_token")
+	}
+	if !isHeaderSafe(accessToken) {
+		return nil, errors.New("access_token contains control characters")
+	}
+	tok := &TokenResponse{AccessToken: accessToken}
+	if refresh, ok := stringField(obj, "refresh_token"); ok && refresh != "" {
+		if !isHeaderSafe(refresh) {
+			return nil, errors.New("refresh_token contains control characters")
+		}
+		tok.RefreshToken = refresh
+	}
+	if tt, ok := stringField(obj, "token_type"); ok {
+		tok.TokenType = tt
+	}
+	if scope, ok := stringField(obj, "scope"); ok {
+		tok.Scope = scope
+	}
+	if exp, ok := numericField(obj, "expires_in"); ok {
+		tok.ExpiresIn = int(exp)
+	}
+	return tok, nil
+}
+
+func stringField(obj map[string]any, key string) (string, bool) {
+	v, ok := obj[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func numericField(obj map[string]any, key string) (float64, bool) {
+	v, ok := obj[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	case string:
+		// Spec says expires_in is numeric, but defend against IdPs that
+		// send it as a quoted string.
+		var f float64
+		if _, err := fmt.Sscanf(n, "%f", &f); err != nil {
+			return 0, false
+		}
+		return f, true
+	}
+	return 0, false
+}
+
+// isHeaderSafe returns false if s contains any byte that would corrupt
+// an HTTP header (\r, \n, NUL). Protects against credential payloads
+// that the user wouldn't want propagated to an Authorization header.
+func isHeaderSafe(s string) bool {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case 0, '\r', '\n':
+			return false
+		}
+	}
+	return true
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/internal/auth/oauth/oauth_test.go
+++ b/internal/auth/oauth/oauth_test.go
@@ -70,7 +70,10 @@ func TestBuildAuthorizationURL_IncludesAllParams(t *testing.T) {
 		WithClientID("test-client"),
 		WithAuthorizeURL("https://example.test/oauth/authorize"),
 	)
-	u := c.BuildAuthorizationURL("the-state", "the-challenge", "http://127.0.0.1:12345/cb", "")
+	u, err := c.BuildAuthorizationURL("the-state", "the-challenge", "http://127.0.0.1:12345/cb", "")
+	if err != nil {
+		t.Fatalf("BuildAuthorizationURL: %v", err)
+	}
 
 	parsed, err := url.Parse(u)
 	if err != nil {
@@ -97,7 +100,10 @@ func TestBuildAuthorizationURL_IncludesAllParams(t *testing.T) {
 
 func TestBuildAuthorizationURL_HonorsExistingQuery(t *testing.T) {
 	c := NewClient(WithAuthorizeURL("https://example.test/oauth/authorize?foo=bar"))
-	u := c.BuildAuthorizationURL("s", "c", "http://127.0.0.1/cb", "openid")
+	u, err := c.BuildAuthorizationURL("s", "c", "http://127.0.0.1/cb", "openid")
+	if err != nil {
+		t.Fatalf("BuildAuthorizationURL: %v", err)
+	}
 	if !strings.Contains(u, "foo=bar") {
 		t.Errorf("expected pre-existing query to survive: %s", u)
 	}
@@ -108,10 +114,31 @@ func TestBuildAuthorizationURL_HonorsExistingQuery(t *testing.T) {
 
 func TestBuildAuthorizationURL_CustomScopeRespected(t *testing.T) {
 	c := NewClient(WithAuthorizeURL("https://example.test/oauth/authorize"))
-	u := c.BuildAuthorizationURL("s", "c", "http://127.0.0.1/cb", "custom scope here")
+	u, err := c.BuildAuthorizationURL("s", "c", "http://127.0.0.1/cb", "custom scope here")
+	if err != nil {
+		t.Fatalf("BuildAuthorizationURL: %v", err)
+	}
 	parsed, _ := url.Parse(u)
 	if got := parsed.Query().Get("scope"); got != "custom scope here" {
 		t.Errorf("scope = %q, want %q", got, "custom scope here")
+	}
+}
+
+func TestBuildAuthorizationURL_RejectsEmptyArgs(t *testing.T) {
+	c := NewClient(WithAuthorizeURL("https://example.test/oauth/authorize"))
+	tests := []struct {
+		name, state, challenge, redirect string
+	}{
+		{"empty state", "", "c", "http://127.0.0.1/cb"},
+		{"empty challenge", "s", "", "http://127.0.0.1/cb"},
+		{"empty redirect", "s", "c", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := c.BuildAuthorizationURL(tc.state, tc.challenge, tc.redirect, ""); err == nil {
+				t.Fatal("expected error for empty arg")
+			}
+		})
 	}
 }
 

--- a/internal/auth/oauth/oauth_test.go
+++ b/internal/auth/oauth/oauth_test.go
@@ -1,0 +1,329 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeIdP wraps an httptest.Server with helpers for the three OAuth
+// endpoints the driver hits. Tests configure the response inline via
+// the HandlerFunc fields.
+type fakeIdP struct {
+	server *httptest.Server
+
+	tokenHandler  http.HandlerFunc
+	revokeHandler http.HandlerFunc
+
+	// captured for assertions
+	lastTokenBody  url.Values
+	lastRevokeBody url.Values
+}
+
+func newFakeIdP(t *testing.T) *fakeIdP {
+	t.Helper()
+	idp := &fakeIdP{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		idp.lastTokenBody, _ = url.ParseQuery(string(body))
+		if idp.tokenHandler != nil {
+			idp.tokenHandler(w, r)
+			return
+		}
+		http.Error(w, "no token handler configured", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/v1/oauth/revoke", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		idp.lastRevokeBody, _ = url.ParseQuery(string(body))
+		if idp.revokeHandler != nil {
+			idp.revokeHandler(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	idp.server = httptest.NewServer(mux)
+	t.Cleanup(idp.server.Close)
+	return idp
+}
+
+func (f *fakeIdP) client(t *testing.T) *Client {
+	t.Helper()
+	return NewClient(
+		WithClientID("test-client"),
+		WithAuthorizeURL("https://example.test/oauth/authorize"),
+		WithTokenURL(f.server.URL+"/v1/oauth/token"),
+		WithRevokeURL(f.server.URL+"/v1/oauth/revoke"),
+		WithHTTPClient(f.server.Client()),
+		WithNow(func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }),
+	)
+}
+
+func TestBuildAuthorizationURL_IncludesAllParams(t *testing.T) {
+	c := NewClient(
+		WithClientID("test-client"),
+		WithAuthorizeURL("https://example.test/oauth/authorize"),
+	)
+	u := c.BuildAuthorizationURL("the-state", "the-challenge", "http://127.0.0.1:12345/cb", "")
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	q := parsed.Query()
+	tests := []struct {
+		key, want string
+	}{
+		{"response_type", "code"},
+		{"client_id", "test-client"},
+		{"redirect_uri", "http://127.0.0.1:12345/cb"},
+		{"scope", DefaultScopes},
+		{"state", "the-state"},
+		{"code_challenge", "the-challenge"},
+		{"code_challenge_method", "S256"},
+	}
+	for _, tc := range tests {
+		if got := q.Get(tc.key); got != tc.want {
+			t.Errorf("query[%s] = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestBuildAuthorizationURL_HonorsExistingQuery(t *testing.T) {
+	c := NewClient(WithAuthorizeURL("https://example.test/oauth/authorize?foo=bar"))
+	u := c.BuildAuthorizationURL("s", "c", "http://127.0.0.1/cb", "openid")
+	if !strings.Contains(u, "foo=bar") {
+		t.Errorf("expected pre-existing query to survive: %s", u)
+	}
+	if !strings.Contains(u, "&client_id=") {
+		t.Errorf("expected & separator, got %s", u)
+	}
+}
+
+func TestBuildAuthorizationURL_CustomScopeRespected(t *testing.T) {
+	c := NewClient(WithAuthorizeURL("https://example.test/oauth/authorize"))
+	u := c.BuildAuthorizationURL("s", "c", "http://127.0.0.1/cb", "custom scope here")
+	parsed, _ := url.Parse(u)
+	if got := parsed.Query().Get("scope"); got != "custom scope here" {
+		t.Errorf("scope = %q, want %q", got, "custom scope here")
+	}
+}
+
+func TestExchangeAuthorizationCode_Success(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"access_token": "AT-123",
+			"refresh_token": "RT-456",
+			"token_type": "Bearer",
+			"expires_in": 3600,
+			"scope": "openid profile email"
+		}`)
+	}
+	c := idp.client(t)
+
+	tok, err := c.ExchangeAuthorizationCode(context.Background(), "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+	if err != nil {
+		t.Fatalf("ExchangeAuthorizationCode: %v", err)
+	}
+	if tok.AccessToken != "AT-123" {
+		t.Errorf("access_token = %q", tok.AccessToken)
+	}
+	if tok.RefreshToken != "RT-456" {
+		t.Errorf("refresh_token = %q", tok.RefreshToken)
+	}
+	if tok.ExpiresIn != 3600 {
+		t.Errorf("expires_in = %d", tok.ExpiresIn)
+	}
+	if tok.IssuedAt.IsZero() {
+		t.Error("IssuedAt should be set by driver")
+	}
+
+	// Verify the form fields the driver POSTed.
+	want := map[string]string{
+		"grant_type":    "authorization_code",
+		"code":          "the-code",
+		"redirect_uri":  "http://127.0.0.1:8080/cb",
+		"client_id":     "test-client",
+		"code_verifier": "the-verifier",
+	}
+	for k, v := range want {
+		if got := idp.lastTokenBody.Get(k); got != v {
+			t.Errorf("form[%s] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestExchangeAuthorizationCode_RejectedReturnsTokenError(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+	}
+	c := idp.client(t)
+
+	_, err := c.ExchangeAuthorizationCode(context.Background(), "bad-code", "verifier", "http://127.0.0.1/cb")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var te *TokenError
+	if !errors.As(err, &te) {
+		t.Fatalf("expected *TokenError, got %T: %v", err, err)
+	}
+	if te.Status != http.StatusBadRequest {
+		t.Errorf("Status = %d", te.Status)
+	}
+	if !errors.Is(err, ErrRejected) {
+		t.Errorf("errors.Is(err, ErrRejected) = false, want true")
+	}
+}
+
+func TestRefreshAccessToken_PreservesPriorTokenWhenServerOmits(t *testing.T) {
+	// RFC 6749 §6 allows the server to skip refresh_token on a refresh
+	// response (no rotation). The driver returns the response as-is;
+	// caller-side persistence handles the preserve. This test verifies
+	// the wire-level behavior — the driver does not invent fields.
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"new-AT","token_type":"Bearer","expires_in":1800}`)
+	}
+	c := idp.client(t)
+
+	tok, err := c.RefreshAccessToken(context.Background(), "old-RT")
+	if err != nil {
+		t.Fatalf("RefreshAccessToken: %v", err)
+	}
+	if tok.AccessToken != "new-AT" {
+		t.Errorf("access_token = %q", tok.AccessToken)
+	}
+	if tok.RefreshToken != "" {
+		t.Errorf("driver should not invent refresh_token, got %q", tok.RefreshToken)
+	}
+	if got := idp.lastTokenBody.Get("grant_type"); got != "refresh_token" {
+		t.Errorf("grant_type = %q", got)
+	}
+	if got := idp.lastTokenBody.Get("refresh_token"); got != "old-RT" {
+		t.Errorf("refresh_token = %q", got)
+	}
+}
+
+func TestRefreshAccessToken_RejectsEmpty(t *testing.T) {
+	idp := newFakeIdP(t)
+	c := idp.client(t)
+	if _, err := c.RefreshAccessToken(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty refresh token")
+	}
+}
+
+func TestRefreshAccessToken_401Returns_ErrRejected(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusUnauthorized)
+	}
+	c := idp.client(t)
+	_, err := c.RefreshAccessToken(context.Background(), "stale-rt")
+	if !errors.Is(err, ErrRejected) {
+		t.Errorf("expected ErrRejected, got %v", err)
+	}
+}
+
+func TestRevokeToken_Success(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.revokeHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+	c := idp.client(t)
+
+	if err := c.RevokeToken(context.Background(), "tok-abc"); err != nil {
+		t.Fatalf("RevokeToken: %v", err)
+	}
+	if got := idp.lastRevokeBody.Get("token"); got != "tok-abc" {
+		t.Errorf("body[token] = %q", got)
+	}
+	if got := idp.lastRevokeBody.Get("client_id"); got != "test-client" {
+		t.Errorf("body[client_id] = %q", got)
+	}
+}
+
+func TestRevokeToken_SwallowsNetworkErrors(t *testing.T) {
+	// Best-effort: a hung/unreachable IdP MUST NOT block local logout.
+	c := NewClient(
+		WithClientID("test-client"),
+		WithRevokeURL("http://127.0.0.1:1/v1/oauth/revoke"), // unroutable
+		WithHTTPClient(&http.Client{Timeout: 50 * time.Millisecond}),
+	)
+	if err := c.RevokeToken(context.Background(), "tok"); err != nil {
+		t.Errorf("expected nil error on network failure, got %v", err)
+	}
+}
+
+func TestRevokeToken_RejectsEmpty(t *testing.T) {
+	c := NewClient()
+	if err := c.RevokeToken(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestExchangeAuthorizationCode_BadShapeReturnsError(t *testing.T) {
+	tests := []struct {
+		name, body string
+	}{
+		{"missing access_token", `{"token_type":"Bearer"}`},
+		{"non-object body", `[]`},
+		{"access_token with newline", "{\"access_token\":\"AT\\nleak\"}"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idp := newFakeIdP(t)
+			idp.tokenHandler = func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.body)
+			}
+			c := idp.client(t)
+			_, err := c.ExchangeAuthorizationCode(context.Background(), "code", "verifier", "http://127.0.0.1/cb")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestExchangeAuthorizationCode_5xxReturnsGenericError(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}
+	c := idp.client(t)
+	_, err := c.ExchangeAuthorizationCode(context.Background(), "code", "verifier", "http://127.0.0.1/cb")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrRejected) {
+		t.Errorf("5xx should not be ErrRejected: %v", err)
+	}
+}
+
+func TestExchangeAuthorizationCode_ContextCancellation(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"AT"}`)
+	}
+	c := idp.client(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := c.ExchangeAuthorizationCode(ctx, "code", "verifier", "http://127.0.0.1/cb")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}

--- a/internal/auth/oauth/pkce.go
+++ b/internal/auth/oauth/pkce.go
@@ -1,0 +1,45 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+// pkceVerifierBytes produces a 64-byte random verifier, which encodes to
+// 86 URL-safe base64 characters — comfortably inside the RFC 7636
+// 43–128 range.
+const pkceVerifierBytes = 64
+
+// GeneratePKCEPair returns a PKCE (RFC 7636) code_verifier and the
+// corresponding S256 code_challenge.
+//
+// The verifier is sent on the token exchange; the challenge is sent on
+// the authorize URL. The server hashes the verifier and rejects the
+// exchange if it doesn't match the challenge that opened the flow —
+// removing the need for a client_secret on a public CLI client.
+func GeneratePKCEPair() (verifier, challenge string, err error) {
+	raw := make([]byte, pkceVerifierBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", "", fmt.Errorf("oauth: read random bytes for PKCE verifier: %w", err)
+	}
+	verifier = base64URL(raw)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64URL(sum[:])
+	return verifier, challenge, nil
+}
+
+// GenerateState returns a random URL-safe string suitable for the OAuth
+// `state` parameter (CSRF token for the authorize redirect).
+func GenerateState() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("oauth: read random bytes for state: %w", err)
+	}
+	return base64URL(raw), nil
+}
+
+func base64URL(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/internal/auth/oauth/pkce_test.go
+++ b/internal/auth/oauth/pkce_test.go
@@ -1,0 +1,76 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestGeneratePKCEPair_ProducesValidS256Pair(t *testing.T) {
+	verifier, challenge, err := GeneratePKCEPair()
+	if err != nil {
+		t.Fatalf("GeneratePKCEPair: %v", err)
+	}
+
+	if got := len(verifier); got < 43 || got > 128 {
+		t.Errorf("verifier length = %d, want in [43, 128]", got)
+	}
+	if strings.ContainsAny(verifier, "+/=") {
+		t.Errorf("verifier %q is not base64url (contains padding/non-url chars)", verifier)
+	}
+	if strings.ContainsAny(challenge, "+/=") {
+		t.Errorf("challenge %q is not base64url (contains padding/non-url chars)", challenge)
+	}
+
+	// Recompute the challenge from the verifier and compare. PKCE S256
+	// is defined as base64url(SHA256(ASCII(verifier))).
+	sum := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if challenge != want {
+		t.Errorf("challenge = %q, want %q", challenge, want)
+	}
+}
+
+func TestGeneratePKCEPair_ReturnsDistinctValues(t *testing.T) {
+	// Each call should produce a new verifier; collisions across 5 calls
+	// would imply a broken random source.
+	seen := map[string]bool{}
+	for i := 0; i < 5; i++ {
+		v, _, err := GeneratePKCEPair()
+		if err != nil {
+			t.Fatalf("GeneratePKCEPair[%d]: %v", i, err)
+		}
+		if seen[v] {
+			t.Fatalf("verifier collision at iteration %d: %q", i, v)
+		}
+		seen[v] = true
+	}
+}
+
+func TestGenerateState_NonEmptyAndURLSafe(t *testing.T) {
+	s, err := GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState: %v", err)
+	}
+	if s == "" {
+		t.Fatal("state is empty")
+	}
+	if strings.ContainsAny(s, "+/=") {
+		t.Errorf("state %q is not base64url", s)
+	}
+}
+
+func TestGenerateState_DistinctValues(t *testing.T) {
+	a, err := GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState a: %v", err)
+	}
+	b, err := GenerateState()
+	if err != nil {
+		t.Fatalf("GenerateState b: %v", err)
+	}
+	if a == b {
+		t.Fatalf("two consecutive states were identical: %q", a)
+	}
+}

--- a/internal/auth/oauth/tokens.go
+++ b/internal/auth/oauth/tokens.go
@@ -1,0 +1,47 @@
+// Package oauth implements the HeyGen public OAuth 2.0 + PKCE driver.
+//
+// PR 1 of the OAuth stack: this package is a self-contained driver with
+// no callers yet. The CLI surface (`heygen auth login`), credential
+// resolver wiring, and Bearer transport land in PR 2.
+//
+// The shared on-disk credentials file (~/.heygen/credentials) already
+// understands the `oauth` block (see internal/auth/file_resolver.go),
+// matching the JSON layout hyperframes-CLI writes. This driver returns
+// TokenResponse values that the resolver/store layer will persist; it
+// does not touch disk itself.
+package oauth
+
+import "time"
+
+// TokenResponse is the RFC 6749 §5.1 token-endpoint response, restricted
+// to the fields heygen-cli cares about. The IdP may include `id_token`
+// (OIDC) and other extensions — we ignore them.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	// ExpiresIn is the access-token lifetime in seconds, as returned by
+	// the IdP. Use Expired() to compare against a wall clock; the package
+	// does not compute an absolute expiry timestamp here (callers persist
+	// the absolute timestamp into the credentials file).
+	ExpiresIn int    `json:"expires_in,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	TokenType string `json:"token_type,omitempty"`
+	// IssuedAt is set by the driver to the wall-clock time the response
+	// was parsed. It is not part of the on-the-wire payload.
+	IssuedAt time.Time `json:"-"`
+}
+
+// Expired reports whether the access token is past its expiry, with the
+// given skew subtracted from the lifetime (so callers can refresh
+// proactively). A zero IssuedAt or zero ExpiresIn is treated as "no
+// information," so Expired returns false rather than guessing.
+func (t *TokenResponse) Expired(now time.Time, skew time.Duration) bool {
+	if t == nil {
+		return true
+	}
+	if t.IssuedAt.IsZero() || t.ExpiresIn <= 0 {
+		return false
+	}
+	expiry := t.IssuedAt.Add(time.Duration(t.ExpiresIn) * time.Second)
+	return !now.Before(expiry.Add(-skew))
+}

--- a/internal/auth/oauth/tokens_test.go
+++ b/internal/auth/oauth/tokens_test.go
@@ -1,0 +1,78 @@
+package oauth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenResponse_Expired(t *testing.T) {
+	base := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		tok         *TokenResponse
+		now         time.Time
+		skew        time.Duration
+		wantExpired bool
+	}{
+		{
+			name:        "nil token is expired",
+			tok:         nil,
+			now:         base,
+			wantExpired: true,
+		},
+		{
+			name:        "zero IssuedAt: no information, treat as live",
+			tok:         &TokenResponse{ExpiresIn: 3600},
+			now:         base,
+			wantExpired: false,
+		},
+		{
+			name:        "zero ExpiresIn: no information, treat as live",
+			tok:         &TokenResponse{IssuedAt: base},
+			now:         base,
+			wantExpired: false,
+		},
+		{
+			name:        "well within lifetime",
+			tok:         &TokenResponse{IssuedAt: base, ExpiresIn: 3600},
+			now:         base.Add(30 * time.Minute),
+			wantExpired: false,
+		},
+		{
+			name:        "exactly at expiry: expired",
+			tok:         &TokenResponse{IssuedAt: base, ExpiresIn: 3600},
+			now:         base.Add(time.Hour),
+			wantExpired: true,
+		},
+		{
+			name:        "past expiry: expired",
+			tok:         &TokenResponse{IssuedAt: base, ExpiresIn: 3600},
+			now:         base.Add(2 * time.Hour),
+			wantExpired: true,
+		},
+		{
+			name:        "skew makes a live token look expired (proactive refresh)",
+			tok:         &TokenResponse{IssuedAt: base, ExpiresIn: 3600},
+			now:         base.Add(59 * time.Minute),
+			skew:        2 * time.Minute,
+			wantExpired: true,
+		},
+		{
+			name:        "skew leaves headroom",
+			tok:         &TokenResponse{IssuedAt: base, ExpiresIn: 3600},
+			now:         base.Add(57 * time.Minute),
+			skew:        2 * time.Minute,
+			wantExpired: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.tok.Expired(tc.now, tc.skew)
+			if got != tc.wantExpired {
+				t.Errorf("Expired() = %v, want %v", got, tc.wantExpired)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

PR 1 of 2 in the heygen-cli OAuth stack. **Foundation only — no
user-visible CLI surface changes yet.** This PR adds a self-contained
`internal/auth/oauth/` package that drives the HeyGen public OAuth
2.0 + PKCE flow. Nothing in the existing CLI, credential resolver,
or HTTP transport changes.

### What's in this PR

| File | Purpose |
|---|---|
| `oauth.go` | OAuth `Client` with `BuildAuthorizationURL`, `ExchangeAuthorizationCode`, `RefreshAccessToken`, `RevokeToken`. Endpoints + client_id are overridable so tests swap in `httptest.Server`. |
| `pkce.go` | RFC 7636 `GeneratePKCEPair()` (S256) + `GenerateState()`. |
| `loopback.go` | `StartLoopbackServer(ctx, redirectPath, expectedState)` — binds `127.0.0.1:0`, serves a single GET, constant-time state check, 5-min timeout, keep-alive-safe shutdown. |
| `browser.go` | `OpenBrowser(url)` — platform `open`/`xdg-open`/`rundll32` via `exec.Command`, with non-TTY + `BROWSER=none` + `HEYGEN_NO_BROWSER=1` headless fallbacks that print the URL. |
| `tokens.go` | `TokenResponse` struct + `Expired(now, skew)` helper. |

### Shared client_id with hyperframes-CLI

Both CLIs are public clients on the same HeyGen IdP and share the
baked-in `q2A2QRSke2LrFTPJhoDbHtXh` client_id; the HyperFrames CLI's
value is the authoritative one and must not drift. Endpoints follow
the same split: authorize on `app.heygen.com` (same origin as the
user's web session cookies), token + revoke on `api2.heygen.com`.

### What's deferred to PR 2

- `internal/auth/file_resolver.go:selectCredential` — the OAuth-aware
  credential resolver seam.
- `internal/client/client.go:Do` — `Authorization: Bearer` transport
  wiring.
- `cmd/heygen/auth_login.go` — new `heygen auth login` UX that calls
  this driver.

PR 2 ships those together so the `auth login` UX lands once with a
working end-to-end path.

### Notes

- No new dependencies — `golang.org/x/term` is already in `go.sum`
  from cross-platform stdin-isatty detection elsewhere. Platform
  browser launching uses `exec.Command`. No CGO.
- `internal/auth/credentials_file.go` already understands the JSON
  layout with an `oauth` block (mirrors hyperframes-CLI's shared file
  format), so the on-disk side is ready for PR 2.
- Headless / CI keeps using `HEYGEN_API_KEY` env (no file fallback in
  CI) per the OAuth-stack scope decision.

## Testing

- Table-driven unit tests for each file in the new package.
- `oauth_test.go` uses `httptest.NewServer` as a fake IdP and asserts
  happy-path + 400/401 (mapped to `ErrRejected`) + 5xx + context-cancel
  + bad-shape token responses (missing `access_token`, control chars,
  non-object).
- `loopback_test.go` covers happy path, state mismatch, IdP-error
  propagation, missing code, context cancel, non-GET rejection,
  argument validation.
- `pkce_test.go` verifies length, base64url shape, S256 round-trip,
  and uniqueness across calls.
- `browser_test.go` exercises the headless print path, opener-failure
  fallback, and the two env-var skips (`BROWSER=none`,
  `HEYGEN_NO_BROWSER=1`).
- `tokens_test.go` covers `Expired(now, skew)` edge cases including
  the proactive-refresh skew.
- All package tests pass with `-race -count=1`; full `make test`
  and `golangci-lint run ./...` clean locally.

— Jerrai (https://claude.com/claude-code)