### PR TITLE
fix(client): per-operation HTTP request timeouts

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -111,6 +111,12 @@ func buildCobraCommand(spec *command.Spec, ctx *cmdContext) *cobra.Command {
 				}
 			}
 
+			// Per-operation HTTP timeout: uploads and create/enqueue calls run
+			// far longer than reads, so give each operation its own budget
+			// rather than one global value. Set once here (each invocation runs
+			// a single command); covers both the --wait and plain paths below.
+			ctx.client.SetTimeout(timeoutForSpec(spec))
+
 			// Poll config is looked up at call time, not attached to Spec.
 			// Spec is immutable (generated); poll configs are hand-written in cmd/.
 			pc := pollConfigs[spec.Group+"/"+spec.Name]

--- a/cmd/heygen/timeouts.go
+++ b/cmd/heygen/timeouts.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/client"
@@ -9,31 +10,39 @@ import (
 
 // Per-operation HTTP request timeouts. A single global timeout is wrong here:
 // server-side latency differs by an order of magnitude across operation classes
-// (reads p99 < 2s; create endpoints p99 ~30s because they do synchronous work;
-// uploads are bounded by file size and client bandwidth, not server compute).
-// These are deliberately not user-configurable yet — add an override only when
-// a real case needs one.
+// (reads p99 < 2s; writes run to a p99 of ~30s because they do synchronous work
+// and some enqueue async jobs; uploads are bounded by file size and client
+// bandwidth, not server compute). Deliberately not user-configurable yet — add
+// an override only when a real case needs one.
 const (
-	// timeoutRead covers reads/lists and quick POSTs. Matches the client default.
+	// timeoutRead covers GET reads and lists (server p99 < 2s). Tracks the
+	// client's built-in default so there is a single source of truth for 30s.
 	timeoutRead = client.DefaultTimeout
-	// timeoutCreate covers create/enqueue endpoints, which run to a p99 of ~30s
-	// server-side; 120s clears that with headroom before giving up.
-	timeoutCreate = 120 * time.Second
-	// timeoutUpload covers multipart uploads, gated by file size and bandwidth.
-	// Matches the dedicated video-download client budget.
+	// timeoutWrite covers every mutating call (POST/PUT/PATCH/DELETE): creates
+	// that do synchronous work or enqueue async jobs, plus other writes. Sized
+	// off the slowest observed case — POST /v3/videos runs to a Datadog p99 of
+	// ~31s (30d window) — with roughly 4x headroom before giving up.
+	timeoutWrite = 120 * time.Second
+	// timeoutUpload covers multipart uploads, bounded by file size and client
+	// bandwidth. Matches the dedicated video-download client budget.
 	timeoutUpload = 10 * time.Minute
 )
 
 // timeoutForSpec picks the per-request HTTP timeout for a generated command by
-// operation class. A runtime enhancement kept out of the immutable generated
-// Spec, like poll configs and --human columns.
+// operation class, keyed on the spec's HTTP method and body encoding — signals
+// that live on the immutable generated Spec. Method-driven, not coupled to the
+// hand-written poll-config set (which covers only 4 of the async-create
+// endpoints), so the classification can't silently drift as commands are added.
+// A runtime enhancement, kept out of the Spec like poll configs and --human
+// columns.
 func timeoutForSpec(spec *command.Spec) time.Duration {
 	if spec.BodyEncoding == "multipart" {
 		return timeoutUpload
 	}
-	// Create/enqueue endpoints are exactly the ones with a poll config.
-	if pollConfigs[spec.Group+"/"+spec.Name] != nil {
-		return timeoutCreate
+	if spec.Method == http.MethodGet {
+		return timeoutRead
 	}
-	return timeoutRead
+	// Every non-GET, non-upload call is a write (create / update / delete).
+	// Creates in particular are slow-synchronous or async-submit server-side.
+	return timeoutWrite
 }

--- a/cmd/heygen/timeouts.go
+++ b/cmd/heygen/timeouts.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"time"
+
+	"github.com/heygen-com/heygen-cli/internal/client"
+	"github.com/heygen-com/heygen-cli/internal/command"
+)
+
+// Per-operation HTTP request timeouts. A single global timeout is wrong here:
+// server-side latency differs by an order of magnitude across operation classes
+// (reads p99 < 2s; create endpoints p99 ~30s because they do synchronous work;
+// uploads are bounded by file size and client bandwidth, not server compute).
+// These are deliberately not user-configurable yet — add an override only when
+// a real case needs one.
+const (
+	// timeoutRead covers reads/lists and quick POSTs. Matches the client default.
+	timeoutRead = client.DefaultTimeout
+	// timeoutCreate covers create/enqueue endpoints, which run to a p99 of ~30s
+	// server-side; 120s clears that with headroom before giving up.
+	timeoutCreate = 120 * time.Second
+	// timeoutUpload covers multipart uploads, gated by file size and bandwidth.
+	// Matches the dedicated video-download client budget.
+	timeoutUpload = 10 * time.Minute
+)
+
+// timeoutForSpec picks the per-request HTTP timeout for a generated command by
+// operation class. A runtime enhancement kept out of the immutable generated
+// Spec, like poll configs and --human columns.
+func timeoutForSpec(spec *command.Spec) time.Duration {
+	if spec.BodyEncoding == "multipart" {
+		return timeoutUpload
+	}
+	// Create/enqueue endpoints are exactly the ones with a poll config.
+	if pollConfigs[spec.Group+"/"+spec.Name] != nil {
+		return timeoutCreate
+	}
+	return timeoutRead
+}

--- a/cmd/heygen/timeouts_test.go
+++ b/cmd/heygen/timeouts_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heygen-com/heygen-cli/internal/command"
+)
+
+func TestTimeoutForSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *command.Spec
+		want time.Duration
+	}{
+		{"multipart upload -> upload budget", &command.Spec{Group: "asset", Name: "create", BodyEncoding: "multipart"}, timeoutUpload},
+		{"pollable create -> create budget", &command.Spec{Group: "video", Name: "create", BodyEncoding: "json"}, timeoutCreate},
+		{"plain read -> default budget", &command.Spec{Group: "video", Name: "list", Method: "GET"}, timeoutRead},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := timeoutForSpec(tt.spec); got != tt.want {
+				t.Errorf("timeoutForSpec = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/heygen/timeouts_test.go
+++ b/cmd/heygen/timeouts_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/heygen-com/heygen-cli/gen"
 	"github.com/heygen-com/heygen-cli/internal/command"
 )
 
@@ -13,9 +15,10 @@ func TestTimeoutForSpec(t *testing.T) {
 		spec *command.Spec
 		want time.Duration
 	}{
-		{"multipart upload -> upload budget", &command.Spec{Group: "asset", Name: "create", BodyEncoding: "multipart"}, timeoutUpload},
-		{"pollable create -> create budget", &command.Spec{Group: "video", Name: "create", BodyEncoding: "json"}, timeoutCreate},
-		{"plain read -> default budget", &command.Spec{Group: "video", Name: "list", Method: "GET"}, timeoutRead},
+		{"multipart upload -> upload budget", &command.Spec{Method: http.MethodPost, BodyEncoding: "multipart"}, timeoutUpload},
+		{"GET read -> read budget", &command.Spec{Method: http.MethodGet}, timeoutRead},
+		{"POST write -> write budget", &command.Spec{Method: http.MethodPost, BodyEncoding: "json"}, timeoutWrite},
+		{"DELETE write -> write budget", &command.Spec{Method: http.MethodDelete}, timeoutWrite},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -23,5 +26,22 @@ func TestTimeoutForSpec(t *testing.T) {
 				t.Errorf("timeoutForSpec = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Async-create endpoints that lack a hand-written poll config must NOT fall to
+// the 30s read budget — that was the regression the method-based classification
+// fixes (an earlier version keyed off pollConfigs, which covers only 4 of the
+// async creates). Assert they get a write-or-larger budget, not read.
+func TestTimeoutForSpec_AsyncCreatesNotRead(t *testing.T) {
+	for _, spec := range []*command.Spec{
+		gen.BackgroundRemovalCreate,
+		gen.AiClippingCreate,
+		gen.AvatarCreate,
+		gen.VoiceCloneCreate,
+	} {
+		if got := timeoutForSpec(spec); got == timeoutRead {
+			t.Errorf("%s %s got the 30s read budget; async creates must get a larger budget", spec.Group, spec.Name)
+		}
 	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -527,6 +527,10 @@ func (c *Client) BaseURL() string {
 // operation class (see timeoutForSpec in cmd/heygen) so uploads and long-
 // running create calls get a larger budget than quick reads. net/http applies
 // the timeout per request, so setting it before issuing requests is safe.
+//
+// Generated commands set this in buildCobraCommand. A hand-written command that
+// issues a create or upload directly via Execute must call this itself — the
+// client otherwise keeps DefaultTimeout (30s), which only suits reads.
 func (c *Client) SetTimeout(d time.Duration) {
 	c.httpClient.Timeout = d
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -522,6 +522,15 @@ func (c *Client) BaseURL() string {
 	return c.baseURL
 }
 
+// SetTimeout sets the per-request HTTP timeout applied to subsequent requests.
+// Zero disables the timeout. The CLI sets this once per invocation from the
+// operation class (see timeoutForSpec in cmd/heygen) so uploads and long-
+// running create calls get a larger budget than quick reads. net/http applies
+// the timeout per request, so setting it before issuing requests is safe.
+func (c *Client) SetTimeout(d time.Duration) {
+	c.httpClient.Timeout = d
+}
+
 // defaultOAuthPersister writes refreshed tokens straight to the shared
 // credentials file. Tests override via WithOAuthPersister.
 type defaultOAuthPersister struct{}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -290,3 +290,23 @@ func TestClient_Do_ExtraHeadersCannotOverrideReserved(t *testing.T) {
 		t.Errorf("X-HeyGen-Source = %q, want %q", gotSource, "cli")
 	}
 }
+
+func TestNewWithCredential_DefaultTimeout(t *testing.T) {
+	c := New("key")
+	if c.httpClient.Timeout != DefaultTimeout {
+		t.Errorf("timeout = %v, want default %v", c.httpClient.Timeout, DefaultTimeout)
+	}
+}
+
+func TestSetTimeout(t *testing.T) {
+	c := New("key")
+	c.SetTimeout(2 * time.Minute)
+	if c.httpClient.Timeout != 2*time.Minute {
+		t.Errorf("timeout = %v, want 2m", c.httpClient.Timeout)
+	}
+	// Zero is an explicit "no timeout".
+	c.SetTimeout(0)
+	if c.httpClient.Timeout != 0 {
+		t.Errorf("timeout = %v, want 0 (disabled)", c.httpClient.Timeout)
+	}
+}


### PR DESCRIPTION
## Scope

**Surfaces:** API (CLI) | **Module:** HTTP client / timeouts

## Summary

The CLI applied one hard-coded 30s HTTP timeout to every request. That truncated roughly 1% of otherwise-successful video-create and asset-upload calls (whose server-side latency sits at or above 30s), while being needlessly loose for sub-second reads. This gives each operation class a timeout budget matched to its real latency.

## Root cause

A single `http.Client{Timeout: 30s}` was shared across all operations. But server-side latency differs by an order of magnitude by operation (Datadog, `api_service`, 30d):

- `POST /v3/videos` (create): p50 3.9s, **p99 30.8s** — create does synchronous work (quota/asset validation, analytics, DB insert), it is not a fast enqueue; already emitting some 504s.
- `POST /v3/assets` (upload): **p99 32.7s** — bounded by file size and client bandwidth, not server compute.
- Reads / lists: p99 < 2s.

So one global value is simultaneously too tight (create/upload) and too loose (reads).

## Fix

`timeoutForSpec` classifies each generated command by operation and picks a budget:

- multipart uploads → **10m** (matches the existing `video download` client)
- create/enqueue endpoints (those with a poll config) → **120s** (clears the ~30s p99 with headroom)
- everything else → **30s**

The policy is a runtime lookup in `cmd/heygen` (like poll configs and `--human` columns), not on the immutable generated `Spec`. It is applied via `client.SetTimeout` once per invocation in the builder (each CLI process runs a single command), covering both the plain and `--wait` paths. Deliberately not user-configurable yet — an override can be added when a real case needs one. No change to JSON output or any success path.

## Testing

Unit tests for `timeoutForSpec` (upload / create / read classes) and `client.SetTimeout`. Affected `go test` (`internal/client`, `cmd/heygen`) and `make lint` pass.
