### PR TITLE
ci: allowlist govulncheck GO-2026-5932 (unmaintained x/crypto/openpgp)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,30 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
-        run: govulncheck ./...
+        # Allowlist GO-2026-5932 ONLY: golang.org/x/crypto/openpgp is unmaintained
+        # ("Fixed in: N/A") and pulled in transitively by go-selfupdate for a PGP
+        # validator the CLI does not use — the updater verifies SHA256 checksums
+        # (ChecksumValidator), not PGP, so openpgp is never reached with untrusted
+        # input. Any OTHER advisory still fails this job. Removal tracked in API-566.
+        run: |
+          out=$(govulncheck ./... 2>&1) && rc=0 || rc=$?
+          echo "$out"
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+          # govulncheck exits 3 when vulnerabilities are found; any other non-zero
+          # code is a tool/build failure and must not be swallowed by the allowlist.
+          if [ "$rc" -ne 3 ]; then
+            echo "::error::govulncheck failed to run (exit $rc)"
+            exit 1
+          fi
+          ids=$(printf '%s\n' "$out" | grep -oE 'GO-[0-9]{4}-[0-9]+' | sort -u)
+          others=$(printf '%s\n' "$ids" | grep -vx 'GO-2026-5932' || true)
+          if [ -z "$ids" ] || [ -n "$others" ]; then
+            echo "::error::Unallowlisted or unrecognized govulncheck result (ids: ${ids:-none})"
+            exit 1
+          fi
+          echo "Only the allowlisted advisory GO-2026-5932 is present; passing."
 
   goreleaser-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope

**Surfaces:** API (CLI) | **Module:** CI / supply-chain

## Summary

`govulncheck` fails on every PR because of **GO-2026-5932**, unrelated to any recent change. This allowlists that single advisory (and only that one) so CI is unblocked, while still failing on any other vulnerability or on a govulncheck tool/build error.

## Root cause

`golang.org/x/crypto/openpgp` is unmaintained and unsafe by design — the advisory is categorical with **"Fixed in: N/A"**, so no version bump resolves it. It is pulled in transitively by `github.com/creativeprojects/go-selfupdate` (via `cmd/heygen/update.go`) for a PGP-signature validator the CLI does **not** use: the updater is configured with `ChecksumValidator{UniqueFilename: "checksums.txt"}` (SHA256 over HTTPS). So openpgp is never invoked on untrusted input — only its package `init` is reachable, which is enough for govulncheck to flag it. It fails identically on `main`.

## Fix

The govulncheck step now:

- passes when govulncheck exits 0 (no vulnerabilities);
- when govulncheck exits 3 (vulnerabilities found), passes **only if `GO-2026-5932` is the sole advisory** — any other advisory fails the job;
- fails on any other non-zero exit (a tool/build failure must not be swallowed by the allowlist).

The allowlist is a stopgap. Removing the `x/crypto/openpgp` dependency (bump/replace `go-selfupdate`) and deleting the allowlist is tracked in **API-566**.

## Testing

Ran the wrapped step locally against real `govulncheck` output: exits 3 with `GO-2026-5932` as the only advisory → step passes. Verified the guard fails on an injected second advisory and on a non-3 exit code. This PR's own CI exercises the new step end-to-end.
