### PR TITLE
feat(auth): identify accounts and add structured login telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ heygen config list       # show all settings with sources
 
 ## Reporting bugs
 
-- **Quick signal (recommended for agents):** `heygen feedback --rating <1-5> --comment "..."`. Goes to private, anonymous analytics. Safe to run unattended.
+- **Quick signal (recommended for agents):** `heygen feedback --rating <1-5> --comment "..."`. Goes to private, anonymous analytics. Safe to run unattended. Usage telemetry is anonymous until you sign in: running `heygen auth login` links it to your account email or username. A one-time notice prints the first time analytics runs; opt out anytime with `HEYGEN_NO_ANALYTICS=1` (or `heygen config set analytics false`).
 - **Tracked bug a maintainer should see:** open a [GitHub issue](https://github.com/heygen-com/heygen-cli/issues). This repo is **public**, so review what you paste first and omit anything sensitive (API keys, prompts, internal URLs, personal data).
 
 **Agents:** do not open GitHub issues automatically. Use `heygen feedback` for bug signal; if something seems worth tracking, surface it to the user and let a human file the issue after reviewing it for sensitive content.

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -309,13 +309,29 @@ func errorsAsPickerCanceled(err error) bool {
 // cleared so the file holds at most one of api_key / oauth (the
 // single-credential normalization invariant). Pre-this-change users
 // with both blocks self-heal on their next login.
-func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
+func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) (err error) {
+	// reported tracks whether this attempt already emitted a terminal
+	// analytics event (AuthLoginCompleted/AuthLoginFailed) on one of the
+	// explicitly-instrumented paths below. The deferred check is a
+	// safety net for every OTHER error return in this function (e.g. a
+	// future early return nobody remembers to instrument): without it,
+	// the AuthLoginStarted event the caller already fired would never
+	// reconcile.
+	reported := false
+	defer func() {
+		if err != nil && !reported {
+			loginAnalytics.AuthLoginFailed("api_key", "internal_error")
+		}
+	}()
+
 	key, err := readAPIKey(cmd.InOrStdin(), cmd.ErrOrStderr())
 	if err != nil {
+		reported = true
 		loginAnalytics.AuthLoginFailed("api_key", "api_key_aborted")
 		return err
 	}
 	if key == "" {
+		reported = true
 		loginAnalytics.AuthLoginFailed("api_key", "api_key_invalid_input")
 		if stdinIsTerminalFunc() {
 			return clierrors.NewUsage(
@@ -416,6 +432,7 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
 	}
+	reported = true
 	loginAnalytics.AuthLoginCompleted("api_key")
 	if display := userInfo.DisplayName(); display != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
@@ -425,7 +442,21 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
 
 // runOAuthLogin drives the browser + PKCE + loopback dance and persists
 // the resulting tokens.
-func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) error {
+func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (err error) {
+	// reported tracks whether this attempt already emitted a terminal
+	// analytics event (AuthLoginCompleted/AuthLoginFailed) on one of the
+	// explicitly-instrumented paths below. The deferred check is a
+	// safety net for every OTHER error return in this function (e.g. a
+	// future early return nobody remembers to instrument): without it,
+	// the AuthLoginStarted event the caller already fired would never
+	// reconcile.
+	reported := false
+	defer func() {
+		if err != nil && !reported {
+			loginAnalytics.AuthLoginFailed("oauth", "internal_error")
+		}
+	}()
+
 	// Headless-shell fast-fail: when explicit --oauth lands in a shell
 	// with no TTY on stdin AND the environment opts out of opening a
 	// browser (BROWSER=none or HEYGEN_NO_BROWSER=1), the callback can
@@ -434,6 +465,7 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	// guard when cfg.OpenBrowser is injected (test path drives the
 	// callback synthetically). (N1)
 	if cfg.OpenBrowser == nil && isHeadlessOAuthShell() {
+		reported = true
 		loginAnalytics.AuthLoginFailed("oauth", "headless_shell")
 		return clierrors.NewUsage(
 			"cannot complete browser OAuth flow in a headless shell " +
@@ -492,21 +524,25 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	var loopbackResult oauth.LoopbackResult
 	select {
 	case <-cmdCtx.Done():
+		reported = true
 		loginAnalytics.AuthLoginFailed("oauth", "oauth_timeout")
 		return clierrors.New(fmt.Sprintf("oauth: timed out waiting for browser callback: %v", cmdCtx.Err()))
 	case loopbackResult = <-results:
 	}
 	if loopbackResult.Err != nil {
+		reported = true
 		loginAnalytics.AuthLoginFailed("oauth", "oauth_flow_error")
 		return clierrors.New(loopbackResult.Err.Error())
 	}
 
 	tok, err := oc.ExchangeAuthorizationCode(cmdCtx, loopbackResult.Code, verifier, loopbackResult.RedirectURI)
 	if err != nil {
+		reported = true
 		loginAnalytics.AuthLoginFailed("oauth", "token_exchange_failed")
 		return clierrors.New(fmt.Sprintf("oauth: token exchange failed: %v", err))
 	}
 	if tok.AccessToken == "" {
+		reported = true
 		loginAnalytics.AuthLoginFailed("oauth", "token_exchange_failed")
 		return clierrors.New("oauth: token endpoint returned no access_token")
 	}
@@ -599,6 +635,7 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
 	}
+	reported = true
 	loginAnalytics.AuthLoginCompleted("oauth")
 	if display := userInfo.DisplayName(); display != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -432,12 +432,19 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) (err error) {
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
 	}
-	reported = true
-	loginAnalytics.AuthLoginCompleted("api_key")
 	if display := userInfo.DisplayName(); display != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
 	}
-	return ctx.formatter.Data(data, "", nil)
+	// Only report the login as completed once the response has actually
+	// been written out successfully: if the formatter fails (e.g. a
+	// broken pipe on stdout), the command still exits non-zero and the
+	// deferred check above reports AuthLoginFailed instead.
+	if err = ctx.formatter.Data(data, "", nil); err != nil {
+		return err
+	}
+	reported = true
+	loginAnalytics.AuthLoginCompleted("api_key")
+	return nil
 }
 
 // runOAuthLogin drives the browser + PKCE + loopback dance and persists
@@ -635,14 +642,21 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (e
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
 	}
-	reported = true
-	loginAnalytics.AuthLoginCompleted("oauth")
 	if display := userInfo.DisplayName(); display != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
 	} else {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Logged in.")
 	}
-	return ctx.formatter.Data(data, "", nil)
+	// Only report the login as completed once the response has actually
+	// been written out successfully: if the formatter fails (e.g. a
+	// broken pipe on stdout), the command still exits non-zero and the
+	// deferred check above reports AuthLoginFailed instead.
+	if err = ctx.formatter.Data(data, "", nil); err != nil {
+		return err
+	}
+	reported = true
+	loginAnalytics.AuthLoginCompleted("oauth")
+	return nil
 }
 
 // lookupCurrentUser GETs /v3/users/me with the freshly minted Bearer

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -43,11 +43,14 @@ var loginAnalytics loginAnalyticsClient = &analytics.Client{}
 // email if present, otherwise username. Deliberately narrower than
 // UserInfo.DisplayName() (which also falls back to "first last") — this
 // links a PostHog person to a stable login handle, not a display string.
+// Lowercased so this joins with hyperframes-oss's own identify call
+// regardless of the account's stored casing — an uppercase-email user would
+// otherwise split across two PostHog profiles.
 func identityKey(userInfo auth.UserInfo) string {
 	if userInfo.Email != "" {
-		return userInfo.Email
+		return strings.ToLower(userInfo.Email)
 	}
-	return userInfo.Username
+	return strings.ToLower(userInfo.Username)
 }
 
 // oauthLoginConfig is overridable in tests so the login flow can be

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/heygen-com/heygen-cli/internal/analytics"
 	"github.com/heygen-com/heygen-cli/internal/auth"
 	"github.com/heygen-com/heygen-cli/internal/auth/oauth"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
@@ -19,6 +20,35 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
+
+// loginAnalyticsClient is the subset of *analytics.Client this file calls,
+// factored out as an interface so tests can inject a spy without needing a
+// real PostHog capture client (internal/analytics's own stubCaptureClient
+// is the lower-level equivalent used in that package's tests).
+type loginAnalyticsClient interface {
+	IdentifyAccount(distinctId string)
+	AuthLoginStarted(method string)
+	AuthLoginCompleted(method string)
+	AuthLoginFailed(method, reason string)
+}
+
+// loginAnalytics is the process-wide analytics client login telemetry
+// calls into. main() sets it to the real client once at startup; left at
+// its inert zero value here so any test that builds the login commands
+// directly (bypassing main()) gets a no-op, matching analytics.New(_,
+// false)'s existing disabled-client contract.
+var loginAnalytics loginAnalyticsClient = &analytics.Client{}
+
+// identityKey picks the identity a successful login links analytics to:
+// email if present, otherwise username. Deliberately narrower than
+// UserInfo.DisplayName() (which also falls back to "first last") — this
+// links a PostHog person to a stable login handle, not a display string.
+func identityKey(userInfo auth.UserInfo) string {
+	if userInfo.Email != "" {
+		return userInfo.Email
+	}
+	return userInfo.Username
+}
 
 // oauthLoginConfig is overridable in tests so the login flow can be
 // driven against an httptest IdP without spawning a real browser.
@@ -187,6 +217,8 @@ var runAuthLoginTestDeps *runAuthLoginDeps
 // override is in effect, else we default to the API-key flow.
 func runAuthLogin(cmd *cobra.Command, ctx *cmdContext, flags authLoginFlags) error {
 	if flags.deviceCodeMode {
+		loginAnalytics.AuthLoginStarted("device_code")
+		loginAnalytics.AuthLoginFailed("device_code", "device_code_unsupported")
 		return clierrors.NewUsage(
 			"--device-code is not yet supported; use the default browser flow or --api-key",
 		)
@@ -219,8 +251,10 @@ func runAuthLogin(cmd *cobra.Command, ctx *cmdContext, flags authLoginFlags) err
 
 	switch {
 	case flags.oauthMode:
+		loginAnalytics.AuthLoginStarted("oauth")
 		return deps.runOAuth(cmd, ctx)
 	case flags.apiKeyMode:
+		loginAnalytics.AuthLoginStarted("api_key")
 		return deps.runAPIKey(cmd, ctx)
 	}
 
@@ -230,6 +264,8 @@ func runAuthLogin(cmd *cobra.Command, ctx *cmdContext, flags authLoginFlags) err
 	// keystrokes), and only when nothing in the environment has asked
 	// us to behave non-interactively.
 	if deps.stdinIsTerminal() && deps.stdoutIsTerminal() && !deps.nonInteractive() {
+		// No AuthLoginStarted here — the picker hasn't resolved a method
+		// yet. A cancel below must emit no started/failed pair at all.
 		choice, err := deps.runPicker(cmd.Context(), cmd.InOrStdin(), cmd.ErrOrStderr())
 		if err != nil {
 			if errors.Is(err, pickerCanceledError{}) || errorsAsPickerCanceled(err) {
@@ -239,8 +275,10 @@ func runAuthLogin(cmd *cobra.Command, ctx *cmdContext, flags authLoginFlags) err
 		}
 		switch choice {
 		case loginChoiceOAuth:
+			loginAnalytics.AuthLoginStarted("oauth")
 			return deps.runOAuth(cmd, ctx)
 		case loginChoiceAPIKey:
+			loginAnalytics.AuthLoginStarted("api_key")
 			return deps.runAPIKey(cmd, ctx)
 		default:
 			return clierrors.New(fmt.Sprintf("unknown login choice: %d", choice))
@@ -251,6 +289,7 @@ func runAuthLogin(cmd *cobra.Command, ctx *cmdContext, flags authLoginFlags) err
 	// decision: agents and CI runners feed keys on stdin, and the
 	// browser-OAuth dance has nowhere to land its loopback callback
 	// when there's no human to click "Allow".
+	loginAnalytics.AuthLoginStarted("api_key")
 	return deps.runAPIKey(cmd, ctx)
 }
 
@@ -273,9 +312,11 @@ func errorsAsPickerCanceled(err error) bool {
 func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
 	key, err := readAPIKey(cmd.InOrStdin(), cmd.ErrOrStderr())
 	if err != nil {
+		loginAnalytics.AuthLoginFailed("api_key", "api_key_aborted")
 		return err
 	}
 	if key == "" {
+		loginAnalytics.AuthLoginFailed("api_key", "api_key_invalid_input")
 		if stdinIsTerminalFunc() {
 			return clierrors.NewUsage(
 				"no API key entered — type your key after the prompt, or paste it.",
@@ -340,6 +381,9 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
 		if saveErr := auth.SaveUserInfo(userInfo); saveErr != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "(warning: could not persist user info: %v)\n", saveErr)
 		}
+		if id := identityKey(userInfo); id != "" {
+			loginAnalytics.IdentifyAccount(id)
+		}
 	} else if clearErr := auth.ClearUserInfo(); clearErr != nil {
 		// Probe failed but a stale user block from a prior login may
 		// still be on disk. Best-effort clear; a failure here is
@@ -372,6 +416,7 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) error {
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
 	}
+	loginAnalytics.AuthLoginCompleted("api_key")
 	if display := userInfo.DisplayName(); display != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
 	}
@@ -389,6 +434,7 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	// guard when cfg.OpenBrowser is injected (test path drives the
 	// callback synthetically). (N1)
 	if cfg.OpenBrowser == nil && isHeadlessOAuthShell() {
+		loginAnalytics.AuthLoginFailed("oauth", "headless_shell")
 		return clierrors.NewUsage(
 			"cannot complete browser OAuth flow in a headless shell " +
 				"(no TTY and BROWSER=none / HEYGEN_NO_BROWSER=1).\n" +
@@ -446,18 +492,22 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	var loopbackResult oauth.LoopbackResult
 	select {
 	case <-cmdCtx.Done():
+		loginAnalytics.AuthLoginFailed("oauth", "oauth_timeout")
 		return clierrors.New(fmt.Sprintf("oauth: timed out waiting for browser callback: %v", cmdCtx.Err()))
 	case loopbackResult = <-results:
 	}
 	if loopbackResult.Err != nil {
+		loginAnalytics.AuthLoginFailed("oauth", "oauth_flow_error")
 		return clierrors.New(loopbackResult.Err.Error())
 	}
 
 	tok, err := oc.ExchangeAuthorizationCode(cmdCtx, loopbackResult.Code, verifier, loopbackResult.RedirectURI)
 	if err != nil {
+		loginAnalytics.AuthLoginFailed("oauth", "token_exchange_failed")
 		return clierrors.New(fmt.Sprintf("oauth: token exchange failed: %v", err))
 	}
 	if tok.AccessToken == "" {
+		loginAnalytics.AuthLoginFailed("oauth", "token_exchange_failed")
 		return clierrors.New("oauth: token endpoint returned no access_token")
 	}
 
@@ -508,6 +558,9 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 		if saveErr := auth.SaveUserInfo(userInfo); saveErr != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "(warning: could not persist user info: %v)\n", saveErr)
 		}
+		if id := identityKey(userInfo); id != "" {
+			loginAnalytics.IdentifyAccount(id)
+		}
 	} else if clearErr := auth.ClearUserInfo(); clearErr != nil {
 		// Probe failed AND the file might still hold a stale user block
 		// from a prior login (different account). Best-effort clear; a
@@ -546,6 +599,7 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) er
 	if err != nil {
 		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
 	}
+	loginAnalytics.AuthLoginCompleted("oauth")
 	if display := userInfo.DisplayName(); display != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
 	} else {

--- a/cmd/heygen/auth_login_dispatch_test.go
+++ b/cmd/heygen/auth_login_dispatch_test.go
@@ -4,11 +4,66 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+// loginAnalyticsSpy is a test double for loginAnalyticsClient (U3/U4): it
+// records every IdentifyAccount / AuthLoginStarted / AuthLoginCompleted /
+// AuthLoginFailed call in order so tests can assert both the exact call
+// and how it reconciles against the others.
+type loginAnalyticsSpy struct {
+	identifyCalls []string
+	started       []string
+	completed     []string
+	failed        []loginAnalyticsFailedCall
+}
+
+type loginAnalyticsFailedCall struct {
+	method string
+	reason string
+}
+
+func (s *loginAnalyticsSpy) IdentifyAccount(distinctId string) {
+	s.identifyCalls = append(s.identifyCalls, distinctId)
+}
+
+func (s *loginAnalyticsSpy) AuthLoginStarted(method string) {
+	s.started = append(s.started, method)
+}
+
+func (s *loginAnalyticsSpy) AuthLoginCompleted(method string) {
+	s.completed = append(s.completed, method)
+}
+
+func (s *loginAnalyticsSpy) AuthLoginFailed(method, reason string) {
+	s.failed = append(s.failed, loginAnalyticsFailedCall{method: method, reason: reason})
+}
+
+// withLoginAnalyticsSpy swaps the package-level loginAnalytics for a spy
+// for the duration of the test, restoring the previous value on cleanup.
+// Every entry point that fires login telemetry (the dispatcher, the two
+// runners, or a full cmd.Execute()) reads the same package var, so this
+// works regardless of how the test drives the login flow.
+func withLoginAnalyticsSpy(t *testing.T) *loginAnalyticsSpy {
+	t.Helper()
+	spy := &loginAnalyticsSpy{}
+	orig := loginAnalytics
+	loginAnalytics = spy
+	t.Cleanup(func() { loginAnalytics = orig })
+	return spy
+}
+
+// erroringReader always fails on Read, simulating an aborted stdin read
+// (e.g. Ctrl-C mid-input) for the api-key login flow.
+type erroringReader struct{}
+
+func (erroringReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("input aborted")
+}
 
 // dispatchSpy records which runner runAuthLogin ended up invoking so
 // the table-driven dispatch tests can assert against a stable value
@@ -262,5 +317,150 @@ func TestNonInteractiveEnvFunc_ParsesCommonShapes(t *testing.T) {
 				t.Errorf("nonInteractiveEnvFunc() = %v, want %v (env %s=%q)", got, tc.want, tc.envKey, tc.envValue)
 			}
 		})
+	}
+}
+
+// U4: AuthLoginStarted fires once per dispatched attempt, after the
+// picker/flag resolves a method — using the same stubbed runOAuth/runAPIKey
+// as TestRunAuthLogin_Dispatch (so only Started is observable here; the
+// real runners' Completed/Failed calls are exercised separately in
+// auth_login_oauth_test.go where the real runOAuthLogin/runAPIKeyLogin run).
+func TestRunAuthLogin_TelemetryStarted(t *testing.T) {
+	cases := []struct {
+		name         string
+		flags        authLoginFlags
+		pickerChoice loginChoice
+		wantStarted  []string
+	}{
+		{
+			name:        "--oauth flag",
+			flags:       authLoginFlags{oauthMode: true},
+			wantStarted: []string{"oauth"},
+		},
+		{
+			name:        "--api-key flag",
+			flags:       authLoginFlags{apiKeyMode: true},
+			wantStarted: []string{"api_key"},
+		},
+		{
+			name:         "picker picks oauth",
+			pickerChoice: loginChoiceOAuth,
+			wantStarted:  []string{"oauth"},
+		},
+		{
+			name:         "picker picks api key",
+			pickerChoice: loginChoiceAPIKey,
+			wantStarted:  []string{"api_key"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := withLoginAnalyticsSpy(t)
+			dispatchTestSpy := &dispatchSpy{pickerChoice: tc.pickerChoice}
+			runAuthLoginTestDeps = dispatchTestSpy.deps()
+			t.Cleanup(func() { runAuthLoginTestDeps = nil })
+
+			cmd, ctx := makeDispatchCmd(t)
+			if err := runAuthLogin(cmd, ctx, tc.flags); err != nil {
+				t.Fatalf("runAuthLogin: %v", err)
+			}
+
+			if !slices.Equal(spy.started, tc.wantStarted) {
+				t.Errorf("started = %v, want %v", spy.started, tc.wantStarted)
+			}
+			// The stubbed runners never call Completed/Failed themselves —
+			// only the dispatcher's Started call is under test here.
+			if len(spy.completed) != 0 {
+				t.Errorf("completed = %v, want none (runner is stubbed)", spy.completed)
+			}
+			if len(spy.failed) != 0 {
+				t.Errorf("failed = %v, want none (runner is stubbed)", spy.failed)
+			}
+		})
+	}
+}
+
+// U4: a picker cancellation must emit no started/failed pair at all —
+// Started only fires after a method is chosen.
+func TestRunAuthLogin_PickerCancel_NoTelemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	dispatchTestSpy := &dispatchSpy{pickerErr: pickerCanceledError{}}
+	runAuthLoginTestDeps = dispatchTestSpy.deps()
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
+
+	cmd, ctx := makeDispatchCmd(t)
+	if err := runAuthLogin(cmd, ctx, authLoginFlags{}); err == nil {
+		t.Fatal("want canceled error, got nil")
+	}
+
+	if len(spy.started) != 0 || len(spy.completed) != 0 || len(spy.failed) != 0 {
+		t.Fatalf("expected no telemetry on picker cancel; started=%v completed=%v failed=%v",
+			spy.started, spy.completed, spy.failed)
+	}
+}
+
+// U4: --device-code emits started(device_code) then
+// failed(device_code, device_code_unsupported) — the reason is explicitly
+// named in the plan's enum, so this implementation instruments it rather
+// than silently dropping telemetry for the flag.
+func TestRunAuthLogin_DeviceCode_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+
+	cmd, ctx := makeDispatchCmd(t)
+	if err := runAuthLogin(cmd, ctx, authLoginFlags{deviceCodeMode: true}); err == nil {
+		t.Fatal("want usage error, got nil")
+	}
+
+	if got := spy.started; len(got) != 1 || got[0] != "device_code" {
+		t.Fatalf("started = %v, want [device_code]", got)
+	}
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"device_code", "device_code_unsupported"}) {
+		t.Fatalf("failed = %v, want [{device_code device_code_unsupported}]", got)
+	}
+}
+
+// U4: --api-key with an aborted stdin read (Ctrl-C mid-input) emits
+// started(api_key) then failed(api_key, api_key_aborted).
+func TestRunAuthLogin_APIKeyAborted_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	cmd, ctx := makeDispatchCmd(t)
+	cmd.SetIn(erroringReader{})
+
+	if err := runAuthLogin(cmd, ctx, authLoginFlags{apiKeyMode: true}); err == nil {
+		t.Fatal("want error, got nil")
+	}
+
+	if got := spy.started; len(got) != 1 || got[0] != "api_key" {
+		t.Fatalf("started = %v, want [api_key]", got)
+	}
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"api_key", "api_key_aborted"}) {
+		t.Fatalf("failed = %v, want [{api_key api_key_aborted}]", got)
+	}
+	if len(spy.completed) != 0 {
+		t.Fatalf("completed = %v, want none", spy.completed)
+	}
+}
+
+// U4: --api-key with empty stdin emits started(api_key) then
+// failed(api_key, api_key_invalid_input).
+func TestRunAuthLogin_APIKeyEmptyInput_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	cmd, ctx := makeDispatchCmd(t)
+	cmd.SetIn(strings.NewReader(""))
+
+	if err := runAuthLogin(cmd, ctx, authLoginFlags{apiKeyMode: true}); err == nil {
+		t.Fatal("want error, got nil")
+	}
+
+	if got := spy.started; len(got) != 1 || got[0] != "api_key" {
+		t.Fatalf("started = %v, want [api_key]", got)
+	}
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"api_key", "api_key_invalid_input"}) {
+		t.Fatalf("failed = %v, want [{api_key api_key_invalid_input}]", got)
 	}
 }

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -601,5 +602,310 @@ func TestRunOAuthLogin_HeadlessShell_FailsFast(t *testing.T) {
 	}
 	if !strings.Contains(msg, "--api-key") {
 		t.Errorf("error = %q, want a pointer to --api-key (N1)", msg)
+	}
+}
+
+// U4: the N1 headless-shell fast-fail is reachable through the real
+// dispatcher too — started(oauth) fires (the dispatcher doesn't know about
+// the guard), then failed(oauth, headless_shell) from inside runOAuthLogin.
+func TestRunAuthLogin_OAuthHeadlessShell_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_NO_BROWSER", "1")
+	t.Setenv("BROWSER", "")
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	orig := stdinIsTerminalFunc
+	stdinIsTerminalFunc = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminalFunc = orig })
+
+	runAuthLoginTestDeps = &runAuthLoginDeps{
+		stdinIsTerminal:  func() bool { return true },
+		stdoutIsTerminal: func() bool { return true },
+		nonInteractive:   func() bool { return false },
+		runOAuth: func(c *cobra.Command, x *cmdContext) error {
+			return runOAuthLogin(c, x, oauthLoginConfig{})
+		},
+	}
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
+
+	cmd, ctx := makeDispatchCmd(t)
+	err := runAuthLogin(cmd, ctx, authLoginFlags{oauthMode: true})
+	if err == nil {
+		t.Fatal("want headless-shell error, got nil")
+	}
+
+	if got := spy.started; len(got) != 1 || got[0] != "oauth" {
+		t.Fatalf("started = %v, want [oauth]", got)
+	}
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "headless_shell"}) {
+		t.Fatalf("failed = %v, want [{oauth headless_shell}]", got)
+	}
+	if len(spy.completed) != 0 {
+		t.Fatalf("completed = %v, want none", spy.completed)
+	}
+}
+
+// U4: a successful --oauth flow driven through the real dispatcher emits
+// started(oauth) then completed(oauth), no failed.
+func TestRunAuthLogin_OAuthSuccess_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	usersMe := fakeUsersMeServer(t, `{"data":{"username":"demo","email":"demo@example.com"}}`)
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+		UsersMeBaseURL: usersMe.URL,
+		Now:            time.Now,
+	}
+
+	runAuthLoginTestDeps = &runAuthLoginDeps{
+		stdinIsTerminal:  func() bool { return true },
+		stdoutIsTerminal: func() bool { return true },
+		nonInteractive:   func() bool { return false },
+		runOAuth: func(c *cobra.Command, x *cmdContext) error {
+			return runOAuthLogin(c, x, cfg)
+		},
+	}
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
+
+	// makeDispatchCmd's bare *cmdContext has a nil formatter — fine for the
+	// stubbed-runner dispatch tests, but runOAuthLogin's success path calls
+	// ctx.formatter.Data(...), so build a real one here (same as
+	// runOAuthLoginForTest).
+	var stdout, stderr strings.Builder
+	formatter := formatterForArgs([]string{"auth", "login"}, &stdout, &stderr)
+	cmd := &cobra.Command{Use: "login"}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+	ctx := &cmdContext{formatter: formatter, version: "test"}
+
+	if err := runAuthLogin(cmd, ctx, authLoginFlags{oauthMode: true}); err != nil {
+		t.Fatalf("runAuthLogin: %v", err)
+	}
+
+	if got := spy.started; len(got) != 1 || got[0] != "oauth" {
+		t.Fatalf("started = %v, want [oauth]", got)
+	}
+	if got := spy.completed; len(got) != 1 || got[0] != "oauth" {
+		t.Fatalf("completed = %v, want [oauth]", got)
+	}
+	if len(spy.failed) != 0 {
+		t.Fatalf("failed = %v, want none", spy.failed)
+	}
+}
+
+// U4: the loopback timing out (no browser callback ever arrives) emits
+// failed(oauth, oauth_timeout). Uses a short-deadline parent context
+// instead of waiting out oauth.DefaultLoopbackTimeout (~5min) — runOAuthLogin
+// derives its own context from cmd.Context() via context.WithTimeout,
+// which honors the parent's earlier deadline.
+func TestRunOAuthLogin_LoopbackTimeout_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	var stdout, stderr strings.Builder
+	formatter := formatterForArgs([]string{"auth", "login"}, &stdout, &stderr)
+	ctx := &cmdContext{formatter: formatter, version: "test"}
+
+	cmd := &cobra.Command{Use: "login"}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	parentCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	cmd.SetContext(parentCtx)
+
+	cfg := oauthLoginConfig{
+		// Non-nil OpenBrowser skips the N1 headless-shell guard; it
+		// deliberately never drives the callback, so the loopback times out.
+		OpenBrowser: func(authURL string) error { return nil },
+	}
+
+	err := runOAuthLogin(cmd, ctx, cfg)
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("err = %q, want a timeout message", err.Error())
+	}
+
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "oauth_timeout"}) {
+		t.Fatalf("failed = %v, want [{oauth oauth_timeout}]", got)
+	}
+	if len(spy.completed) != 0 {
+		t.Fatalf("completed = %v, want none", spy.completed)
+	}
+}
+
+// U4: the IdP rejecting the token exchange emits
+// failed(oauth, token_exchange_failed), no completed.
+func TestRunOAuthLogin_TokenExchangeFailed_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	idp.tokenStatus = http.StatusBadRequest
+	idp.tokenResponse = `{"error":"invalid_grant"}`
+
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+	}
+	res := runOAuthLoginForTest(t, cfg)
+	if res.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit, got 0\nstderr: %s\nstdout: %s", res.Stderr, res.Stdout)
+	}
+
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "token_exchange_failed"}) {
+		t.Fatalf("failed = %v, want [{oauth token_exchange_failed}]", got)
+	}
+	if len(spy.completed) != 0 {
+		t.Fatalf("completed = %v, want none", spy.completed)
+	}
+}
+
+// U3: a successful OAuth login that resolves an email enqueues
+// Alias{DistinctId: email, Alias: <shared install id>} followed by
+// Identify{DistinctId: email}.
+func TestRunOAuthLogin_IdentifyAccount_Email(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	usersMe := fakeUsersMeServer(t, `{"data":{"username":"demo","email":"demo@example.com"}}`)
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+		UsersMeBaseURL: usersMe.URL,
+		Now:            time.Now,
+	}
+
+	res := runOAuthLoginForTest(t, cfg)
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	if got := spy.identifyCalls; len(got) != 1 || got[0] != "demo@example.com" {
+		t.Fatalf("identifyCalls = %v, want [demo@example.com]", got)
+	}
+}
+
+// U3: no email resolved, only a username → IdentifyAccount is keyed on the
+// username instead.
+func TestRunOAuthLogin_IdentifyAccount_UsernameFallback(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	usersMe := fakeUsersMeServer(t, `{"data":{"username":"demo"}}`)
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+		UsersMeBaseURL: usersMe.URL,
+		Now:            time.Now,
+	}
+
+	res := runOAuthLoginForTest(t, cfg)
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	if got := spy.identifyCalls; len(got) != 1 || got[0] != "demo" {
+		t.Fatalf("identifyCalls = %v, want [demo]", got)
+	}
+}
+
+// U3: the identity probe failing entirely (login still succeeds per
+// existing behavior) must not call IdentifyAccount.
+func TestRunOAuthLogin_IdentifyAccount_ProbeFailure_NoIdentify(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	// /v3/users/me probe: unreachable server → probe fails, login proceeds.
+	unreachable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	unreachable.Close() // closed immediately: connection refused on probe
+
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+		UsersMeBaseURL: unreachable.URL,
+		Now:            time.Now,
+	}
+
+	res := runOAuthLoginForTest(t, cfg)
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0 (login must not roll back on probe failure)\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	if len(spy.identifyCalls) != 0 {
+		t.Fatalf("identifyCalls = %v, want none (probe failed)", spy.identifyCalls)
+	}
+	// Login still completes despite the identity probe failure.
+	if got := spy.completed; len(got) != 1 || got[0] != "oauth" {
+		t.Fatalf("completed = %v, want [oauth]", got)
+	}
+}
+
+// U3: a successful api-key login resolving an identity emits the same
+// Alias-then-Identify pair as the OAuth path.
+func TestRunAuthLogin_APIKey_IdentifyAccount(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	srv, _ := usersMeServerForKey(t, "hg_test_key", `{"data":{"username":"jdoe","email":"jane@example.com"}}`)
+
+	res := runCommandWithInput(t, srv.URL, "", strings.NewReader("hg_test_key\n"),
+		"auth", "login", "--api-key")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	if got := spy.identifyCalls; len(got) != 1 || got[0] != "jane@example.com" {
+		t.Fatalf("identifyCalls = %v, want [jane@example.com]", got)
+	}
+	if got := spy.completed; len(got) != 1 || got[0] != "api_key" {
+		t.Fatalf("completed = %v, want [api_key]", got)
 	}
 }

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,9 +18,25 @@ import (
 	"github.com/heygen-com/heygen-cli/internal/analytics"
 	"github.com/heygen-com/heygen-cli/internal/auth"
 	"github.com/heygen-com/heygen-cli/internal/auth/oauth"
+	"github.com/heygen-com/heygen-cli/internal/command"
 	"github.com/heygen-com/heygen-cli/internal/config"
+	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 	"github.com/spf13/cobra"
 )
+
+// errorFormatter is a test double for output.Formatter whose Data call
+// always fails, simulating e.g. a broken-pipe stdout write (piping the
+// CLI's output through something that closes early, like `head -1`).
+// Used to confirm that a formatter failure on the success path is
+// reflected in login telemetry: the attempt must NOT be recorded as
+// AuthLoginCompleted if the CLI itself exits non-zero.
+type errorFormatter struct{}
+
+func (errorFormatter) Data(_ json.RawMessage, _ string, _ []command.Column) error {
+	return errors.New("write: broken pipe")
+}
+
+func (errorFormatter) Error(_ *clierrors.CLIError) {}
 
 // fakeIdP serves a minimal subset of the HeyGen OAuth endpoints for the
 // PR 2 login integration test. It accepts a single authorization_code
@@ -704,6 +722,65 @@ func TestRunAuthLogin_OAuthSuccess_Telemetry(t *testing.T) {
 	}
 }
 
+// Regression test: a login that otherwise succeeds but whose final
+// response write fails (e.g. stdout piped into something that closes
+// early) must NOT be recorded as AuthLoginCompleted — the CLI itself
+// exits non-zero, so telemetry must agree and report AuthLoginFailed
+// instead. Previously runOAuthLogin set reported=true and called
+// AuthLoginCompleted BEFORE calling ctx.formatter.Data, so a formatter
+// failure here still recorded a completed login.
+func TestRunAuthLogin_OAuthFormatterFailure_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	usersMe := fakeUsersMeServer(t, `{"data":{"username":"demo","email":"demo@example.com"}}`)
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+		UsersMeBaseURL: usersMe.URL,
+		Now:            time.Now,
+	}
+
+	runAuthLoginTestDeps = &runAuthLoginDeps{
+		stdinIsTerminal:  func() bool { return true },
+		stdoutIsTerminal: func() bool { return true },
+		nonInteractive:   func() bool { return false },
+		runOAuth: func(c *cobra.Command, x *cmdContext) error {
+			return runOAuthLogin(c, x, cfg)
+		},
+	}
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
+
+	cmd := &cobra.Command{Use: "login"}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetContext(context.Background())
+	ctx := &cmdContext{formatter: errorFormatter{}, version: "test"}
+
+	err := runAuthLogin(cmd, ctx, authLoginFlags{oauthMode: true})
+	if err == nil {
+		t.Fatal("runAuthLogin: want the formatter error, got nil")
+	}
+	if !strings.Contains(err.Error(), "broken pipe") {
+		t.Fatalf("err = %q, want it to surface the formatter failure", err.Error())
+	}
+
+	if len(spy.completed) != 0 {
+		t.Fatalf("completed = %v, want none (formatter failed after login succeeded)", spy.completed)
+	}
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "internal_error"}) {
+		t.Fatalf("failed = %v, want [{oauth internal_error}]", got)
+	}
+}
+
 // U4: the loopback timing out (no browser callback ever arrives) emits
 // failed(oauth, oauth_timeout). Uses a short-deadline parent context
 // instead of waiting out oauth.DefaultLoopbackTimeout (~5min) — runOAuthLogin
@@ -907,5 +984,57 @@ func TestRunAuthLogin_APIKey_IdentifyAccount(t *testing.T) {
 	}
 	if got := spy.completed; len(got) != 1 || got[0] != "api_key" {
 		t.Fatalf("completed = %v, want [api_key]", got)
+	}
+}
+
+// Regression test, api-key path: same as
+// TestRunAuthLogin_OAuthFormatterFailure_Telemetry but through
+// runAPIKeyLogin. A formatter failure on the success path must surface
+// as the function's return error (non-zero exit) AND must be reported
+// as AuthLoginFailed(api_key, internal_error), never
+// AuthLoginCompleted.
+func TestRunAuthLogin_APIKeyFormatterFailure_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	srv, _ := usersMeServerForKey(t, "hg_test_key", `{"data":{"username":"jdoe","email":"jane@example.com"}}`)
+	t.Setenv("HEYGEN_API_BASE", srv.URL)
+	t.Setenv("HEYGEN_ALLOW_HTTP", "1")
+
+	runAuthLoginTestDeps = &runAuthLoginDeps{
+		stdinIsTerminal:  func() bool { return true },
+		stdoutIsTerminal: func() bool { return true },
+		nonInteractive:   func() bool { return false },
+		runAPIKey:        runAPIKeyLogin,
+	}
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
+
+	cmd := &cobra.Command{Use: "login"}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader("hg_test_key\n"))
+	cmd.SetContext(context.Background())
+	ctx := &cmdContext{
+		formatter: errorFormatter{},
+		version:   "test",
+		configProvider: &config.LayeredProvider{
+			Env:  &config.EnvProvider{},
+			File: &config.FileProvider{},
+		},
+	}
+
+	err := runAuthLogin(cmd, ctx, authLoginFlags{apiKeyMode: true})
+	if err == nil {
+		t.Fatal("runAuthLogin: want the formatter error, got nil")
+	}
+	if !strings.Contains(err.Error(), "broken pipe") {
+		t.Fatalf("err = %q, want it to surface the formatter failure", err.Error())
+	}
+
+	if len(spy.completed) != 0 {
+		t.Fatalf("completed = %v, want none (formatter failed after login succeeded)", spy.completed)
+	}
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"api_key", "internal_error"}) {
+		t.Fatalf("failed = %v, want [{api_key internal_error}]", got)
 	}
 }

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -923,6 +923,38 @@ func TestRunOAuthLogin_IdentifyAccount_UsernameFallback(t *testing.T) {
 	}
 }
 
+// identityKey lowercases the resolved email so this joins the same PostHog
+// person regardless of the account's stored casing.
+func TestRunOAuthLogin_IdentifyAccount_EmailLowercased(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	usersMe := fakeUsersMeServer(t, `{"data":{"username":"Demo","email":"Demo@Example.com"}}`)
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+		UsersMeBaseURL: usersMe.URL,
+		Now:            time.Now,
+	}
+
+	res := runOAuthLoginForTest(t, cfg)
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	if got := spy.identifyCalls; len(got) != 1 || got[0] != "demo@example.com" {
+		t.Fatalf("identifyCalls = %v, want [demo@example.com]", got)
+	}
+}
+
 // U3: the identity probe failing entirely (login still succeeds per
 // existing behavior) must not call IdentifyAccount.
 func TestRunOAuthLogin_IdentifyAccount_ProbeFailure_NoIdentify(t *testing.T) {

--- a/cmd/heygen/main.go
+++ b/cmd/heygen/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/analytics"
 	"github.com/heygen-com/heygen-cli/internal/config"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
+	"github.com/heygen-com/heygen-cli/internal/paths"
 )
 
 // version is set at build time via ldflags.
@@ -18,7 +22,10 @@ func main() {
 	// Bootstrap formatter created before the Cobra tree so it's available
 	// for errors returned from command execution, including in --human mode.
 	formatter := formatterForArgs(os.Args[1:], os.Stdout, os.Stderr)
-	analyticsClient := analytics.New(version, analyticsEnabled())
+	enabled := analyticsEnabled()
+	maybeShowTelemetryNotice(enabled, os.Stderr)
+	analyticsClient := analytics.New(version, enabled)
+	loginAnalytics = analyticsClient
 
 	cmd := newRootCmd(version, formatter, analyticsClient)
 	start := time.Now()
@@ -88,4 +95,35 @@ func analyticsEnabled() bool {
 		return false
 	}
 	return true
+}
+
+// telemetryNoticePath is heygen-cli's own record of whether the telemetry
+// disclosure notice has already been shown — heygen-cli's own config
+// directory, not the shared ~/.hyperframes/config.json (that file's write
+// surface is kept to the anonymousId field alone; see internal/analytics).
+func telemetryNoticePath() string {
+	return filepath.Join(paths.ConfigDir(), "telemetry_notice_shown")
+}
+
+// maybeShowTelemetryNotice prints a one-time disclosure that heygen-cli
+// sends usage telemetry and that signing in links it to the account email
+// or username, mirroring hyperframes-oss's existing notice. Gated the same
+// way analyticsEnabled() already gates the analytics client itself:
+// nothing to disclose when analytics is disabled, and shown at most once
+// per install. stderr is injectable so tests can assert on it without
+// redirecting the process's real os.Stderr.
+func maybeShowTelemetryNotice(enabled bool, stderr io.Writer) {
+	if !enabled {
+		return
+	}
+	path := telemetryNoticePath()
+	if _, err := os.Stat(path); err == nil {
+		return
+	}
+	fmt.Fprintln(stderr,
+		"heygen-cli sends anonymous usage telemetry (command, os/arch, outcome). "+
+			"Signing in via `heygen auth login` links this usage to your account email or username. "+
+			"Opt out with HEYGEN_NO_ANALYTICS=1.")
+	_ = os.MkdirAll(filepath.Dir(path), 0o700)
+	_ = os.WriteFile(path, []byte("1"), 0o600)
 }

--- a/cmd/heygen/main_test.go
+++ b/cmd/heygen/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -38,5 +39,52 @@ func TestAnalyticsEnabled_EnvOverridesConfig(t *testing.T) {
 
 	if analyticsEnabled() {
 		t.Fatal("analyticsEnabled = true, want false")
+	}
+}
+
+// U3: first analytics-enabled run with no local notice-shown flag prints
+// the disclosure once and persists the flag to heygen-cli's own config dir
+// (not the shared ~/.hyperframes/config.json — see internal/analytics).
+func TestMaybeShowTelemetryNotice_FirstRun(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	var stderr strings.Builder
+	maybeShowTelemetryNotice(true, &stderr)
+
+	if !strings.Contains(stderr.String(), "telemetry") {
+		t.Fatalf("stderr = %q, want a telemetry disclosure", stderr.String())
+	}
+	if _, err := os.Stat(telemetryNoticePath()); err != nil {
+		t.Fatalf("notice-shown flag not persisted: %v", err)
+	}
+}
+
+func TestMaybeShowTelemetryNotice_AlreadyShown(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", dir)
+	if err := os.WriteFile(filepath.Join(dir, "telemetry_notice_shown"), []byte("1"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var stderr strings.Builder
+	maybeShowTelemetryNotice(true, &stderr)
+
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty (notice already shown)", stderr.String())
+	}
+}
+
+func TestMaybeShowTelemetryNotice_AnalyticsDisabled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", dir)
+
+	var stderr strings.Builder
+	maybeShowTelemetryNotice(false, &stderr)
+
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty (analytics disabled)", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "telemetry_notice_shown")); err == nil {
+		t.Fatal("notice-shown flag written despite analytics being disabled")
 	}
 }

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -1,6 +1,7 @@
 package analytics
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,7 +14,11 @@ import (
 	"github.com/posthog/posthog-go"
 )
 
-const posthogAPIKey = "phc_Bvsz7U8BvVxZtguuTGiBcbRUCkX46MwqdZ9t8LQ7cBGr"
+// Same public ingestion key and project hyperframes-oss (packages/cli,
+// skills/media-use) already ships to, so heygen-cli's events land in the
+// same PostHog project and become queryable against the shared install
+// identity (see distinctID / sharedConfigPath below).
+const posthogAPIKey = "phc_zjjbX0PnWxERXrMHhkEJWj9A9BhGVLRReICgsfTMmpx"
 const posthogEndpoint = "https://us.i.posthog.com"
 
 type captureClient interface {
@@ -29,6 +34,7 @@ type Client struct {
 	version      string
 	clientOrigin string
 	started      bool
+	identified   bool
 }
 
 // New creates an analytics client. Disabled clients are inert no-ops.
@@ -126,6 +132,11 @@ func (c *Client) baseProperties(command string) posthog.Properties {
 		Set("cli_version", c.version).
 		Set("os", runtime.GOOS).
 		Set("arch", runtime.GOARCH).
+		// heygen-cli's events now land in the same PostHog project as
+		// hyperframes-oss and media-use (shared posthogAPIKey above); every
+		// event needs this marker so a dashboard/query can isolate one
+		// tool's traffic instead of relying only on event-name prefixes.
+		Set("surface", "heygen-cli").
 		// Send $ip: null so PostHog neither stores the caller's IP nor geolocates
 		// it. The CLI is opt-in anonymous telemetry; IP would undermine that. PostHog
 		// otherwise derives IP from the ingest request, so this must be set explicitly.
@@ -146,16 +157,161 @@ func (c *Client) Started() bool {
 	return c.started
 }
 
-func distinctID() string {
+// IdentifyAccount links a resolved HeyGen account identity (email, falling
+// back to username — the caller's job to pick) to this install's shared
+// anonymous id, exactly once per process. This is the anon-to-identified
+// merge: posthog-go v1.11.2's Identify message has no $anon_distinct_id
+// field (Identify.Properties only becomes person-property $set data), so
+// the actual merge primitive in this SDK version is the separate Alias
+// message, which fires PostHog's $create_alias event. Direction matters —
+// DistinctId is the identity being merged INTO (the account), Alias is the
+// anonymous id being merged FROM; reversed, the merge silently fails.
+func (c *Client) IdentifyAccount(distinctId string) {
+	if !c.enabled || c.ph == nil || c.identified || distinctId == "" {
+		return
+	}
+	c.identified = true
+	_ = c.ph.Enqueue(posthog.Alias{
+		DistinctId: distinctId,
+		Alias:      c.distinctID,
+	})
+	_ = c.ph.Enqueue(posthog.Identify{
+		DistinctId: distinctId,
+	})
+}
+
+// AuthLoginStarted records that a login attempt was dispatched to a
+// specific method ("oauth" / "api_key" / "device_code"), after the picker
+// or an explicit flag resolved which one — never before a picker
+// cancellation, so started reconciles cleanly to completed/failed.
+func (c *Client) AuthLoginStarted(method string) {
+	if !c.enabled || c.ph == nil {
+		return
+	}
+	_ = c.ph.Enqueue(posthog.Capture{
+		DistinctId: c.distinctID,
+		Event:      "AUTH_LOGIN_STARTED",
+		Properties: c.baseProperties("auth login").Set("method", method),
+	})
+}
+
+// AuthLoginCompleted records a successful login for the given method.
+func (c *Client) AuthLoginCompleted(method string) {
+	if !c.enabled || c.ph == nil {
+		return
+	}
+	_ = c.ph.Enqueue(posthog.Capture{
+		DistinctId: c.distinctID,
+		Event:      "AUTH_LOGIN_COMPLETED",
+		Properties: c.baseProperties("auth login").Set("method", method),
+	})
+}
+
+// AuthLoginFailed records a failed login attempt with a specific reason
+// drawn from the login flow's real failure branches (see auth_login.go).
+func (c *Client) AuthLoginFailed(method, reason string) {
+	if !c.enabled || c.ph == nil {
+		return
+	}
+	_ = c.ph.Enqueue(posthog.Capture{
+		DistinctId: c.distinctID,
+		Event:      "AUTH_LOGIN_FAILED",
+		Properties: c.baseProperties("auth login").Set("method", method).Set("reason", reason),
+	})
+}
+
+// sharedConfigPath returns ~/.hyperframes/config.json, the cross-tool
+// install-identity file hyperframes CLI and media-use already read/write
+// (skills/media-use/scripts/lib/telemetry.mjs: sharedConfigPath /
+// anonymousId). Resolved independently of HEYGEN_CONFIG_DIR — it's a
+// different, cross-tool directory by design, not heygen-cli's own config
+// dir. Returns "" if the home directory can't be resolved; callers treat
+// that the same as "file absent."
+func sharedConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".hyperframes", "config.json")
+}
+
+// readSharedConfig reads and parses the shared config file, tolerating a
+// missing or malformed file as "absent" (returns an empty map, never
+// panics) so a corrupt file from another tool never breaks heygen-cli.
+func readSharedConfig() map[string]any {
+	path := sharedConfigPath()
+	if path == "" {
+		return map[string]any{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]any{}
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil || config == nil {
+		return map[string]any{}
+	}
+	return config
+}
+
+// writeSharedConfig writes the full config object back to disk. Callers
+// must read-merge-write (readSharedConfig, set only the key(s) this
+// codebase owns, then writeSharedConfig the whole map) — this file is
+// written by three independent codebases (hyperframes CLI, media-use, and
+// heygen-cli), and a blind overwrite here would drop a field one of the
+// others just wrote (e.g. telemetryNoticeShown).
+func writeSharedConfig(config map[string]any) {
+	path := sharedConfigPath()
+	if path == "" {
+		return
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(path), 0o700)
+	_ = os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+// legacyAnalyticsID reads heygen-cli's own pre-existing analytics id
+// (~/.heygen/analytics_id, or HEYGEN_CONFIG_DIR's override) from before
+// this codebase adopted the shared install identity. Read-only: nothing
+// writes to this file anymore.
+func legacyAnalyticsID() string {
 	idPath := filepath.Join(paths.ConfigDir(), "analytics_id")
-	if data, err := os.ReadFile(idPath); err == nil {
-		if id := strings.TrimSpace(string(data)); id != "" {
-			return id
+	data, err := os.ReadFile(idPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// distinctID resolves heygen-cli's PostHog distinct id from the shared
+// hyperframes install identity (~/.hyperframes/config.json's anonymousId),
+// the same cross-tool id hyperframes CLI and media-use already use.
+//
+//   - Shared config has anonymousId → use it verbatim.
+//   - Shared config absent (or malformed) but a legacy heygen-cli-only id
+//     exists → promote it into the shared config so an upgrading user
+//     keeps their identity, then use it.
+//   - Neither exists → mint a fresh id and write it to the shared config.
+//
+// Every write is read-merge-write via readSharedConfig/writeSharedConfig,
+// so a field another tool wrote to the same file survives.
+func distinctID() string {
+	config := readSharedConfig()
+	if id, ok := config["anonymousId"].(string); ok {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			return trimmed
 		}
 	}
 
-	id := uuid.NewString()
-	_ = os.MkdirAll(filepath.Dir(idPath), 0o700)
-	_ = os.WriteFile(idPath, []byte(id), 0o600)
+	id := legacyAnalyticsID()
+	if id == "" {
+		id = uuid.NewString()
+	}
+
+	config["anonymousId"] = id
+	writeSharedConfig(config)
 	return id
 }

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -21,9 +21,45 @@ import (
 const posthogAPIKey = "phc_zjjbX0PnWxERXrMHhkEJWj9A9BhGVLRReICgsfTMmpx"
 const posthogEndpoint = "https://us.i.posthog.com"
 
+// legacyPosthogAPIKey is heygen-cli's own pre-existing PostHog project,
+// predating this identity/destination unification. Every event is
+// dual-written here too so its existing dashboard keeps receiving fresh
+// data (rather than flatlining as clients upgrade) until it's migrated to
+// query the shared project instead.
+const legacyPosthogAPIKey = "phc_Bvsz7U8BvVxZtguuTGiBcbRUCkX46MwqdZ9t8LQ7cBGr"
+
 type captureClient interface {
 	Enqueue(posthog.Message) error
 	Close() error
+}
+
+// multiClient fans every Enqueue/Close out to every wrapped client, so a
+// single call site (CommandRun, IdentifyAccount, etc.) can dual-write to
+// more than one PostHog destination without any event-emitting method
+// knowing about it. Continues past a failing client so one destination
+// being down never blocks the others.
+type multiClient struct {
+	clients []captureClient
+}
+
+func (m *multiClient) Enqueue(msg posthog.Message) error {
+	var firstErr error
+	for _, c := range m.clients {
+		if err := c.Enqueue(msg); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (m *multiClient) Close() error {
+	var firstErr error
+	for _, c := range m.clients {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // Client wraps PostHog event capture behind a small no-op-friendly surface.
@@ -43,15 +79,24 @@ func New(version string, enabled bool) *Client {
 		return &Client{}
 	}
 
-	ph, err := posthog.NewWithConfig(posthogAPIKey, posthog.Config{
-		BatchSize: 1,
-		Endpoint:  posthogEndpoint,
-	})
-	if err != nil {
+	var clients []captureClient
+	for _, key := range [...]string{posthogAPIKey, legacyPosthogAPIKey} {
+		if key == "" {
+			continue
+		}
+		ph, err := posthog.NewWithConfig(key, posthog.Config{
+			BatchSize: 1,
+			Endpoint:  posthogEndpoint,
+		})
+		if err == nil {
+			clients = append(clients, ph)
+		}
+	}
+	if len(clients) == 0 {
 		return &Client{}
 	}
 
-	return newWithCapture(version, ph)
+	return newWithCapture(version, &multiClient{clients: clients})
 }
 
 func newWithCapture(version string, ph captureClient) *Client {

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -4,11 +4,22 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/posthog/posthog-go"
 )
+
+// setHomeDirForTest sandboxes the home directory os.UserHomeDir resolves,
+// which on Windows reads USERPROFILE rather than HOME.
+func setHomeDirForTest(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
+}
 
 type stubCaptureClient struct {
 	messages []posthog.Message
@@ -226,7 +237,7 @@ func TestClose_DisabledNoop(t *testing.T) {
 // HEYGEN_CONFIG_DIR — never touch a developer's real shared config file.
 
 func TestDistinctID_Persists(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setHomeDirForTest(t, t.TempDir())
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 
 	first := distinctID()
@@ -280,7 +291,7 @@ func TestCommandRunComplete_SourceAndHTTPStatus(t *testing.T) {
 // verbatim.
 func TestDistinctID_UsesSharedConfigAnonymousId(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDirForTest(t, home)
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 
 	hfDir := filepath.Join(home, ".hyperframes")
@@ -300,7 +311,7 @@ func TestDistinctID_UsesSharedConfigAnonymousId(t *testing.T) {
 // value is promoted into a newly written shared config file and used.
 func TestDistinctID_PromotesLegacyId(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDirForTest(t, home)
 	configDir := t.TempDir()
 	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
 
@@ -330,7 +341,7 @@ func TestDistinctID_PromotesLegacyId(t *testing.T) {
 // minted and written to the shared config file.
 func TestDistinctID_MintsFreshId(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDirForTest(t, home)
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 
 	got := distinctID()
@@ -355,7 +366,7 @@ func TestDistinctID_MintsFreshId(t *testing.T) {
 // through to the legacy-then-mint path) and must never panic.
 func TestDistinctID_MalformedSharedConfigTreatedAsAbsent(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDirForTest(t, home)
 	configDir := t.TempDir()
 	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
 
@@ -380,7 +391,7 @@ func TestDistinctID_MalformedSharedConfigTreatedAsAbsent(t *testing.T) {
 // path resolution stays anchored to HOME regardless.
 func TestDistinctID_HeygenConfigDirIndependentOfSharedPath(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDirForTest(t, home)
 	configDir := t.TempDir()
 	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
 
@@ -405,7 +416,7 @@ func TestDistinctID_HeygenConfigDirIndependentOfSharedPath(t *testing.T) {
 // read-merge-write, not a blind overwrite.
 func TestDistinctID_PreservesUnrelatedSharedConfigKeys(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHomeDirForTest(t, home)
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 
 	hfDir := filepath.Join(home, ".hyperframes")

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -1,6 +1,9 @@
 package analytics
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -52,6 +55,9 @@ func TestCommandRun_Properties(t *testing.T) {
 	if got := msg.Properties["cli_version"]; got != "v1.2.3" {
 		t.Fatalf("cli_version = %v, want %q", got, "v1.2.3")
 	}
+	if got := msg.Properties["surface"]; got != "heygen-cli" {
+		t.Fatalf("surface = %v, want %q", got, "heygen-cli")
+	}
 }
 
 func TestCommandRunComplete_Properties(t *testing.T) {
@@ -86,6 +92,9 @@ func TestCommandRunComplete_Properties(t *testing.T) {
 	}
 	if got := msg.Properties["error_code"]; got != "timeout" {
 		t.Fatalf("error_code = %v, want %q", got, "timeout")
+	}
+	if got := msg.Properties["surface"]; got != "heygen-cli" {
+		t.Fatalf("surface = %v, want %q", got, "heygen-cli")
 	}
 }
 
@@ -212,7 +221,12 @@ func TestClose_DisabledNoop(t *testing.T) {
 	}
 }
 
+// distinctID now reads/writes ~/.hyperframes/config.json (resolved via
+// os.UserHomeDir, i.e. $HOME), so every test below isolates both HOME and
+// HEYGEN_CONFIG_DIR — never touch a developer's real shared config file.
+
 func TestDistinctID_Persists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 
 	first := distinctID()
@@ -260,4 +274,318 @@ func TestCommandRunComplete_SourceAndHTTPStatus(t *testing.T) {
 			t.Fatalf("source should be omitted on success")
 		}
 	})
+}
+
+// U1: shared config file exists with an anonymousId → that value is used
+// verbatim.
+func TestDistinctID_UsesSharedConfigAnonymousId(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	hfDir := filepath.Join(home, ".hyperframes")
+	if err := os.MkdirAll(hfDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hfDir, "config.json"), []byte(`{"anonymousId":"shared-id-123"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := distinctID(); got != "shared-id-123" {
+		t.Fatalf("distinctID() = %q, want %q", got, "shared-id-123")
+	}
+}
+
+// U1: shared config absent, legacy ~/.heygen/analytics_id exists → its
+// value is promoted into a newly written shared config file and used.
+func TestDistinctID_PromotesLegacyId(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	if err := os.WriteFile(filepath.Join(configDir, "analytics_id"), []byte("legacy-id-456\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := distinctID()
+	if got != "legacy-id-456" {
+		t.Fatalf("distinctID() = %q, want %q", got, "legacy-id-456")
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, ".hyperframes", "config.json"))
+	if err != nil {
+		t.Fatalf("ReadFile shared config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatalf("Unmarshal shared config: %v", err)
+	}
+	if config["anonymousId"] != "legacy-id-456" {
+		t.Fatalf("shared config anonymousId = %v, want %q", config["anonymousId"], "legacy-id-456")
+	}
+}
+
+// U1: neither the shared config nor a legacy id exists → a fresh id is
+// minted and written to the shared config file.
+func TestDistinctID_MintsFreshId(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	got := distinctID()
+	if got == "" {
+		t.Fatal("distinctID() is empty")
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, ".hyperframes", "config.json"))
+	if err != nil {
+		t.Fatalf("ReadFile shared config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatalf("Unmarshal shared config: %v", err)
+	}
+	if config["anonymousId"] != got {
+		t.Fatalf("shared config anonymousId = %v, want %q", config["anonymousId"], got)
+	}
+}
+
+// U1: a malformed shared config file must be treated as absent (falls
+// through to the legacy-then-mint path) and must never panic.
+func TestDistinctID_MalformedSharedConfigTreatedAsAbsent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	hfDir := filepath.Join(home, ".hyperframes")
+	if err := os.MkdirAll(hfDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hfDir, "config.json"), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "analytics_id"), []byte("legacy-from-malformed\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := distinctID()
+	if got != "legacy-from-malformed" {
+		t.Fatalf("distinctID() = %q, want %q (malformed config should fall through)", got, "legacy-from-malformed")
+	}
+}
+
+// U1: HEYGEN_CONFIG_DIR only affects the legacy-id read; the shared config
+// path resolution stays anchored to HOME regardless.
+func TestDistinctID_HeygenConfigDirIndependentOfSharedPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+
+	if err := os.WriteFile(filepath.Join(configDir, "analytics_id"), []byte("from-override-dir\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := distinctID()
+	if got != "from-override-dir" {
+		t.Fatalf("distinctID() = %q, want %q", got, "from-override-dir")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".hyperframes", "config.json")); err != nil {
+		t.Fatalf("shared config not written under HOME: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "config.json")); err == nil {
+		t.Fatal("shared config incorrectly written under HEYGEN_CONFIG_DIR")
+	}
+}
+
+// U1: unrelated keys already in the shared config (written by hyperframes
+// CLI or media-use) must survive a heygen-cli write untouched — proves
+// read-merge-write, not a blind overwrite.
+func TestDistinctID_PreservesUnrelatedSharedConfigKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+
+	hfDir := filepath.Join(home, ".hyperframes")
+	if err := os.MkdirAll(hfDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hfDir, "config.json"), []byte(`{"telemetryNoticeShown":true}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := distinctID()
+	if got == "" {
+		t.Fatal("distinctID() is empty")
+	}
+
+	raw, err := os.ReadFile(filepath.Join(hfDir, "config.json"))
+	if err != nil {
+		t.Fatalf("ReadFile shared config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatalf("Unmarshal shared config: %v", err)
+	}
+	if config["telemetryNoticeShown"] != true {
+		t.Fatalf("telemetryNoticeShown = %v, want true (must survive heygen-cli's write)", config["telemetryNoticeShown"])
+	}
+	if config["anonymousId"] != got {
+		t.Fatalf("anonymousId = %v, want %q", config["anonymousId"], got)
+	}
+}
+
+// IdentifyAccount (U3): enqueues Alias then Identify, exactly once per
+// process, no-ops on an empty distinct id or a disabled client.
+
+func TestIdentifyAccount_EnqueuesAliasThenIdentify(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+	client.distinctID = "anon-id"
+
+	client.IdentifyAccount("person@example.com")
+
+	if len(stub.messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(stub.messages))
+	}
+	alias, ok := stub.messages[0].(posthog.Alias)
+	if !ok {
+		t.Fatalf("message 0 type = %T, want posthog.Alias", stub.messages[0])
+	}
+	if alias.DistinctId != "person@example.com" {
+		t.Fatalf("Alias.DistinctId = %q, want %q", alias.DistinctId, "person@example.com")
+	}
+	if alias.Alias != "anon-id" {
+		t.Fatalf("Alias.Alias = %q, want %q", alias.Alias, "anon-id")
+	}
+	identify, ok := stub.messages[1].(posthog.Identify)
+	if !ok {
+		t.Fatalf("message 1 type = %T, want posthog.Identify", stub.messages[1])
+	}
+	if identify.DistinctId != "person@example.com" {
+		t.Fatalf("Identify.DistinctId = %q, want %q", identify.DistinctId, "person@example.com")
+	}
+}
+
+func TestIdentifyAccount_UsernameFallback(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+	client.distinctID = "anon-id"
+
+	client.IdentifyAccount("someusername")
+
+	alias := stub.messages[0].(posthog.Alias)
+	if alias.DistinctId != "someusername" || alias.Alias != "anon-id" {
+		t.Fatalf("Alias = %+v, want DistinctId=someusername Alias=anon-id", alias)
+	}
+	identify := stub.messages[1].(posthog.Identify)
+	if identify.DistinctId != "someusername" {
+		t.Fatalf("Identify.DistinctId = %q, want %q", identify.DistinctId, "someusername")
+	}
+}
+
+func TestIdentifyAccount_FiresOnlyOncePerProcess(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+
+	client.IdentifyAccount("first@example.com")
+	client.IdentifyAccount("second@example.com")
+
+	if len(stub.messages) != 2 {
+		t.Fatalf("messages = %d, want 2 (second call must no-op)", len(stub.messages))
+	}
+}
+
+func TestIdentifyAccount_EmptyDistinctIdNoops(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+
+	client.IdentifyAccount("")
+
+	if len(stub.messages) != 0 {
+		t.Fatalf("messages = %d, want 0 for an empty distinct id", len(stub.messages))
+	}
+}
+
+func TestIdentifyAccount_DisabledClientNoops(t *testing.T) {
+	client := New("test", false)
+	// Must not panic on a nil capture client.
+	client.IdentifyAccount("person@example.com")
+}
+
+// AuthLoginStarted/Completed/Failed (U4): each fires a single Capture
+// event carrying method (and reason, for Failed).
+
+func TestAuthLoginStarted_Properties(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+	client.distinctID = "anon-id"
+
+	client.AuthLoginStarted("oauth")
+
+	if len(stub.messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(stub.messages))
+	}
+	msg, ok := stub.messages[0].(posthog.Capture)
+	if !ok {
+		t.Fatalf("message type = %T, want posthog.Capture", stub.messages[0])
+	}
+	if msg.Event != "AUTH_LOGIN_STARTED" {
+		t.Fatalf("Event = %q, want %q", msg.Event, "AUTH_LOGIN_STARTED")
+	}
+	if got := msg.Properties["method"]; got != "oauth" {
+		t.Fatalf("method = %v, want %q", got, "oauth")
+	}
+	if got := msg.Properties["surface"]; got != "heygen-cli" {
+		t.Fatalf("surface = %v, want %q", got, "heygen-cli")
+	}
+}
+
+func TestAuthLoginCompleted_Properties(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+
+	client.AuthLoginCompleted("api_key")
+
+	msg, ok := stub.messages[0].(posthog.Capture)
+	if !ok {
+		t.Fatalf("message type = %T, want posthog.Capture", stub.messages[0])
+	}
+	if msg.Event != "AUTH_LOGIN_COMPLETED" {
+		t.Fatalf("Event = %q, want %q", msg.Event, "AUTH_LOGIN_COMPLETED")
+	}
+	if got := msg.Properties["method"]; got != "api_key" {
+		t.Fatalf("method = %v, want %q", got, "api_key")
+	}
+}
+
+func TestAuthLoginFailed_Properties(t *testing.T) {
+	stub := &stubCaptureClient{}
+	client := newWithCapture("v1.2.3", stub)
+
+	client.AuthLoginFailed("oauth", "oauth_timeout")
+
+	msg, ok := stub.messages[0].(posthog.Capture)
+	if !ok {
+		t.Fatalf("message type = %T, want posthog.Capture", stub.messages[0])
+	}
+	if msg.Event != "AUTH_LOGIN_FAILED" {
+		t.Fatalf("Event = %q, want %q", msg.Event, "AUTH_LOGIN_FAILED")
+	}
+	if got := msg.Properties["method"]; got != "oauth" {
+		t.Fatalf("method = %v, want %q", got, "oauth")
+	}
+	if got := msg.Properties["reason"]; got != "oauth_timeout" {
+		t.Fatalf("reason = %v, want %q", got, "oauth_timeout")
+	}
+}
+
+func TestAuthLoginEvents_DisabledClientNoop(t *testing.T) {
+	client := New("test", false)
+	// Must not panic on a nil capture client.
+	client.AuthLoginStarted("oauth")
+	client.AuthLoginCompleted("oauth")
+	client.AuthLoginFailed("oauth", "oauth_timeout")
 }

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -34,6 +35,51 @@ func (s *stubCaptureClient) Enqueue(msg posthog.Message) error {
 func (s *stubCaptureClient) Close() error {
 	s.closed++
 	return nil
+}
+
+// Dual-write: every event reaches both the shared hyperframes-oss project
+// and heygen-cli's own pre-existing project, so that project's dashboard
+// keeps receiving data instead of flatlining as clients upgrade.
+func TestMultiClient_FansOutEnqueueAndClose(t *testing.T) {
+	a := &stubCaptureClient{}
+	b := &stubCaptureClient{}
+	m := &multiClient{clients: []captureClient{a, b}}
+
+	msg := posthog.Capture{DistinctId: "anon-id", Event: "COMMAND_RUN"}
+	if err := m.Enqueue(msg); err != nil {
+		t.Fatalf("Enqueue() error = %v, want nil", err)
+	}
+	if len(a.messages) != 1 || len(b.messages) != 1 {
+		t.Fatalf("messages = %d, %d, want 1, 1", len(a.messages), len(b.messages))
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+	if a.closed != 1 || b.closed != 1 {
+		t.Fatalf("closed = %d, %d, want 1, 1", a.closed, b.closed)
+	}
+}
+
+type erroringCaptureClient struct {
+	err error
+}
+
+func (e *erroringCaptureClient) Enqueue(posthog.Message) error { return e.err }
+func (e *erroringCaptureClient) Close() error                  { return e.err }
+
+// One destination failing must not stop the others from receiving the event.
+func TestMultiClient_ContinuesPastFailingClient(t *testing.T) {
+	failing := &erroringCaptureClient{err: errors.New("boom")}
+	ok := &stubCaptureClient{}
+	m := &multiClient{clients: []captureClient{failing, ok}}
+
+	if err := m.Enqueue(posthog.Capture{Event: "COMMAND_RUN"}); err == nil {
+		t.Fatal("Enqueue() error = nil, want the failing client's error surfaced")
+	}
+	if len(ok.messages) != 1 {
+		t.Fatalf("messages = %d, want 1 (the healthy client must still receive the event)", len(ok.messages))
+	}
 }
 
 func TestCommandRun_Properties(t *testing.T) {


### PR DESCRIPTION
## Summary

heygen-cli's own analytics reported to a separate PostHog project under a locally-minted identity, with no identify call on login — so a successful `heygen auth login` couldn't be joined to anything the rest of the toolchain already tracks, and login attempts only ever showed up as a generic command-run event with no method or failure reason. This wires heygen-cli into the same cross-tool identity and destination, and makes login itself first-class, queryable telemetry.

Companion change to a matching PR in `heygen-com/hyperframes`: https://github.com/heygen-com/hyperframes/pull/2130 (media-use side: failure classification + free/paid tagging + test-isolation hardening). The two land independently — neither repo's release blocks the other.

## What changed

- **Shared install identity**: the analytics client's distinct id now comes from the same cross-tool install identity file other HeyGen CLIs already share, promoting any existing local id on first run so upgrading users don't reset their history.
- **Shared destination + surface tag**: events now land in the same ingestion project as the rest of the toolchain, tagged with a `surface` property so a query can still isolate this CLI's traffic.
- **Account identify on login**: a successful login (OAuth or API-key) now links the anonymous install identity to the signed-in account, the same way the rest of the toolchain already does — plus a one-time console notice disclosing this.
- **Structured login telemetry**: `auth login` attempts now emit distinct started/completed/failed events carrying the method (OAuth vs. API-key) and, on failure, a specific reason drawn from the login flow's real failure branches (timeout, cancellation, invalid input, etc.) instead of a generic pass/fail.
- **Reconciliation fix**: a handful of rare early-return error paths (malformed credentials, save/clear failures, PKCE/state generation, loopback startup) previously left a `started` event with no matching `completed`/`failed`; every path now reconciles through a safety-net terminal event.

## Design decisions

- Identity adoption is a read-merge-write against the shared identity file, never a blind overwrite — the file is written by more than one tool, so a write here must not drop a field another tool wrote moments earlier.
- The anon-to-identified merge uses this repo's pinned analytics SDK version's actual merge primitive, verified against that SDK's source rather than assumed from a newer version's API.
- Every new analytics call preserves the existing fire-and-forget contract (guarded, error-swallowing, non-blocking) — none of this can affect the login flow's own success/failure behavior.

## Testing

- Reviewed end-to-end (correctness, no auth-behavior change, fire-and-forget discipline, identity file handling, SDK usage, test coverage) with no blocking issues found.
- Go toolchain unavailable in this environment for a live `go test` run; verified by careful manual reading and cross-checking against the pinned SDK's actual source.

## Post-Deploy Monitoring & Validation

- No additional operational monitoring required beyond normal telemetry review — this is additive, best-effort instrumentation with no change to auth flow behavior, credential storage, or login outcomes.
- Expected healthy signal: no change in login success/failure rates or latency (every new call is fire-and-forget and swallows its own errors).
