### PR TITLE
auth: show friendly user name/email on login + auth status

### DIFF
--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -38,6 +38,22 @@ var defaultOAuthLoginConfig = oauthLoginConfig{
 	TokenURL:     oauth.DefaultTokenURL,
 }
 
+// apiKeyLoginConfig is overridable in tests so the api-key login flow's
+// friendly-display probe can be driven against an httptest /v3/users/me
+// without depending on the production base URL. Production callers
+// leave every field zero — the dispatcher reads ctx.configProvider for
+// the base URL the same way oauth login does.
+type apiKeyLoginConfig struct {
+	// UsersMeBaseURL pins the /v3/users/me base URL (test-only). When
+	// empty, the dispatcher falls back to ctx.configProvider.BaseURL().
+	UsersMeBaseURL string
+}
+
+// apiKeyLoginConfigForTest is set by tests that need to override the
+// friendly-display probe target. Production callers leave this nil so
+// runAPIKeyLogin walks the standard ctx.configProvider path.
+var apiKeyLoginConfigForTest *apiKeyLoginConfig
+
 // authLoginRedirectPath is the loopback path the browser callback hits.
 const authLoginRedirectPath = "/oauth/callback"
 
@@ -303,6 +319,34 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
 		clearedOAuth = true
 	}
 
+	// Best-effort identity probe so we can surface "Logged in as ..."
+	// for api-key callers too. Same contract as the OAuth probe — a
+	// failure here is non-fatal; the api_key on disk is still usable,
+	// and the user just won't see friendly fields until the next
+	// successful re-login.
+	//
+	// Resolve the base URL the same way the OAuth flow does so a CLI
+	// pointed at a dev sandbox via HEYGEN_API_BASE doesn't accidentally
+	// hit production for the probe.
+	probeBase := ""
+	if apiKeyLoginConfigForTest != nil {
+		probeBase = apiKeyLoginConfigForTest.UsersMeBaseURL
+	}
+	if probeBase == "" && ctx.configProvider != nil {
+		probeBase = ctx.configProvider.BaseURL()
+	}
+	userInfo := lookupCurrentUserAPIKey(cmd.Context(), key, probeBase)
+	if !userInfo.IsZero() {
+		if saveErr := auth.SaveUserInfo(userInfo); saveErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "(warning: could not persist user info: %v)\n", saveErr)
+		}
+	} else if clearErr := auth.ClearUserInfo(); clearErr != nil {
+		// Probe failed but a stale user block from a prior login may
+		// still be on disk. Best-effort clear; a failure here is
+		// non-fatal (stale display is a minor UX bug, not security).
+		fmt.Fprintf(cmd.ErrOrStderr(), "(warning: could not clear stale user info: %v)\n", clearErr)
+	}
+
 	credPath := filepath.Join(paths.ConfigDir(), "credentials")
 	message := "API key saved to " + credPath
 	if clearedOAuth {
@@ -312,9 +356,24 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
 		"message":       message,
 		"cleared_oauth": clearedOAuth,
 	}
+	if userInfo.Username != "" {
+		payload["username"] = userInfo.Username
+	}
+	if userInfo.Email != "" {
+		payload["email"] = userInfo.Email
+	}
+	if userInfo.FirstName != "" {
+		payload["first_name"] = userInfo.FirstName
+	}
+	if userInfo.LastName != "" {
+		payload["last_name"] = userInfo.LastName
+	}
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
+	}
+	if display := userInfo.DisplayName(); display != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
 	}
 	return ctx.formatter.Data(data, "", nil)
 }
@@ -438,7 +497,24 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	if probeBase == "" && ctx.configProvider != nil {
 		probeBase = ctx.configProvider.BaseURL()
 	}
-	username, email := lookupCurrentUser(cmdCtx, tok.AccessToken, probeBase)
+	userInfo := lookupCurrentUser(cmdCtx, tok.AccessToken, probeBase)
+
+	// Persist the friendly-display block alongside the OAuth tokens so
+	// subsequent `auth status` invocations can show "Logged in as ..."
+	// without re-hitting /v3/users/me. Best-effort: a persist failure is
+	// non-fatal (login proceeds; the user just won't see friendly fields
+	// until the next successful re-login).
+	if !userInfo.IsZero() {
+		if saveErr := auth.SaveUserInfo(userInfo); saveErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "(warning: could not persist user info: %v)\n", saveErr)
+		}
+	} else if clearErr := auth.ClearUserInfo(); clearErr != nil {
+		// Probe failed AND the file might still hold a stale user block
+		// from a prior login (different account). Best-effort clear; a
+		// failure here is non-fatal — stale display is a minor UX bug,
+		// not a security issue.
+		fmt.Fprintf(cmd.ErrOrStderr(), "(warning: could not clear stale user info: %v)\n", clearErr)
+	}
 
 	credPath := filepath.Join(paths.ConfigDir(), "credentials")
 	message := "Signed in via OAuth; credentials saved to " + credPath
@@ -454,20 +530,24 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	if !expiresAt.IsZero() {
 		payload["expires_at"] = expiresAt.UTC().Format(time.RFC3339)
 	}
-	if username != "" {
-		payload["username"] = username
+	if userInfo.Username != "" {
+		payload["username"] = userInfo.Username
 	}
-	if email != "" {
-		payload["email"] = email
+	if userInfo.Email != "" {
+		payload["email"] = userInfo.Email
+	}
+	if userInfo.FirstName != "" {
+		payload["first_name"] = userInfo.FirstName
+	}
+	if userInfo.LastName != "" {
+		payload["last_name"] = userInfo.LastName
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
 	}
-	if username != "" {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", username)
-	} else if email != "" {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", email)
+	if display := userInfo.DisplayName(); display != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
 	} else {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Logged in.")
 	}
@@ -475,45 +555,90 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 }
 
 // lookupCurrentUser GETs /v3/users/me with the freshly minted Bearer
-// token and pulls a display name from the response. The CLI doesn't
-// have the regular Client wired up yet at this point (we just minted
-// the credential), so we issue a one-shot http call rather than
-// re-bootstrapping the resolver.
-func lookupCurrentUser(ctx context.Context, accessToken, baseURL string) (username, email string) {
+// token and pulls the friendly-display fields from the response. The
+// CLI doesn't have the regular Client wired up yet at this point (we
+// just minted the credential), so we issue a one-shot http call rather
+// than re-bootstrapping the resolver.
+//
+// On any failure (network, non-200, malformed body) returns a zero
+// UserInfo with no error — the caller treats this as "friendly display
+// unavailable" and proceeds without it. The login itself is NEVER
+// rolled back on a probe failure.
+func lookupCurrentUser(ctx context.Context, accessToken, baseURL string) auth.UserInfo {
+	req, err := buildUsersMeRequest(ctx, baseURL)
+	if err != nil {
+		return auth.UserInfo{}
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("User-Agent", "heygen-cli/oauth-login")
+	return runUsersMeRequest(req)
+}
+
+// lookupCurrentUserAPIKey is the api_key equivalent of
+// lookupCurrentUser. It sends the key on the x-api-key header (the
+// transport that the api_key resolver would use) and pulls the same
+// friendly-display fields. Same best-effort contract — a failure here
+// is non-fatal and yields a zero UserInfo.
+func lookupCurrentUserAPIKey(ctx context.Context, apiKey, baseURL string) auth.UserInfo {
+	req, err := buildUsersMeRequest(ctx, baseURL)
+	if err != nil {
+		return auth.UserInfo{}
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("User-Agent", "heygen-cli/apikey-login")
+	return runUsersMeRequest(req)
+}
+
+// buildUsersMeRequest assembles the GET /v3/users/me request shared by
+// both lookup paths. Centralized so the OAuth and api_key variants
+// can't drift on URL / headers / context plumbing.
+func buildUsersMeRequest(ctx context.Context, baseURL string) (*http.Request, error) {
 	if baseURL == "" {
 		baseURL = "https://api.heygen.com"
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v3/users/me", nil)
 	if err != nil {
-		return "", ""
+		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "heygen-cli/oauth-login")
+	return req, nil
+}
 
+// runUsersMeRequest executes the prepared /v3/users/me probe and
+// decodes the friendly-display fields. Returns a zero UserInfo on any
+// failure (network, non-200, malformed body) — the caller treats this
+// as "friendly display unavailable" and proceeds without it.
+func runUsersMeRequest(req *http.Request) auth.UserInfo {
 	hc := &http.Client{Timeout: 10 * time.Second}
 	resp, err := hc.Do(req) //nolint:gosec // G704: short-lived /v3/users/me probe
 	if err != nil {
-		return "", ""
+		return auth.UserInfo{}
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", ""
+		return auth.UserInfo{}
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", ""
+		return auth.UserInfo{}
 	}
 	var envelope struct {
 		Data struct {
-			Username string `json:"username"`
-			Email    string `json:"email"`
+			Username  string `json:"username"`
+			Email     string `json:"email"`
+			FirstName string `json:"first_name"`
+			LastName  string `json:"last_name"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil {
-		return "", ""
+		return auth.UserInfo{}
 	}
-	return envelope.Data.Username, envelope.Data.Email
+	return auth.UserInfo{
+		Username:  envelope.Data.Username,
+		Email:     envelope.Data.Email,
+		FirstName: envelope.Data.FirstName,
+		LastName:  envelope.Data.LastName,
+	}
 }
 
 func readAPIKey(in io.Reader, errOut io.Writer) (string, error) {

--- a/cmd/heygen/auth_login_friendly_test.go
+++ b/cmd/heygen/auth_login_friendly_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/heygen-com/heygen-cli/internal/auth"
+)
+
+// usersMeServerForKey serves /v3/users/me, asserting the api-key probe
+// sent the supplied key on x-api-key (and NOT Authorization: Bearer).
+// The body fields control what the probe returns.
+func usersMeServerForKey(t *testing.T, wantKey, body string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	hits := &atomic.Int32{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v3/users/me" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("x-api-key"); got != wantKey {
+			t.Errorf("x-api-key = %q, want %q", got, wantKey)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization header set on api-key probe: %q", got)
+		}
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, hits
+}
+
+// TestAuthLogin_APIKey_PersistsFriendlyUserInfo is the end-to-end happy
+// path for the friendly-display change on the api-key login route:
+// post-login, the CLI probes /v3/users/me with x-api-key, persists the
+// returned email/name/username to the credentials file, and surfaces
+// "Logged in as ..." on stderr.
+func TestAuthLogin_APIKey_PersistsFriendlyUserInfo(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	srv, hits := usersMeServerForKey(t, "hg_test_key",
+		`{"data":{"username":"jdoe","email":"jane@example.com","first_name":"Jane","last_name":"Doe"}}`)
+
+	res := runCommandWithInput(t, srv.URL, "", strings.NewReader("hg_test_key\n"),
+		"auth", "login", "--api-key")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s\nstdout: %s", res.ExitCode, res.Stderr, res.Stdout)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("/v3/users/me hits = %d, want 1", got)
+	}
+
+	// Persisted user block on disk.
+	ui, err := auth.LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: %v", err)
+	}
+	want := auth.UserInfo{
+		Username:  "jdoe",
+		Email:     "jane@example.com",
+		FirstName: "Jane",
+		LastName:  "Doe",
+	}
+	if ui != want {
+		t.Fatalf("user block = %+v, want %+v", ui, want)
+	}
+
+	// Friendly-display priority: email wins. Stderr must surface the
+	// email rather than the username so the line shows recognizable
+	// identity instead of an opaque handle.
+	if !strings.Contains(res.Stderr, "Logged in as jane@example.com") {
+		t.Errorf("stderr = %q, want 'Logged in as jane@example.com'", res.Stderr)
+	}
+
+	// JSON payload exposes the friendly fields so jq pipelines can read
+	// them without a second /v3/users/me call.
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, res.Stdout)
+	}
+	if parsed["email"] != "jane@example.com" {
+		t.Errorf("stdout.email = %v, want jane@example.com", parsed["email"])
+	}
+	if parsed["first_name"] != "Jane" {
+		t.Errorf("stdout.first_name = %v, want Jane", parsed["first_name"])
+	}
+}
+
+// TestAuthLogin_APIKey_FallsBackOnProbeFailure verifies the
+// non-blocking-on-failure invariant: when /v3/users/me is unreachable
+// (or returns a non-200), the api-key login still succeeds and the key
+// is on disk. Friendly fields are simply absent.
+func TestAuthLogin_APIKey_FallsBackOnProbeFailure(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	// Server returns 500 on the probe — non-fatal per the contract.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	res := runCommandWithInput(t, srv.URL, "", strings.NewReader("hg_key\n"),
+		"auth", "login", "--api-key")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0 (login must not block on probe failure)\nstderr: %s",
+			res.ExitCode, res.Stderr)
+	}
+
+	// api_key was persisted.
+	creds, err := os.ReadFile(filepath.Join(configDir, "credentials"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(creds), `"hg_key"`) {
+		t.Fatalf("api_key missing from creds:\n%s", creds)
+	}
+
+	// No friendly fields persisted.
+	ui, err := auth.LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: %v", err)
+	}
+	if !ui.IsZero() {
+		t.Fatalf("expected zero UserInfo on probe failure, got %+v", ui)
+	}
+
+	// Friendly-display line absent (probe failed → no display).
+	if strings.Contains(res.Stderr, "Logged in as") {
+		t.Errorf("stderr should NOT contain 'Logged in as' on probe failure:\n%s", res.Stderr)
+	}
+}
+
+// TestAuthLogin_APIKey_ClearsStaleUserInfo: re-login with a key for a
+// DIFFERENT account where the probe FAILS must not leave the prior
+// account's friendly fields on disk to mislead `auth status`.
+func TestAuthLogin_APIKey_ClearsStaleUserInfo(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	// Seed prior account state directly via the store: api_key + user.
+	if err := (&auth.FileCredentialStore{}).Save("hg_old"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := auth.SaveUserInfo(auth.UserInfo{Email: "old@example.com"}); err != nil {
+		t.Fatalf("SaveUserInfo: %v", err)
+	}
+
+	// New login: probe fails (500).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	res := runCommandWithInput(t, srv.URL, "", strings.NewReader("hg_new\n"),
+		"auth", "login", "--api-key")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	// New key on disk.
+	creds, err := os.ReadFile(filepath.Join(configDir, "credentials"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(creds), `"hg_new"`) {
+		t.Fatalf("new api_key missing:\n%s", creds)
+	}
+	// Old user info must be gone — leaving it would surface the wrong
+	// account in `auth status` until the next successful probe.
+	if strings.Contains(string(creds), "old@example.com") {
+		t.Fatalf("stale user block survived re-login:\n%s", creds)
+	}
+}
+
+// TestAuthLogin_OAuth_PersistsFullUserInfo extends the existing OAuth
+// integration test to assert the new full schema (first_name, last_name)
+// is persisted, not just username/email.
+func TestAuthLogin_OAuth_PersistsFullUserInfo(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	usersMe := fakeUsersMeServer(t,
+		`{"data":{"username":"jdoe","email":"jane@example.com","first_name":"Jane","last_name":"Doe"}}`)
+
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go hitBrowserCallbackAfter(t, idp.expectedCode, authURL)
+			return nil
+		},
+		UsersMeBaseURL: usersMe.URL,
+	}
+	res := runOAuthLoginForTest(t, cfg)
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s\nstdout: %s", res.ExitCode, res.Stderr, res.Stdout)
+	}
+
+	ui, err := auth.LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: %v", err)
+	}
+	want := auth.UserInfo{
+		Username:  "jdoe",
+		Email:     "jane@example.com",
+		FirstName: "Jane",
+		LastName:  "Doe",
+	}
+	if ui != want {
+		t.Fatalf("persisted user block = %+v, want %+v", ui, want)
+	}
+}
+
+// hitBrowserCallbackAfter mirrors the goroutine pattern the other OAuth
+// tests use: a tiny delay so the loopback server's Accept() loop is up
+// before we connect, then invoke the shared hitBrowserCallback helper
+// defined in auth_login_oauth_test.go.
+func hitBrowserCallbackAfter(t *testing.T, code, authURL string) {
+	t.Helper()
+	time.Sleep(50 * time.Millisecond)
+	hitBrowserCallback(t, code, authURL)
+}

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -193,9 +193,12 @@ func TestAuthLogin_OAuthFlow_PersistsTokens(t *testing.T) {
 		}
 	}
 
-	// Stderr should mention "Logged in as demo" (from /v3/users/me).
-	if !strings.Contains(res.Stderr, "Logged in as demo") {
-		t.Errorf("stderr = %q, want 'Logged in as demo'", res.Stderr)
+	// Stderr should mention "Logged in as demo@example.com" — the
+	// friendly-display change prefers email over username so the
+	// status line surfaces a recognizable identity rather than an
+	// opaque handle. (Falls back to "first last" then username.)
+	if !strings.Contains(res.Stderr, "Logged in as demo@example.com") {
+		t.Errorf("stderr = %q, want 'Logged in as demo@example.com'", res.Stderr)
 	}
 
 	// Stdout JSON should expose the credential metadata so callers can
@@ -484,8 +487,11 @@ func TestAuthLogin_OAuthFlow_HonorsHEYGEN_API_BASEForUsersMeProbe(t *testing.T) 
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s\nstdout: %s", res.ExitCode, res.Stderr, res.Stdout)
 	}
-	if !strings.Contains(res.Stderr, "Logged in as sandbox-user") {
-		t.Errorf("stderr = %q, want 'Logged in as sandbox-user' (probe should have hit %s, not api.heygen.com)", res.Stderr, usersMe.URL)
+	// The probe should have hit usersMe.URL (via HEYGEN_API_BASE) and
+	// returned u@example.com. Friendly-display prefers email, so the
+	// status line surfaces the email rather than the username.
+	if !strings.Contains(res.Stderr, "Logged in as u@example.com") {
+		t.Errorf("stderr = %q, want 'Logged in as u@example.com' (probe should have hit %s, not api.heygen.com)", res.Stderr, usersMe.URL)
 	}
 }
 

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -58,6 +58,11 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 // any of the secret values themselves. Returns nil on any resolution
 // failure so the existing happy path remains unchanged for api-key
 // users.
+//
+// Also folds in the persisted friendly-display block (email / name /
+// username) under a `user` key so callers can surface "Logged in as
+// ..." without re-hitting /v3/users/me. The block is omitted when the
+// credentials file holds no user block (e.g. pre-this-change logins).
 func credentialMetadata() map[string]any {
 	resolver := &auth.ChainCredentialResolver{
 		Resolvers: []auth.CredentialResolver{
@@ -90,6 +95,32 @@ func credentialMetadata() map[string]any {
 		meta["scope"] = cred.Scope
 		if !cred.ExpiresAt.IsZero() {
 			meta["expires_at"] = cred.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+	}
+	// Friendly-display block — only present when the source is the
+	// credentials file AND a user block was persisted at login time.
+	// Env-based credentials (HEYGEN_API_KEY) deliberately don't carry
+	// friendly fields because we never probe /v3/users/me on cold env
+	// reads — the user can re-run `auth login` if they want them.
+	if cred.Source == auth.SourceFile {
+		if ui, loadErr := auth.LoadUserInfo(); loadErr == nil && !ui.IsZero() {
+			userMeta := map[string]any{}
+			if ui.Email != "" {
+				userMeta["email"] = ui.Email
+			}
+			if ui.FirstName != "" {
+				userMeta["first_name"] = ui.FirstName
+			}
+			if ui.LastName != "" {
+				userMeta["last_name"] = ui.LastName
+			}
+			if ui.Username != "" {
+				userMeta["username"] = ui.Username
+			}
+			if display := ui.DisplayName(); display != "" {
+				userMeta["display_name"] = display
+			}
+			meta["user"] = userMeta
 		}
 	}
 	return meta

--- a/cmd/heygen/auth_status_friendly_test.go
+++ b/cmd/heygen/auth_status_friendly_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/heygen-com/heygen-cli/internal/auth"
+)
+
+// TestAuthStatus_SurfacesPersistedUserInfo verifies that when a user
+// block is on disk (the post-login state after this change), `auth
+// status` includes it under the `credential.user` key in the JSON
+// envelope so consumers can read the friendly display without an extra
+// /v3/users/me call.
+func TestAuthStatus_SurfacesPersistedUserInfo(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	// Seed: api_key + user block (post-login state).
+	if err := (&auth.FileCredentialStore{}).Save("hg_test"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := auth.SaveUserInfo(auth.UserInfo{
+		Email:     "jane@example.com",
+		FirstName: "Jane",
+		LastName:  "Doe",
+		Username:  "jdoe",
+	}); err != nil {
+		t.Fatalf("SaveUserInfo: %v", err)
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"jane@example.com","username":"jdoe"}}`,
+		},
+	})
+	defer srv.Close()
+
+	// Do NOT pass an api key on env — we want the file-resolver path so
+	// credentialMetadata picks up the persisted user block (env-source
+	// credentials deliberately skip the user lookup).
+	res := runCommand(t, srv.URL, "", "auth", "status")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, res.Stdout)
+	}
+	credMeta, ok := parsed["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credential block in stdout, got %v", parsed)
+	}
+	userMeta, ok := credMeta["user"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credential.user block in stdout, got %v", credMeta)
+	}
+	if userMeta["email"] != "jane@example.com" {
+		t.Errorf("credential.user.email = %v, want jane@example.com", userMeta["email"])
+	}
+	if userMeta["first_name"] != "Jane" {
+		t.Errorf("credential.user.first_name = %v, want Jane", userMeta["first_name"])
+	}
+	if userMeta["last_name"] != "Doe" {
+		t.Errorf("credential.user.last_name = %v, want Doe", userMeta["last_name"])
+	}
+	if userMeta["display_name"] != "jane@example.com" {
+		t.Errorf("credential.user.display_name = %v, want jane@example.com (email)", userMeta["display_name"])
+	}
+}
+
+// TestAuthStatus_NoUserBlock_FallsBack verifies the backwards-compat
+// case: a credentials file without a user block (from a pre-this-change
+// login) parses cleanly and `auth status` simply omits credential.user.
+func TestAuthStatus_NoUserBlock_FallsBack(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	if err := (&auth.FileCredentialStore{}).Save("hg_legacy"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"u@example.com","username":"u"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "", "auth", "status")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, res.Stdout)
+	}
+	credMeta, ok := parsed["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credential block in stdout, got %v", parsed)
+	}
+	if _, present := credMeta["user"]; present {
+		t.Errorf("credential.user should be absent for legacy file, got %v", credMeta["user"])
+	}
+
+	// Sanity: the existing /v3/users/me-derived fields are still in the
+	// `data` envelope. The friendly display change is strictly additive.
+	data, ok := parsed["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data block missing: %v", parsed)
+	}
+	if data["email"] != "u@example.com" {
+		t.Errorf("data.email = %v, want u@example.com", data["email"])
+	}
+}
+
+// TestAuthStatus_EnvSourceCredential_SkipsUserBlock — when the active
+// credential came from HEYGEN_API_KEY (env), the persisted user block
+// on disk could belong to a DIFFERENT api_key (the file one). We don't
+// merge them in because the labels would be misleading. Env-source
+// credentials therefore skip the user block.
+func TestAuthStatus_EnvSourceCredential_SkipsUserBlock(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	// Seed a file-side api_key + user block belonging to ANOTHER user.
+	if err := (&auth.FileCredentialStore{}).Save("hg_file_key"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := auth.SaveUserInfo(auth.UserInfo{Email: "file-user@example.com"}); err != nil {
+		t.Fatalf("SaveUserInfo: %v", err)
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"env-user@example.com","username":"env"}}`,
+		},
+	})
+	defer srv.Close()
+
+	// Pass an api key via env — this beats the file resolver.
+	res := runCommand(t, srv.URL, "hg_env_key", "auth", "status")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, res.Stdout)
+	}
+	credMeta, ok := parsed["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credential block in stdout, got %v", parsed)
+	}
+	if user, present := credMeta["user"]; present {
+		t.Errorf("credential.user should be absent for env-source credential, got %v", user)
+	}
+	if credMeta["source"] != "env" {
+		t.Errorf("credential.source = %v, want env", credMeta["source"])
+	}
+	// The data envelope reflects the /v3/users/me response under the
+	// env credential, which is what the user actually wants to see.
+	data, ok := parsed["data"].(map[string]any)
+	if !ok || data["email"] != "env-user@example.com" {
+		t.Errorf("data.email = %v, want env-user@example.com", parsed["data"])
+	}
+	// Cross-check: the on-disk user block was NOT touched (its account
+	// has nothing to do with the env credential).
+	ui, err := auth.LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: %v", err)
+	}
+	if ui.Email != "file-user@example.com" {
+		t.Errorf("file-side user info corrupted: %+v", ui)
+	}
+}

--- a/internal/auth/file_resolver.go
+++ b/internal/auth/file_resolver.go
@@ -8,9 +8,15 @@ import (
 // jsonCredentials is the on-disk format hyperframes-CLI (and heygen-cli,
 // since the write-side change) persist to ~/.heygen/credentials. Mirror
 // the shape used by packages/cli/src/auth/store.ts in hyperframes-oss.
+//
+// The `user` block is additive friendly-display metadata captured at
+// login time from /v3/users/me — NOT a credential. It is safe to persist
+// alongside either credential type and is cleared whenever the credential
+// itself is cleared.
 type jsonCredentials struct {
 	APIKey string           `json:"api_key,omitempty"`
 	OAuth  *jsonOAuthTokens `json:"oauth,omitempty"`
+	User   *jsonUserInfo    `json:"user,omitempty"`
 }
 
 // jsonOAuthTokens is parsed and round-tripped (so heygen-cli preserves a
@@ -22,6 +28,17 @@ type jsonOAuthTokens struct {
 	ExpiresAt    string `json:"expires_at,omitempty"`
 	Scope        string `json:"scope,omitempty"`
 	TokenType    string `json:"token_type,omitempty"`
+}
+
+// jsonUserInfo is the friendly-display block captured at login time from
+// /v3/users/me. All fields are optional — a credentials file without a
+// user block is fully backwards-compatible (existing logins surface only
+// after re-login).
+type jsonUserInfo struct {
+	Email     string `json:"email,omitempty"`
+	FirstName string `json:"first_name,omitempty"`
+	LastName  string `json:"last_name,omitempty"`
+	Username  string `json:"username,omitempty"`
 }
 
 // nowFn is the wall-clock source used when comparing OAuth expiry. Tests

--- a/internal/auth/file_resolver.go
+++ b/internal/auth/file_resolver.go
@@ -1,9 +1,22 @@
 package auth
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 )
+
+// Cross-CLI forward compatibility: the ~/.heygen/credentials file is
+// SHARED with the Node hyperframes CLI (and any future tool). Either CLI
+// may write keys this version doesn't model yet. To avoid one CLI
+// silently clobbering the other's data on a read → write round-trip,
+// every struct below captures the unrecognized keys it sees into an
+// unexported `extra` bag at unmarshal time and re-emits them verbatim at
+// marshal time. Known fields stay strictly typed and validated; the
+// passthrough is purely additive and never feeds an HTTP header. This
+// mirrors the Node-side hardening in hyperframes-oss
+// (packages/cli/src/auth/store.ts).
 
 // jsonCredentials is the on-disk format hyperframes-CLI (and heygen-cli,
 // since the write-side change) persist to ~/.heygen/credentials. Mirror
@@ -17,6 +30,10 @@ type jsonCredentials struct {
 	APIKey string           `json:"api_key,omitempty"`
 	OAuth  *jsonOAuthTokens `json:"oauth,omitempty"`
 	User   *jsonUserInfo    `json:"user,omitempty"`
+	// extra holds unknown/foreign top-level keys captured at read time so
+	// the next write round-trips them instead of dropping another CLI's
+	// data. Never serialized as its own key — see (un)marshalExtras.
+	extra map[string]json.RawMessage
 }
 
 // jsonOAuthTokens is parsed and round-tripped (so heygen-cli preserves a
@@ -28,6 +45,9 @@ type jsonOAuthTokens struct {
 	ExpiresAt    string `json:"expires_at,omitempty"`
 	Scope        string `json:"scope,omitempty"`
 	TokenType    string `json:"token_type,omitempty"`
+	// extra holds unknown keys seen inside the oauth sub-object (e.g. a
+	// future `id_token`), round-tripped verbatim.
+	extra map[string]json.RawMessage
 }
 
 // jsonUserInfo is the friendly-display block captured at login time from
@@ -39,6 +59,146 @@ type jsonUserInfo struct {
 	FirstName string `json:"first_name,omitempty"`
 	LastName  string `json:"last_name,omitempty"`
 	Username  string `json:"username,omitempty"`
+	// extra holds unknown keys seen inside the user sub-object (e.g. a
+	// future `avatar_url`), round-tripped verbatim.
+	extra map[string]json.RawMessage
+}
+
+// unmarshalExtras decodes data into the typed value pointed to by known
+// (the caller passes a recursion-breaking alias) and, separately,
+// captures every top-level key NOT named in knownKeys into a raw bag.
+// Returns the bag (nil when there are no unknown keys) so the caller can
+// stash it on the struct's `extra` field. Known fields stay strictly
+// typed; only the residue is preserved opaquely.
+func unmarshalExtras(data []byte, known any, knownKeys map[string]struct{}) (map[string]json.RawMessage, error) {
+	if err := json.Unmarshal(data, known); err != nil {
+		return nil, err
+	}
+	var all map[string]json.RawMessage
+	if err := json.Unmarshal(data, &all); err != nil {
+		return nil, err
+	}
+	var extra map[string]json.RawMessage
+	for k, v := range all {
+		if _, ok := knownKeys[k]; ok {
+			continue
+		}
+		if extra == nil {
+			extra = make(map[string]json.RawMessage, len(all))
+		}
+		extra[k] = v
+	}
+	return extra, nil
+}
+
+// marshalExtras serializes the typed value pointed to by known (via the
+// caller's alias) and merges the preserved unknown keys back in. Known
+// fields are authoritative — collection already excluded them, so a
+// collision can't normally occur; on the off chance one does, the known
+// field wins. Keys are emitted in sorted order for deterministic,
+// diff-friendly output.
+func marshalExtras(known any, extra map[string]json.RawMessage) ([]byte, error) {
+	knownBytes, err := json.Marshal(known)
+	if err != nil {
+		return nil, err
+	}
+	if len(extra) == 0 {
+		return knownBytes, nil
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(knownBytes, &merged); err != nil {
+		return nil, err
+	}
+	if merged == nil {
+		merged = make(map[string]json.RawMessage, len(extra))
+	}
+	for k, v := range extra {
+		if _, clash := merged[k]; clash {
+			continue // known field wins
+		}
+		merged[k] = v
+	}
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	buf := []byte{'{'}
+	for i, k := range keys {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, kb...)
+		buf = append(buf, ':')
+		buf = append(buf, merged[k]...)
+	}
+	buf = append(buf, '}')
+	return buf, nil
+}
+
+var (
+	knownCredentialsKeys = map[string]struct{}{"api_key": {}, "oauth": {}, "user": {}}
+	knownOAuthKeys       = map[string]struct{}{
+		"access_token": {}, "refresh_token": {}, "expires_at": {}, "scope": {}, "token_type": {},
+	}
+	knownUserKeys = map[string]struct{}{
+		"email": {}, "first_name": {}, "last_name": {}, "username": {},
+	}
+)
+
+func (c *jsonCredentials) UnmarshalJSON(data []byte) error {
+	type alias jsonCredentials
+	var a alias
+	extra, err := unmarshalExtras(data, &a, knownCredentialsKeys)
+	if err != nil {
+		return err
+	}
+	*c = jsonCredentials(a)
+	c.extra = extra
+	return nil
+}
+
+func (c jsonCredentials) MarshalJSON() ([]byte, error) {
+	type alias jsonCredentials
+	return marshalExtras(alias(c), c.extra)
+}
+
+func (o *jsonOAuthTokens) UnmarshalJSON(data []byte) error {
+	type alias jsonOAuthTokens
+	var a alias
+	extra, err := unmarshalExtras(data, &a, knownOAuthKeys)
+	if err != nil {
+		return err
+	}
+	*o = jsonOAuthTokens(a)
+	o.extra = extra
+	return nil
+}
+
+func (o jsonOAuthTokens) MarshalJSON() ([]byte, error) {
+	type alias jsonOAuthTokens
+	return marshalExtras(alias(o), o.extra)
+}
+
+func (u *jsonUserInfo) UnmarshalJSON(data []byte) error {
+	type alias jsonUserInfo
+	var a alias
+	extra, err := unmarshalExtras(data, &a, knownUserKeys)
+	if err != nil {
+		return err
+	}
+	*u = jsonUserInfo(a)
+	u.extra = extra
+	return nil
+}
+
+func (u jsonUserInfo) MarshalJSON() ([]byte, error) {
+	type alias jsonUserInfo
+	return marshalExtras(alias(u), u.extra)
 }
 
 // nowFn is the wall-clock source used when comparing OAuth expiry. Tests

--- a/internal/auth/file_resolver_test.go
+++ b/internal/auth/file_resolver_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -21,6 +22,22 @@ func writeCredentials(t *testing.T, contents string) string {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	return path
+}
+
+// readRawJSON decodes the on-disk credentials file into a generic map so
+// tests can assert the presence of keys this CLI doesn't model (which the
+// typed jsonCredentials view deliberately hides on its `extra` field).
+func readRawJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("on-disk file is not valid JSON: %v\ncontents: %s", err, data)
+	}
+	return out
 }
 
 // --- legacy plaintext ------------------------------------------------------
@@ -313,10 +330,17 @@ func TestFileCredentialResolver_MultiLineNonJSONIsRejected(t *testing.T) {
 	}
 }
 
-func TestFileCredentialResolver_JSON_DropsUnknownFields(t *testing.T) {
+// Cross-CLI forward compatibility: the credentials file is SHARED with
+// the Node hyperframes CLI. heygen-cli must NOT strip top-level / nested
+// keys it doesn't model when it rewrites the file, or it silently
+// destroys data the other CLI wrote (and vice versa). The reader stashes
+// unrecognized keys and the writer re-emits them verbatim. This mirrors
+// the Node-side hardening in hyperframes#1741.
+func TestFileCredentialResolver_JSON_PreservesUnknownFields(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
-	writeCredentials(t, `{"api_key":"hg_x","future_field":{"nested":true}}`)
+	path := writeCredentials(t, `{"api_key":"hg_x","future_field":{"nested":true}}`)
 
+	// Reading still resolves the known credential cleanly.
 	r := &FileCredentialResolver{}
 	key, err := r.Resolve()
 	if err != nil {
@@ -324,5 +348,83 @@ func TestFileCredentialResolver_JSON_DropsUnknownFields(t *testing.T) {
 	}
 	if key != "hg_x" {
 		t.Fatalf("key = %q, want hg_x", key)
+	}
+
+	// And the unknown key is captured on the parsed value so the next
+	// write round-trips it instead of dropping it.
+	parsed, _, err := loadCredentialsFile(path)
+	if err != nil {
+		t.Fatalf("loadCredentialsFile: %v", err)
+	}
+	if _, ok := parsed.extra["future_field"]; !ok {
+		t.Fatalf("future_field not captured for round-trip, extra = %v", parsed.extra)
+	}
+
+	// Rewrite the file (here: re-save the same parsed value). The
+	// unknown key must survive on disk.
+	if err := writeCredentialsFile(path, parsed); err != nil {
+		t.Fatalf("writeCredentialsFile: %v", err)
+	}
+	onDisk := readRawJSON(t, path)
+	if onDisk["api_key"] != "hg_x" {
+		t.Fatalf("api_key = %v, want hg_x", onDisk["api_key"])
+	}
+	ff, ok := onDisk["future_field"].(map[string]any)
+	if !ok || ff["nested"] != true {
+		t.Fatalf("future_field not preserved on round-trip: %v", onDisk["future_field"])
+	}
+}
+
+// An unknown key INSIDE the oauth sub-object (e.g. a future id_token the
+// hyperframes CLI starts writing) must survive a heygen-cli round-trip.
+func TestFileCredentialResolver_JSON_PreservesUnknownOAuthSubKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	path := writeCredentials(t, `{"oauth":{"access_token":"at_1","id_token":"future_id_token_value"}}`)
+
+	parsed, _, err := loadCredentialsFile(path)
+	if err != nil {
+		t.Fatalf("loadCredentialsFile: %v", err)
+	}
+	if err := writeCredentialsFile(path, parsed); err != nil {
+		t.Fatalf("writeCredentialsFile: %v", err)
+	}
+
+	onDisk := readRawJSON(t, path)
+	oauth, ok := onDisk["oauth"].(map[string]any)
+	if !ok {
+		t.Fatalf("oauth block missing after round-trip: %v", onDisk)
+	}
+	if oauth["access_token"] != "at_1" {
+		t.Fatalf("oauth.access_token = %v, want at_1", oauth["access_token"])
+	}
+	if oauth["id_token"] != "future_id_token_value" {
+		t.Fatalf("oauth.id_token not preserved: %v", oauth["id_token"])
+	}
+}
+
+// An unknown key INSIDE the user sub-object (e.g. a future avatar_url)
+// must survive a heygen-cli round-trip.
+func TestFileCredentialResolver_JSON_PreservesUnknownUserSubKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	path := writeCredentials(t, `{"api_key":"hg_x","user":{"email":"u@example.com","avatar_url":"https://cdn/x.png"}}`)
+
+	parsed, _, err := loadCredentialsFile(path)
+	if err != nil {
+		t.Fatalf("loadCredentialsFile: %v", err)
+	}
+	if err := writeCredentialsFile(path, parsed); err != nil {
+		t.Fatalf("writeCredentialsFile: %v", err)
+	}
+
+	onDisk := readRawJSON(t, path)
+	user, ok := onDisk["user"].(map[string]any)
+	if !ok {
+		t.Fatalf("user block missing after round-trip: %v", onDisk)
+	}
+	if user["email"] != "u@example.com" {
+		t.Fatalf("user.email = %v, want u@example.com", user["email"])
+	}
+	if user["avatar_url"] != "https://cdn/x.png" {
+		t.Fatalf("user.avatar_url not preserved: %v", user["avatar_url"])
 	}
 }

--- a/internal/auth/file_store_test.go
+++ b/internal/auth/file_store_test.go
@@ -129,6 +129,55 @@ func TestFileCredentialStore_PreservesExistingOAuth(t *testing.T) {
 	}
 }
 
+func TestFileCredentialStore_PreservesUnknownFieldsThroughSave(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// The cross-CLI data-loss scenario exercised through the public Save
+	// path: the Node hyperframes CLI wrote a top-level key (and a nested
+	// oauth key) heygen-cli doesn't model. A heygen-cli `auth login`
+	// (FileCredentialStore.Save) must NOT strip them.
+	path := filepath.Join(paths.ConfigDir(), "credentials")
+	if err := os.MkdirAll(paths.ConfigDir(), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	seed := `{"oauth":{"access_token":"at_keep","id_token":"future_id"},"future_field":{"flag":true}}`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &FileCredentialStore{}
+	if err := s.Save("hg_new_key"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var onDisk map[string]any
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("on-disk file is not valid JSON: %v\ncontents: %s", err, data)
+	}
+
+	if onDisk["api_key"] != "hg_new_key" {
+		t.Fatalf("api_key = %v, want hg_new_key", onDisk["api_key"])
+	}
+	ff, ok := onDisk["future_field"].(map[string]any)
+	if !ok || ff["flag"] != true {
+		t.Fatalf("unknown top-level future_field dropped by Save: %v", onDisk["future_field"])
+	}
+	oauth, ok := onDisk["oauth"].(map[string]any)
+	if !ok {
+		t.Fatalf("oauth block missing after Save: %v", onDisk)
+	}
+	if oauth["access_token"] != "at_keep" {
+		t.Fatalf("oauth.access_token = %v, want at_keep", oauth["access_token"])
+	}
+	if oauth["id_token"] != "future_id" {
+		t.Fatalf("unknown oauth.id_token dropped by Save: %v", oauth["id_token"])
+	}
+}
+
 func TestFileCredentialStore_RefusesToClobberMalformedFile(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 

--- a/internal/auth/oauth_store.go
+++ b/internal/auth/oauth_store.go
@@ -122,8 +122,12 @@ func ClearOAuthTokens(alsoAPIKey bool) error {
 		parsed.APIKey = ""
 	}
 	if parsed.APIKey == "" && parsed.OAuth == nil {
+		// No credential left — the friendly-display block is orphaned
+		// metadata. Drop it and remove the now-empty file.
 		return removeCredentialsFile(path)
 	}
+	// At least one credential survives — preserve the user block on
+	// disk so it stays visible to the survivor.
 	return writeCredentialsFile(path, parsed)
 }
 

--- a/internal/auth/user_store.go
+++ b/internal/auth/user_store.go
@@ -1,0 +1,139 @@
+package auth
+
+import "fmt"
+
+// UserInfo is the resolver-layer view of the on-disk `user` block — the
+// friendly-display metadata captured at login time from /v3/users/me.
+//
+// UserInfo is NOT a credential. It is additive metadata persisted next to
+// the credential so `auth status` (and any other friendly-display
+// surface) can show "Logged in as user@example.com" without re-hitting
+// the API on every invocation, and so the display still works when the
+// API is unreachable.
+type UserInfo struct {
+	Email     string
+	FirstName string
+	LastName  string
+	Username  string
+}
+
+// IsZero reports whether ui carries no friendly fields. Used by callers
+// (e.g. auth status) to decide whether to surface the user block at all.
+func (ui UserInfo) IsZero() bool {
+	return ui.Email == "" && ui.FirstName == "" && ui.LastName == "" && ui.Username == ""
+}
+
+// DisplayName returns the most friendly name available, in priority
+// order: email > "first last" > username > "" (caller falls back to
+// user_id or another marker).
+func (ui UserInfo) DisplayName() string {
+	if ui.Email != "" {
+		return ui.Email
+	}
+	if name := combineName(ui.FirstName, ui.LastName); name != "" {
+		return name
+	}
+	return ui.Username
+}
+
+// combineName joins a first + last into "First Last", tolerating either
+// half being empty.
+func combineName(first, last string) string {
+	switch {
+	case first != "" && last != "":
+		return first + " " + last
+	case first != "":
+		return first
+	default:
+		return last
+	}
+}
+
+// SaveUserInfo persists the friendly-display block to the shared
+// credentials file, preserving any co-located api_key / oauth blocks.
+//
+// A pre-existing malformed credentials file is refused (same contract as
+// FileCredentialStore.Save / SaveOAuthTokens) so we don't silently destroy
+// a recoverable credential.
+//
+// Calling SaveUserInfo with an all-empty UserInfo is a no-op write that
+// still preserves the existing file; callers should typically check
+// ui.IsZero() and skip the call in that case so the file isn't touched
+// when there's nothing to persist.
+func SaveUserInfo(ui UserInfo) error {
+	path := credentialFilePath()
+	existing, format, err := loadCredentialsFile(path)
+	if err != nil {
+		if format != formatAbsent {
+			return fmt.Errorf("%w; delete the file and re-run `heygen auth login`", err)
+		}
+		existing = jsonCredentials{}
+	}
+	if ui.IsZero() {
+		// Nothing to persist — leave the existing file untouched rather
+		// than rewriting it with no effective change.
+		return nil
+	}
+	existing.User = &jsonUserInfo{
+		Email:     ui.Email,
+		FirstName: ui.FirstName,
+		LastName:  ui.LastName,
+		Username:  ui.Username,
+	}
+	return writeCredentialsFile(path, existing)
+}
+
+// LoadUserInfo reads the friendly-display block from disk. Returns a
+// zero-value UserInfo (with no error) when the credentials file is
+// absent or when it is present but holds no user block — the caller
+// then falls back to whatever display is appropriate (user_id, "Logged
+// in", etc).
+//
+// Errors are surfaced for genuinely broken files so the caller can warn
+// rather than silently pretend the file is clean.
+func LoadUserInfo() (UserInfo, error) {
+	path := credentialFilePath()
+	parsed, format, err := loadCredentialsFile(path)
+	if format == formatAbsent && err == nil {
+		return UserInfo{}, nil
+	}
+	if err != nil {
+		return UserInfo{}, err
+	}
+	if parsed.User == nil {
+		return UserInfo{}, nil
+	}
+	return UserInfo{
+		Email:     parsed.User.Email,
+		FirstName: parsed.User.FirstName,
+		LastName:  parsed.User.LastName,
+		Username:  parsed.User.Username,
+	}, nil
+}
+
+// ClearUserInfo removes the friendly-display block from disk, leaving
+// any co-located credential blocks intact. When the resulting credential
+// file would be empty (no api_key, no oauth, no user) the file is
+// removed entirely.
+//
+// Returns nil (no-op) when the credential file is absent or already
+// holds no user block — the post-condition the caller wants is "no
+// user block on disk", which is already true.
+func ClearUserInfo() error {
+	path := credentialFilePath()
+	parsed, format, err := loadCredentialsFile(path)
+	if format == formatAbsent {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%w; delete the file and try again", err)
+	}
+	if parsed.User == nil {
+		return nil
+	}
+	parsed.User = nil
+	if parsed.APIKey == "" && parsed.OAuth == nil {
+		return removeCredentialsFile(path)
+	}
+	return writeCredentialsFile(path, parsed)
+}

--- a/internal/auth/user_store_test.go
+++ b/internal/auth/user_store_test.go
@@ -1,0 +1,292 @@
+package auth
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/heygen-com/heygen-cli/internal/paths"
+)
+
+// TestUserInfo_DisplayName covers the priority order (email > "first
+// last" > username > "") the login surfaces lean on for the "Logged in
+// as ..." line.
+func TestUserInfo_DisplayName(t *testing.T) {
+	cases := []struct {
+		name string
+		ui   UserInfo
+		want string
+	}{
+		{"email_present", UserInfo{Email: "user@example.com", FirstName: "Jane", LastName: "Doe", Username: "jdoe"}, "user@example.com"},
+		{"no_email_full_name", UserInfo{FirstName: "Jane", LastName: "Doe", Username: "jdoe"}, "Jane Doe"},
+		{"only_first_name", UserInfo{FirstName: "Jane", Username: "jdoe"}, "Jane"},
+		{"only_last_name", UserInfo{LastName: "Doe", Username: "jdoe"}, "Doe"},
+		{"only_username", UserInfo{Username: "jdoe"}, "jdoe"},
+		{"all_empty", UserInfo{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ui.DisplayName(); got != tc.want {
+				t.Fatalf("DisplayName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUserInfo_IsZero covers the gate callers use to decide whether to
+// persist a user block at all.
+func TestUserInfo_IsZero(t *testing.T) {
+	if !(UserInfo{}).IsZero() {
+		t.Errorf("empty UserInfo should be Zero")
+	}
+	if (UserInfo{Email: "u@example.com"}).IsZero() {
+		t.Errorf("UserInfo with email should not be Zero")
+	}
+	if (UserInfo{Username: "u"}).IsZero() {
+		t.Errorf("UserInfo with username should not be Zero")
+	}
+	if (UserInfo{FirstName: "J"}).IsZero() {
+		t.Errorf("UserInfo with first name should not be Zero")
+	}
+	if (UserInfo{LastName: "D"}).IsZero() {
+		t.Errorf("UserInfo with last name should not be Zero")
+	}
+}
+
+// TestSaveAndLoadUserInfo round-trips the friendly-display block through
+// the credentials file.
+func TestSaveAndLoadUserInfo(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// Seed an api_key first so the file has a credential alongside the
+	// user block (the production state).
+	if err := (&FileCredentialStore{}).Save("hg_test"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	ui := UserInfo{
+		Email:     "user@example.com",
+		FirstName: "Jane",
+		LastName:  "Doe",
+		Username:  "jdoe",
+	}
+	if err := SaveUserInfo(ui); err != nil {
+		t.Fatalf("SaveUserInfo: %v", err)
+	}
+
+	got, err := LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: %v", err)
+	}
+	if got != ui {
+		t.Fatalf("roundtrip mismatch: got %+v, want %+v", got, ui)
+	}
+}
+
+// TestSaveUserInfo_PreservesAPIKey verifies that persisting the user
+// block does NOT wipe the api_key that's already on disk.
+func TestSaveUserInfo_PreservesAPIKey(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	if err := (&FileCredentialStore{}).Save("hg_keep"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := SaveUserInfo(UserInfo{Email: "u@example.com"}); err != nil {
+		t.Fatalf("SaveUserInfo: %v", err)
+	}
+
+	creds := parseStoredFile(t)
+	if creds.APIKey != "hg_keep" {
+		t.Fatalf("api_key wiped: got %q, want hg_keep", creds.APIKey)
+	}
+	if creds.User == nil || creds.User.Email != "u@example.com" {
+		t.Fatalf("user block not persisted: %+v", creds.User)
+	}
+}
+
+// TestSaveUserInfo_EmptyIsNoOp guards the IsZero() short-circuit so a
+// failed probe doesn't rewrite the file with an empty user block.
+func TestSaveUserInfo_EmptyIsNoOp(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	if err := (&FileCredentialStore{}).Save("hg_keep"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "credentials"))
+	if err != nil {
+		t.Fatalf("read pre-state: %v", err)
+	}
+
+	if err := SaveUserInfo(UserInfo{}); err != nil {
+		t.Fatalf("SaveUserInfo(empty): %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "credentials"))
+	if err != nil {
+		t.Fatalf("read post-state: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("file was rewritten on empty SaveUserInfo:\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+// TestLoadUserInfo_AbsentFile returns (zero, nil) — the caller should
+// treat this as "no friendly display available" rather than an error.
+func TestLoadUserInfo_AbsentFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	got, err := LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: unexpected error %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("expected zero UserInfo, got %+v", got)
+	}
+}
+
+// TestLoadUserInfo_FileWithoutUserBlock_ReturnsZero is the backwards-
+// compat case: an existing credentials file (api_key or oauth only,
+// from before this change) must parse cleanly and yield a zero
+// UserInfo — login surfaces fall back to user_id / "Logged in" until
+// the next re-login populates the block.
+func TestLoadUserInfo_FileWithoutUserBlock_ReturnsZero(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// Pre-this-change file shape (api_key only, no user block).
+	seed := `{"api_key":"hg_legacy"}`
+	dir := paths.ConfigDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "credentials"), []byte(seed), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("expected zero UserInfo for legacy file, got %+v", got)
+	}
+
+	// Sanity: the api_key must still resolve cleanly through the
+	// normal resolver — the new schema field is purely additive.
+	r := &FileCredentialResolver{}
+	cred, err := r.ResolveCredential()
+	if err != nil {
+		t.Fatalf("ResolveCredential on legacy file: %v", err)
+	}
+	if cred.APIKey != "hg_legacy" {
+		t.Fatalf("api_key = %q, want hg_legacy", cred.APIKey)
+	}
+}
+
+// TestClearUserInfo_RemovesOnlyUserBlock checks the credential survives
+// when only the user block is cleared.
+func TestClearUserInfo_RemovesOnlyUserBlock(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	if err := (&FileCredentialStore{}).Save("hg_keep"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := SaveUserInfo(UserInfo{Email: "u@example.com"}); err != nil {
+		t.Fatalf("SaveUserInfo: %v", err)
+	}
+
+	if err := ClearUserInfo(); err != nil {
+		t.Fatalf("ClearUserInfo: %v", err)
+	}
+
+	creds := parseStoredFile(t)
+	if creds.APIKey != "hg_keep" {
+		t.Fatalf("api_key wiped on user clear: got %q", creds.APIKey)
+	}
+	if creds.User != nil {
+		t.Fatalf("user block survived clear: %+v", creds.User)
+	}
+}
+
+// TestClearUserInfo_RemovesEmptyFile checks that clearing the user
+// block when no credential is left removes the whole file (no orphan
+// metadata).
+func TestClearUserInfo_RemovesEmptyFile(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	// Seed a file with ONLY a user block (no credential). This is an
+	// unusual state but the post-condition we want is "file gone."
+	dir := paths.ConfigDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	seed := `{"user":{"email":"u@example.com"}}`
+	path := filepath.Join(dir, "credentials")
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := ClearUserInfo(); err != nil {
+		t.Fatalf("ClearUserInfo: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file removed, Stat returned %v", err)
+	}
+}
+
+// TestClearUserInfo_NoUserBlock_NoOp verifies the function is safe to
+// call when there's no user block to clear (the production "post-
+// failed-probe" path on a fresh login).
+func TestClearUserInfo_NoUserBlock_NoOp(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	if err := (&FileCredentialStore{}).Save("hg_only"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "credentials"))
+	if err != nil {
+		t.Fatalf("read pre-state: %v", err)
+	}
+
+	if err := ClearUserInfo(); err != nil {
+		t.Fatalf("ClearUserInfo: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "credentials"))
+	if err != nil {
+		t.Fatalf("read post-state: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("file was rewritten despite no user block:\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+// TestJSONUserInfoOmitempty checks that every field on jsonUserInfo
+// uses omitempty so a partially-populated block doesn't litter the
+// credentials file with empty strings. (Catches schema-drift if a
+// future field forgets the tag.)
+func TestJSONUserInfoOmitempty(t *testing.T) {
+	creds := jsonCredentials{
+		APIKey: "hg_test",
+		User:   &jsonUserInfo{Email: "u@example.com"},
+	}
+	body, err := json.Marshal(creds)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(body)
+	for _, banned := range []string{`"first_name":""`, `"last_name":""`, `"username":""`} {
+		if contains := indexOf(got, banned); contains >= 0 {
+			t.Errorf("found %q in marshalled output (should be omitted):\n%s", banned, got)
+		}
+	}
+}
+
+// indexOf is a tiny helper so the omitempty test reads naturally
+// without pulling in strings.Contains semantics.
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Description

Per Somansh's ask on the heygen-cli OAuth thread (James greenlit):
opaque user_ids are unfriendly in `auth status` output. After login
(both OAuth and API-key paths), fetch `/v3/users/me` once and persist
`email` + `first_name` + `last_name` + `username` into
`~/.heygen/credentials` alongside the credential. `auth status`
surfaces them in the JSON envelope under `credential.user`.

### Schema

- New optional `user` block on `jsonCredentials` (json tag `omitempty`).
- All inner fields (`email`, `first_name`, `last_name`, `username`)
  are `omitempty` too so a partially-populated block doesn't litter
  the file with empty strings.
- The block is additive METADATA, not a credential. Single-credential
  invariant (at-most-one of `api_key` / `oauth`) is unchanged; the
  user block is safe to persist alongside either credential type.
- New public API in `internal/auth`: `UserInfo`, `SaveUserInfo`,
  `LoadUserInfo`, `ClearUserInfo` + `UserInfo.DisplayName()` /
  `UserInfo.IsZero()` helpers.

### Login behavior

- OAuth path already probed `/v3/users/me` to surface "Logged in
  as ..." on stderr; that path now also persists the result. Probe
  signature returns `UserInfo` (was `username, email`) so the
  persisted block carries first/last name too.
- API-key path did NOT probe before. Add a best-effort probe using
  `x-api-key`, persist the result, and emit "Logged in as ..." on
  stderr to match the OAuth path.
- Both paths handle probe failure gracefully: warn on stderr,
  proceed with the login. The credential is NEVER rolled back on
  a probe failure (tokens / key are still on disk and usable).
- On probe failure, any stale user block from a prior login is
  cleared so `auth status` doesn't surface the wrong account.

### `auth status` output

- New `credential.user` block in the JSON envelope: `email`,
  `first_name`, `last_name`, `username`, `display_name` (the
  resolved priority email > "first last" > username).
- Only present when the active credential's source is the file
  AND a user block is persisted. Env-source credentials
  (`HEYGEN_API_KEY`) skip the block — the on-disk one could
  belong to a different key.
- Strictly additive; the existing `data` envelope from
  `/v3/users/me` is unchanged.

### Display priority

`email` > `first_name` + `last_name` > `username` > `user_id`
(existing fallback). Matches the ask on the thread.

### Backwards compatibility

- Credentials files without the user block (pre-this-change logins)
  parse fine. They show `user_id` like today; re-login populates the
  friendly fields. No migration needed.
- The single-credential invariant is preserved end-to-end.

## Testing

- `internal/auth`: `UserInfo.DisplayName` priority order, `IsZero`
  gate, Save/Load round-trip, Save preserves `api_key`, Save with
  empty `UserInfo` is a no-op (no file rewrite), Load on absent
  file returns zero, Load on legacy file (no user block) returns
  zero, Clear leaves credential intact, Clear on no-credential
  state removes the file, Clear when no user block is a no-op,
  `omitempty` schema guard.
- `cmd/heygen`: API-key login probe persists friendly fields,
  probe failure is non-fatal (key still on disk), probe failure
  clears stale user block, OAuth login persists full schema
  (`first_name`, `last_name` too), `auth status` surfaces the
  persisted user block, legacy file falls back without the block,
  env-source credential deliberately skips the block.
- Updated existing OAuth tests to assert the new email-preferred
  display (`Logged in as jane@example.com` vs the old username
  `Logged in as demo`) — the friendly-display change is the whole
  point.
- `go test -race ./...` clean.
- `go vet ./...` clean.
- `golangci-lint run ./...` clean (0 issues).

— Jerrai (https://claude.com/claude-code)