### PR TITLE
cli: classify video-download failures into specific codes

### DIFF
--- a/cmd/heygen/video_download.go
+++ b/cmd/heygen/video_download.go
@@ -105,7 +105,7 @@ func newVideoDownloadCmd(ctx *cmdContext) *cobra.Command {
 			})
 			if err != nil {
 				return &clierrors.CLIError{
-					Code:     "internal_error",
+					Code:     "cli_response_encode_error",
 					Message:  fmt.Sprintf("failed to encode response: %v", err),
 					Hint:     "Please report this CLI bug with the command you ran.",
 					ExitCode: clierrors.ExitGeneral,
@@ -128,7 +128,7 @@ func extractAssetURL(raw json.RawMessage, videoID string, info assetInfo) (strin
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return "", &clierrors.CLIError{
-			Code:     "response_parse_error",
+			Code:     "cli_response_parse_error",
 			Message:  "failed to parse the video response",
 			Hint:     "The API response could not be parsed. Retry; if it persists, report it (possible CLI/API mismatch).",
 			ExitCode: clierrors.ExitGeneral,
@@ -191,7 +191,7 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, videoURL, nil)
 	if err != nil {
 		return &clierrors.CLIError{
-			Code:     "response_parse_error",
+			Code:     "cli_response_parse_error",
 			Message:  fmt.Sprintf("the download URL returned by the API is unusable: %v", err),
 			Hint:     "Re-fetch a fresh URL: heygen video get <video_id>",
 			ExitCode: clierrors.ExitGeneral,
@@ -200,6 +200,10 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 
 	resp, err := downloadClient.Do(req)
 	if err != nil {
+		// network_error is intentionally NOT cli_-prefixed. It is a shared code
+		// also emitted by the API-executor transport path
+		// (internal/client/executor.go); kept bare so both sites agree. Do not
+		// prefix one site without the other.
 		return &clierrors.CLIError{
 			Code:     "network_error",
 			Message:  fmt.Sprintf("failed to download video: %v", err),
@@ -214,14 +218,14 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 		// re-fetch); any other status is the asset host (our storage/CDN) failing.
 		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
 			return &clierrors.CLIError{
-				Code:     "download_url_expired",
+				Code:     "cli_download_url_expired",
 				Message:  fmt.Sprintf("download link expired or unavailable (HTTP %d)", resp.StatusCode),
 				Hint:     "This download link has expired. Re-fetch a fresh URL: heygen video get <video_id>",
 				ExitCode: clierrors.ExitGeneral,
 			}
 		}
 		return &clierrors.CLIError{
-			Code:     "asset_download_failed",
+			Code:     "cli_download_failed",
 			Message:  fmt.Sprintf("download failed with HTTP %d", resp.StatusCode),
 			Hint:     "The asset host returned an error fetching the file. This is usually transient — retry shortly.",
 			ExitCode: clierrors.ExitGeneral,
@@ -234,7 +238,7 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 	tmp, err := os.CreateTemp(dir, ".heygen-download-*.tmp")
 	if err != nil {
 		return &clierrors.CLIError{
-			Code:     "file_io_error",
+			Code:     "cli_file_io_error",
 			Message:  fmt.Sprintf("failed to create temp file in %q: %v", dir, err),
 			Hint:     "Could not write locally. Check the destination path and free disk space.",
 			ExitCode: clierrors.ExitGeneral,
@@ -247,16 +251,16 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 	if copyErr != nil {
 		_ = os.Remove(tmpPath)
 		return &clierrors.CLIError{
-			Code:     "download_interrupted",
+			Code:     "cli_download_interrupted",
 			Message:  fmt.Sprintf("download interrupted: %v", copyErr),
-			Hint:     "The transfer was cut off. Retry; the partial file was cleaned up.",
+			Hint:     "The transfer was cut off. Retry the download. The partial file was cleaned up.",
 			ExitCode: clierrors.ExitGeneral,
 		}
 	}
 	if closeErr != nil {
 		_ = os.Remove(tmpPath)
 		return &clierrors.CLIError{
-			Code:     "file_io_error",
+			Code:     "cli_file_io_error",
 			Message:  fmt.Sprintf("failed to finalize download: %v", closeErr),
 			Hint:     "Could not finalize the file locally. Check free disk space.",
 			ExitCode: clierrors.ExitGeneral,
@@ -269,7 +273,7 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 	if err := os.Rename(tmpPath, dest); err != nil {
 		_ = os.Remove(tmpPath)
 		return &clierrors.CLIError{
-			Code:     "file_io_error",
+			Code:     "cli_file_io_error",
 			Message:  fmt.Sprintf("failed to move download to %q: %v", dest, err),
 			Hint:     "Could not write to the destination path. Check permissions and free disk space.",
 			ExitCode: clierrors.ExitGeneral,

--- a/cmd/heygen/video_download.go
+++ b/cmd/heygen/video_download.go
@@ -104,7 +104,12 @@ func newVideoDownloadCmd(ctx *cmdContext) *cobra.Command {
 				"path":    dest,
 			})
 			if err != nil {
-				return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
+				return &clierrors.CLIError{
+					Code:     "internal_error",
+					Message:  fmt.Sprintf("failed to encode response: %v", err),
+					Hint:     "Please report this CLI bug with the command you ran.",
+					ExitCode: clierrors.ExitGeneral,
+				}
 			}
 
 			return ctx.formatter.Data(data, "", nil)
@@ -122,7 +127,12 @@ func extractAssetURL(raw json.RawMessage, videoID string, info assetInfo) (strin
 		Data map[string]json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return "", clierrors.New("failed to parse video response")
+		return "", &clierrors.CLIError{
+			Code:     "response_parse_error",
+			Message:  "failed to parse the video response",
+			Hint:     "The API response could not be parsed. Retry; if it persists, report it (possible CLI/API mismatch).",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 
 	var status string
@@ -180,17 +190,42 @@ func assetHint(field string) string {
 func downloadFile(ctx context.Context, videoURL, dest string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, videoURL, nil)
 	if err != nil {
-		return clierrors.New(fmt.Sprintf("failed to build download request: %v", err))
+		return &clierrors.CLIError{
+			Code:     "response_parse_error",
+			Message:  fmt.Sprintf("the download URL returned by the API is unusable: %v", err),
+			Hint:     "Re-fetch a fresh URL: heygen video get <video_id>",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 
 	resp, err := downloadClient.Do(req)
 	if err != nil {
-		return clierrors.New(fmt.Sprintf("failed to download video: %v", err))
+		return &clierrors.CLIError{
+			Code:     "network_error",
+			Message:  fmt.Sprintf("failed to download video: %v", err),
+			Hint:     "This is usually a temporary network issue. Check your connection and retry.",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return clierrors.New(fmt.Sprintf("download failed with HTTP %d", resp.StatusCode))
+		// A presigned asset URL that 403s/404s is expired or revoked (client can
+		// re-fetch); any other status is the asset host (our storage/CDN) failing.
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+			return &clierrors.CLIError{
+				Code:     "download_url_expired",
+				Message:  fmt.Sprintf("download link expired or unavailable (HTTP %d)", resp.StatusCode),
+				Hint:     "This download link has expired. Re-fetch a fresh URL: heygen video get <video_id>",
+				ExitCode: clierrors.ExitGeneral,
+			}
+		}
+		return &clierrors.CLIError{
+			Code:     "asset_download_failed",
+			Message:  fmt.Sprintf("download failed with HTTP %d", resp.StatusCode),
+			Hint:     "The asset host returned an error fetching the file. This is usually transient — retry shortly.",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 
 	// Write to a temp file in the same directory, then rename on success.
@@ -198,7 +233,12 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 	dir := filepath.Dir(dest)
 	tmp, err := os.CreateTemp(dir, ".heygen-download-*.tmp")
 	if err != nil {
-		return clierrors.New(fmt.Sprintf("failed to create temp file in %q: %v", dir, err))
+		return &clierrors.CLIError{
+			Code:     "file_io_error",
+			Message:  fmt.Sprintf("failed to create temp file in %q: %v", dir, err),
+			Hint:     "Could not write locally. Check the destination path and free disk space.",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 	tmpPath := tmp.Name()
 
@@ -206,11 +246,21 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 	closeErr := tmp.Close()
 	if copyErr != nil {
 		_ = os.Remove(tmpPath)
-		return clierrors.New(fmt.Sprintf("download interrupted: %v", copyErr))
+		return &clierrors.CLIError{
+			Code:     "download_interrupted",
+			Message:  fmt.Sprintf("download interrupted: %v", copyErr),
+			Hint:     "The transfer was cut off. Retry; the partial file was cleaned up.",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 	if closeErr != nil {
 		_ = os.Remove(tmpPath)
-		return clierrors.New(fmt.Sprintf("failed to finalize download: %v", closeErr))
+		return &clierrors.CLIError{
+			Code:     "file_io_error",
+			Message:  fmt.Sprintf("failed to finalize download: %v", closeErr),
+			Hint:     "Could not finalize the file locally. Check free disk space.",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 
 	// Atomic rename. On Windows this may fail if dest is open elsewhere;
@@ -218,7 +268,12 @@ func downloadFile(ctx context.Context, videoURL, dest string) error {
 	// same directory so this is safe.
 	if err := os.Rename(tmpPath, dest); err != nil {
 		_ = os.Remove(tmpPath)
-		return clierrors.New(fmt.Sprintf("failed to move download to %q: %v", dest, err))
+		return &clierrors.CLIError{
+			Code:     "file_io_error",
+			Message:  fmt.Sprintf("failed to move download to %q: %v", dest, err),
+			Hint:     "Could not write to the destination path. Check permissions and free disk space.",
+			ExitCode: clierrors.ExitGeneral,
+		}
 	}
 
 	return nil

--- a/cmd/heygen/video_download_test.go
+++ b/cmd/heygen/video_download_test.go
@@ -406,8 +406,8 @@ func TestVideoDownload_DownloadFails(t *testing.T) {
 	if res.ExitCode != 1 {
 		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, `"code":"asset_download_failed"`) {
-		t.Fatalf("stderr should carry asset_download_failed (asset-host 5xx):\n%s", res.Stderr)
+	if !strings.Contains(res.Stderr, `"code":"cli_download_failed"`) {
+		t.Fatalf("stderr should carry cli_download_failed (asset-host 5xx):\n%s", res.Stderr)
 	}
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
 		t.Fatalf("expected no output file, stat err = %v", err)
@@ -415,7 +415,7 @@ func TestVideoDownload_DownloadFails(t *testing.T) {
 }
 
 // A presigned asset URL that 403s or 404s is expired/revoked — a client-side
-// download_url_expired, distinct from the asset host failing (asset_download_failed).
+// cli_download_url_expired, distinct from the asset host failing (cli_download_failed).
 func TestVideoDownload_ExpiredURL(t *testing.T) {
 	for _, status := range []int{http.StatusForbidden, http.StatusNotFound} {
 		t.Run(fmt.Sprintf("HTTP_%d", status), func(t *testing.T) {
@@ -444,8 +444,8 @@ func TestVideoDownload_ExpiredURL(t *testing.T) {
 			if res.ExitCode != 1 {
 				t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
 			}
-			if !strings.Contains(res.Stderr, `"code":"download_url_expired"`) {
-				t.Fatalf("stderr should carry download_url_expired (HTTP %d on presigned URL):\n%s", status, res.Stderr)
+			if !strings.Contains(res.Stderr, `"code":"cli_download_url_expired"`) {
+				t.Fatalf("stderr should carry cli_download_url_expired (HTTP %d on presigned URL):\n%s", status, res.Stderr)
 			}
 			if !strings.Contains(res.Stderr, "video get") {
 				t.Fatalf("expired-URL hint should point to re-fetching via video get:\n%s", res.Stderr)
@@ -455,7 +455,7 @@ func TestVideoDownload_ExpiredURL(t *testing.T) {
 }
 
 // The video-get response failing to parse, or yielding an unusable download URL,
-// classifies as response_parse_error (not the opaque error code).
+// classifies as cli_response_parse_error (not the opaque error code).
 func TestVideoDownload_ResponseParseError(t *testing.T) {
 	t.Run("malformed video-get JSON", func(t *testing.T) {
 		dest := filepath.Join(t.TempDir(), "x.mp4")
@@ -473,8 +473,8 @@ func TestVideoDownload_ResponseParseError(t *testing.T) {
 		if res.ExitCode != 1 {
 			t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
 		}
-		if !strings.Contains(res.Stderr, `"code":"response_parse_error"`) {
-			t.Fatalf("stderr should carry response_parse_error:\n%s", res.Stderr)
+		if !strings.Contains(res.Stderr, `"code":"cli_response_parse_error"`) {
+			t.Fatalf("stderr should carry cli_response_parse_error:\n%s", res.Stderr)
 		}
 	})
 
@@ -495,8 +495,8 @@ func TestVideoDownload_ResponseParseError(t *testing.T) {
 		if res.ExitCode != 1 {
 			t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
 		}
-		if !strings.Contains(res.Stderr, `"code":"response_parse_error"`) {
-			t.Fatalf("stderr should carry response_parse_error for an unusable URL:\n%s", res.Stderr)
+		if !strings.Contains(res.Stderr, `"code":"cli_response_parse_error"`) {
+			t.Fatalf("stderr should carry cli_response_parse_error for an unusable URL:\n%s", res.Stderr)
 		}
 	})
 }
@@ -519,4 +519,101 @@ func writeJSON(t *testing.T, w http.ResponseWriter, payload any) {
 		t.Fatalf("Marshal: %v", err)
 	}
 	_, _ = w.Write(raw)
+}
+
+// Transport failure reaching the asset host classifies as network_error (the
+// grandfathered shared transport code, intentionally unprefixed).
+func TestVideoDownload_NetworkError(t *testing.T) {
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close() // deadURL now refuses connections
+
+	dest := filepath.Join(t.TempDir(), "x.mp4")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/videos/vid_123" {
+			writeJSON(t, w, map[string]any{
+				"data": map[string]any{"video_url": deadURL + "/x.mp4", "status": "completed"},
+			})
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest)
+	if res.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"code":"network_error"`) {
+		t.Fatalf("stderr should carry network_error (transport failure):\n%s", res.Stderr)
+	}
+}
+
+// A response that promises more bytes than it delivers, then drops, cuts io.Copy
+// off mid-stream and classifies as cli_download_interrupted.
+func TestVideoDownload_Interrupted(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "x.mp4")
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos/vid_123":
+			writeJSON(t, w, map[string]any{
+				"data": map[string]any{"video_url": srv.URL + "/download/x.mp4", "status": "completed"},
+			})
+		case "/download/x.mp4":
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("test server does not support hijacking")
+			}
+			conn, buf, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			// Promise 1000 bytes, send 7, then drop the connection → the client's
+			// io.Copy hits an unexpected EOF.
+			_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\npartial")
+			_ = buf.Flush()
+			_ = conn.Close()
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest)
+	if res.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"code":"cli_download_interrupted"`) {
+		t.Fatalf("stderr should carry cli_download_interrupted (mid-stream cutoff):\n%s", res.Stderr)
+	}
+}
+
+// A destination whose parent directory does not exist fails temp-file creation
+// and classifies as cli_file_io_error.
+func TestVideoDownload_FileIOError(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "no-such-dir", "x.mp4") // parent dir absent
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/videos/vid_123":
+			writeJSON(t, w, map[string]any{
+				"data": map[string]any{"video_url": srv.URL + "/download/x.mp4", "status": "completed"},
+			})
+		case "/download/x.mp4":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("video-bytes"))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest)
+	if res.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"code":"cli_file_io_error"`) {
+		t.Fatalf("stderr should carry cli_file_io_error (temp-create in missing dir):\n%s", res.Stderr)
+	}
 }

--- a/cmd/heygen/video_download_test.go
+++ b/cmd/heygen/video_download_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -405,9 +406,99 @@ func TestVideoDownload_DownloadFails(t *testing.T) {
 	if res.ExitCode != 1 {
 		t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
 	}
+	if !strings.Contains(res.Stderr, `"code":"asset_download_failed"`) {
+		t.Fatalf("stderr should carry asset_download_failed (asset-host 5xx):\n%s", res.Stderr)
+	}
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
 		t.Fatalf("expected no output file, stat err = %v", err)
 	}
+}
+
+// A presigned asset URL that 403s or 404s is expired/revoked — a client-side
+// download_url_expired, distinct from the asset host failing (asset_download_failed).
+func TestVideoDownload_ExpiredURL(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusNotFound} {
+		t.Run(fmt.Sprintf("HTTP_%d", status), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			dest := filepath.Join(tmpDir, "expired.mp4")
+
+			var srv *httptest.Server
+			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v3/videos/vid_123":
+					writeJSON(t, w, map[string]any{
+						"data": map[string]any{
+							"video_url": srv.URL + "/download/expired.mp4",
+							"status":    "completed",
+						},
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/download/expired.mp4":
+					w.WriteHeader(status)
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest)
+			if res.ExitCode != 1 {
+				t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+			}
+			if !strings.Contains(res.Stderr, `"code":"download_url_expired"`) {
+				t.Fatalf("stderr should carry download_url_expired (HTTP %d on presigned URL):\n%s", status, res.Stderr)
+			}
+			if !strings.Contains(res.Stderr, "video get") {
+				t.Fatalf("expired-URL hint should point to re-fetching via video get:\n%s", res.Stderr)
+			}
+		})
+	}
+}
+
+// The video-get response failing to parse, or yielding an unusable download URL,
+// classifies as response_parse_error (not the opaque error code).
+func TestVideoDownload_ResponseParseError(t *testing.T) {
+	t.Run("malformed video-get JSON", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "x.mp4")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/v3/videos/vid_123" {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("{ this is not valid json"))
+				return
+			}
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}))
+		defer srv.Close()
+
+		res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest)
+		if res.ExitCode != 1 {
+			t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+		}
+		if !strings.Contains(res.Stderr, `"code":"response_parse_error"`) {
+			t.Fatalf("stderr should carry response_parse_error:\n%s", res.Stderr)
+		}
+	})
+
+	t.Run("unusable download URL", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "x.mp4")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/v3/videos/vid_123" {
+				writeJSON(t, w, map[string]any{
+					"data": map[string]any{"video_url": "http://%zz", "status": "completed"},
+				})
+				return
+			}
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}))
+		defer srv.Close()
+
+		res := runCommand(t, srv.URL, "test-key", "video", "download", "vid_123", "--output-path", dest)
+		if res.ExitCode != 1 {
+			t.Fatalf("ExitCode = %d, want 1\nstderr: %s", res.ExitCode, res.Stderr)
+		}
+		if !strings.Contains(res.Stderr, `"code":"response_parse_error"`) {
+			t.Fatalf("stderr should carry response_parse_error for an unusable URL:\n%s", res.Stderr)
+		}
+	})
 }
 
 func TestVideoDownload_AuthRequired(t *testing.T) {


### PR DESCRIPTION
## Scope

**Surfaces:** CLI (video download) | **Module:** Error handling

Stacked on #206.

## Summary

The video-download path collapsed *every* failure — expired link, CDN error, network drop, local disk error, unparseable response — into the generic `error` code. This splits each into a specific, actionable code so an agent or user knows what actually failed and what to do. CLI-originated codes carry the reserved `cli_` prefix.

## How it works

`downloadFile` fetches the finished asset directly from a presigned CDN URL (the v3 API is not in that path), so these are all CLI-side failures classified by where they occur:

| Failure | Code | Meaning / next step |
|---|---|---|
| Presigned URL 403/404 | `cli_download_url_expired` | link expired — re-fetch with `heygen video get` |
| Asset host 5xx/other | `cli_download_failed` | storage/CDN error — usually transient, retry |
| Transport failure | `network_error` | connectivity — retry (bare: grandfathered, shared with the executor transport path) |
| Mid-stream cutoff (`io.Copy`) | `cli_download_interrupted` | retry (partial file cleaned up) |
| Local temp/finalize/rename | `cli_file_io_error` | check destination path / disk space |
| Unparseable video-get response / unusable URL | `cli_response_parse_error` | retry; report if persistent |
| Encoding our own output | `cli_response_encode_error` | CLI bug |

Each carries a matching hint. **No exit-code changes** — all were exit 1 and stay exit 1.

## Design decisions

**CLI-originated codes are `cli_`-prefixed.** These are all CLI-side failures (the CLI fetches the asset from a presigned CDN URL; the API is not in the path), so their codes carry the reserved `cli_` prefix to keep them out of the API's namespace and collision-proof against any current or future API code. `network_error` is the one deliberate exception: it is a grandfathered, released code shared with the API-executor transport path (`internal/client/executor.go`), kept bare so both sites agree (documented at the emission site).

**`cli_download_failed` vs the API's `download_failed`.** The API's `download_failed` is a **400** for a *user-provided input URL* the API failed to fetch (a client error) — the opposite of the CLI failing to fetch the *finished* asset from the CDN (server-side). These near-opposite conditions must not share a code; the `cli_` prefix keeps them unambiguous. (An earlier `asset_`-qualified name dodged the same collision by hand; the prefix now handles it structurally.)

**Split by origin, not lumped.** `cli_download_url_expired` (client can fix by re-fetching) is separated from `cli_download_failed` (our storage failing) because the remedies differ.

## Testing

`httptest`-backed download tests: 403/404 → `cli_download_url_expired` (+ re-fetch hint), 500 → `cli_download_failed`, malformed JSON + unusable URL → `cli_response_parse_error`, transport failure → `network_error`, mid-stream cutoff → `cli_download_interrupted`, missing-parent-dir → `cli_file_io_error`. Existing download success/not-ready tests still pass. `make lint` clean. (`cli_response_encode_error` is a `json.Marshal` of a fixed map — effectively unreachable, not tested.)

## Follow-up (not in this PR) — tracked in PRINFRA-247

Dashboard server-list at release: add `cli_download_failed` + `cli_response_parse_error`; move the API's client-side `download_failed` (400) out of the server-list. Documenting the `cli_` codes and wiring their `doc_url` is tracked in the same issue. `source` origin tag is in telemetry (#208).
