### PR TITLE
ci: bump Go toolchain to 1.25.12 to clear crypto/tls advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - name: Build
         run: make build
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: golangci/golangci-lint-action@v9
         with:
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -98,7 +98,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - name: Run tests
         run: make test

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - name: Validate version
         shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heygen-com/heygen-cli
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/getkin/kin-openapi v0.137.0


### PR DESCRIPTION
## Scope
Surfaces: CI/build | Module: Toolchain

## Summary
govulncheck fails on the Go standard library's crypto/tls at go1.25.11
(2 vulnerabilities reachable from the CLI's HTTP/OAuth paths). Bump the
pinned Go toolchain to 1.25.12, where the advisory is fixed.

## Root cause
The stdlib crypto/tls vulnerabilities are "Found in: crypto/tls@go1.25.11 /
Fixed in: crypto/tls@go1.25.12". The repo pins Go 1.25.11 in go.mod and in
every CI/release workflow, so govulncheck reports reachable traces
(StartLoopbackServer, RevokeToken, retryTransport.RoundTrip, HumanFormatter.Error).

## Fix
Bump the `go` directive in go.mod and the `go-version` in ci.yml,
release-stable.yml, and dev-release.yml from 1.25.11 to 1.25.12. No source
changes; the fix is entirely in the toolchain that builds and scans the binary.

## Testing
Builds clean under go1.25.12 (`go build ./...`). CI's govulncheck job installs
govulncheck fresh under the pinned Go, so it validates the advisory is cleared.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>