### PR TITLE
auth: classify oauth loopback and token-exchange failures into distinct telemetry reasons

### DIFF
--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -479,6 +479,48 @@ func oauthFailureReason(err error) string {
 	}
 }
 
+// tokenFailureReason maps a token-endpoint error to its AUTH_LOGIN_FAILED
+// reason. Same contract as oauthFailureReason: bounded vocabulary, never
+// interpolates IdP-supplied text, and unmapped errors keep the historical
+// "token_exchange_failed" bucket so a new unwrapped path stays visible.
+//
+// The distinction that matters downstream is retryability: network, canceled,
+// and server errors are transient, whereas a rejected code needs a fresh login
+// and an invalid response means the IdP is misbehaving.
+func tokenFailureReason(err error) string {
+	switch {
+	// Order matters: all three arrive as a 400/401 TokenError, and
+	// ErrRejectionUnclassified also matches ErrRejected, so it must be tested
+	// first. ErrTokenClientConfig is a separate class, not fixable by logging in
+	// again;
+	// ErrRejectionUnclassified is a rejection we inferred from the status rather
+	// than one the IdP stated, and reporting it as a verified invalid_grant would
+	// overclaim.
+	case errors.Is(err, oauth.ErrTokenClientConfig):
+		return "token_client_error"
+	case errors.Is(err, oauth.ErrRejectionUnclassified):
+		return "token_rejected_unclassified"
+	case errors.Is(err, oauth.ErrRejected):
+		return "token_rejected"
+	case errors.Is(err, oauth.ErrTokenCanceled):
+		return "token_canceled"
+	case errors.Is(err, oauth.ErrTokenNetwork):
+		return "token_network_error"
+	case errors.Is(err, oauth.ErrTokenServerError):
+		return "token_server_error"
+	case errors.Is(err, oauth.ErrTokenRateLimited):
+		return "token_rate_limited"
+	case errors.Is(err, oauth.ErrTokenUnexpectedStatus):
+		return "token_http_error"
+	case errors.Is(err, oauth.ErrTokenResponseInvalid):
+		return "token_response_invalid"
+	case errors.Is(err, oauth.ErrTokenRequestFailed):
+		return "token_request_failed"
+	default:
+		return "token_exchange_failed"
+	}
+}
+
 // runOAuthLogin drives the browser + PKCE + loopback dance and persists
 // the resulting tokens.
 func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (err error) {
@@ -583,12 +625,15 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (e
 	tok, err := oc.ExchangeAuthorizationCode(cmdCtx, loopbackResult.Code, verifier, loopbackResult.RedirectURI)
 	if err != nil {
 		reported = true
-		loginAnalytics.AuthLoginFailed("oauth", "token_exchange_failed")
+		loginAnalytics.AuthLoginFailed("oauth", tokenFailureReason(err))
 		return clierrors.New(fmt.Sprintf("oauth: token exchange failed: %v", err))
 	}
 	if tok.AccessToken == "" {
+		// Defensive: parseTokenResponse already rejects an empty access_token, so
+		// reaching here means a future code path bypassed it. Classify it the same
+		// as any other malformed response rather than inventing a reason.
 		reported = true
-		loginAnalytics.AuthLoginFailed("oauth", "token_exchange_failed")
+		loginAnalytics.AuthLoginFailed("oauth", "token_response_invalid")
 		return clierrors.New("oauth: token endpoint returned no access_token")
 	}
 

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -450,6 +450,35 @@ func runAPIKeyLogin(cmd *cobra.Command, ctx *cmdContext) (err error) {
 	return nil
 }
 
+// oauthFailureReason maps a loopback error to its AUTH_LOGIN_FAILED
+// reason. Unmapped errors keep the historical "oauth_flow_error" bucket
+// so a future delivery site that forgets a sentinel stays visible in
+// telemetry rather than dropping out of the series.
+//
+// Keep the returned values a small fixed set: they are analytics
+// dimensions, so anything derived from IdP-supplied text would be
+// unbounded cardinality.
+func oauthFailureReason(err error) string {
+	switch {
+	case errors.Is(err, oauth.ErrLoopbackTimeout):
+		return "oauth_timeout"
+	case errors.Is(err, oauth.ErrLoopbackCanceled):
+		return "oauth_canceled"
+	case errors.Is(err, oauth.ErrAuthorizeDenied):
+		return "oauth_authorize_denied"
+	case errors.Is(err, oauth.ErrAuthorizeFailed):
+		return "oauth_authorize_failed"
+	case errors.Is(err, oauth.ErrStateMismatch):
+		return "oauth_state_mismatch"
+	case errors.Is(err, oauth.ErrMissingCode):
+		return "oauth_missing_code"
+	case errors.Is(err, oauth.ErrLoopbackServer):
+		return "oauth_loopback_failed"
+	default:
+		return "oauth_flow_error"
+	}
+}
+
 // runOAuthLogin drives the browser + PKCE + loopback dance and persists
 // the resulting tokens.
 func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (err error) {
@@ -499,6 +528,11 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (e
 
 	loopback, results, stopLoopback, err := oauth.StartLoopbackServer(cmdCtx, authLoginRedirectPath, state)
 	if err != nil {
+		// Classify here too: a bind failure never reaches the results
+		// channel, so without this it would fall through to the deferred
+		// net and be reported as a generic internal_error.
+		reported = true
+		loginAnalytics.AuthLoginFailed("oauth", oauthFailureReason(err))
 		return clierrors.New(fmt.Sprintf("oauth: loopback: %v", err))
 	}
 	defer stopLoopback()
@@ -531,17 +565,18 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (e
 		fmt.Fprintf(cmd.ErrOrStderr(), "(could not open browser automatically: %v)\n", err)
 	}
 
-	var loopbackResult oauth.LoopbackResult
-	select {
-	case <-cmdCtx.Done():
-		reported = true
-		loginAnalytics.AuthLoginFailed("oauth", "oauth_timeout")
-		return clierrors.New(fmt.Sprintf("oauth: timed out waiting for browser callback: %v", cmdCtx.Err()))
-	case loopbackResult = <-results:
-	}
+	// Block on the loopback alone rather than racing it against cmdCtx.
+	// cmdCtx already governs the loopback (it was passed to
+	// StartLoopbackServer), which converts cancellation and its own
+	// timer into exactly one delivered result. Selecting on cmdCtx here
+	// too would make two observers of one deadline, and whichever won
+	// decided the analytics reason: with a parent deadline earlier than
+	// DefaultLoopbackTimeout+30s (Ctrl-C, an agent-imposed timeout, a
+	// test) both fire in the same instant, so the label was a coin flip.
+	loopbackResult := <-results
 	if loopbackResult.Err != nil {
 		reported = true
-		loginAnalytics.AuthLoginFailed("oauth", "oauth_flow_error")
+		loginAnalytics.AuthLoginFailed("oauth", oauthFailureReason(loopbackResult.Err))
 		return clierrors.New(loopbackResult.Err.Error())
 	}
 

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -781,12 +782,13 @@ func TestRunAuthLogin_OAuthFormatterFailure_Telemetry(t *testing.T) {
 	}
 }
 
-// U4: the loopback timing out (no browser callback ever arrives) emits
-// failed(oauth, oauth_timeout). Uses a short-deadline parent context
-// instead of waiting out oauth.DefaultLoopbackTimeout (~5min) — runOAuthLogin
-// derives its own context from cmd.Context() via context.WithTimeout,
-// which honors the parent's earlier deadline.
-func TestRunOAuthLogin_LoopbackTimeout_Telemetry(t *testing.T) {
+// U4: the parent context expiring before any browser callback arrives
+// emits failed(oauth, oauth_canceled). A short-deadline parent stands in
+// for Ctrl-C or an agent-imposed timeout; runOAuthLogin derives cmdCtx
+// from cmd.Context(), which honors the parent's earlier deadline. The
+// pure DefaultLoopbackTimeout path (oauth_timeout) is covered by the
+// oauth package's own sentinel tests rather than a ~5min wait here.
+func TestRunOAuthLogin_ParentContextCanceled_Telemetry(t *testing.T) {
 	spy := withLoginAnalyticsSpy(t)
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
 
@@ -809,14 +811,14 @@ func TestRunOAuthLogin_LoopbackTimeout_Telemetry(t *testing.T) {
 
 	err := runOAuthLogin(cmd, ctx, cfg)
 	if err == nil {
-		t.Fatal("want timeout error, got nil")
+		t.Fatal("want cancellation error, got nil")
 	}
-	if !strings.Contains(err.Error(), "timed out") {
-		t.Fatalf("err = %q, want a timeout message", err.Error())
+	if !strings.Contains(err.Error(), "canceled waiting for browser callback") {
+		t.Fatalf("err = %q, want a cancellation message", err.Error())
 	}
 
-	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "oauth_timeout"}) {
-		t.Fatalf("failed = %v, want [{oauth oauth_timeout}]", got)
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "oauth_canceled"}) {
+		t.Fatalf("failed = %v, want [{oauth oauth_canceled}]", got)
 	}
 	if len(spy.completed) != 0 {
 		t.Fatalf("completed = %v, want none", spy.completed)
@@ -1068,5 +1070,56 @@ func TestRunAuthLogin_APIKeyFormatterFailure_Telemetry(t *testing.T) {
 	}
 	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"api_key", "internal_error"}) {
 		t.Fatalf("failed = %v, want [{api_key internal_error}]", got)
+	}
+}
+
+// Each loopback sentinel must map to its own analytics reason, and
+// anything unrecognized must fall back to the historical bucket rather
+// than dropping out of the series.
+func TestOAuthFailureReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"timeout", oauth.ErrLoopbackTimeout, "oauth_timeout"},
+		{"canceled", oauth.ErrLoopbackCanceled, "oauth_canceled"},
+		{"denied", oauth.ErrAuthorizeDenied, "oauth_authorize_denied"},
+		{"authorize failed", oauth.ErrAuthorizeFailed, "oauth_authorize_failed"},
+		{"state mismatch", oauth.ErrStateMismatch, "oauth_state_mismatch"},
+		{"missing code", oauth.ErrMissingCode, "oauth_missing_code"},
+		{"loopback server", oauth.ErrLoopbackServer, "oauth_loopback_failed"},
+		{"unmapped falls back", errors.New("something new"), "oauth_flow_error"},
+		{"wrapped sentinel still matches", fmt.Errorf("ctx: %w", oauth.ErrLoopbackTimeout), "oauth_timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := oauthFailureReason(tt.err); got != tt.want {
+				t.Errorf("oauthFailureReason(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// The reason set is an analytics dimension, so it must stay a small
+// fixed vocabulary. This pins it: adding a reason is fine, but it has to
+// be a deliberate edit here too.
+func TestOAuthFailureReason_BoundedVocabulary(t *testing.T) {
+	allowed := map[string]bool{
+		"oauth_timeout": true, "oauth_canceled": true,
+		"oauth_authorize_denied": true, "oauth_authorize_failed": true,
+		"oauth_state_mismatch": true, "oauth_missing_code": true,
+		"oauth_loopback_failed": true, "oauth_flow_error": true,
+	}
+	for _, err := range []error{
+		oauth.ErrLoopbackTimeout, oauth.ErrLoopbackCanceled,
+		oauth.ErrAuthorizeDenied, oauth.ErrAuthorizeFailed,
+		oauth.ErrStateMismatch, oauth.ErrMissingCode,
+		oauth.ErrLoopbackServer, errors.New("unmapped"),
+	} {
+		if got := oauthFailureReason(err); !allowed[got] {
+			t.Errorf("oauthFailureReason(%v) = %q, outside the allowed set", err, got)
+		}
 	}
 }

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -1120,6 +1121,70 @@ func TestOAuthFailureReason_BoundedVocabulary(t *testing.T) {
 	} {
 		if got := oauthFailureReason(err); !allowed[got] {
 			t.Errorf("oauthFailureReason(%v) = %q, outside the allowed set", err, got)
+		}
+	}
+}
+
+// allowedLoginFailureReasons is the full AUTH_LOGIN_FAILED vocabulary, per
+// method. These are PostHog analytics dimensions, so the set must stay small
+// and fixed; adding one has to be a deliberate edit here too.
+var allowedLoginFailureReasons = map[string]map[string]bool{
+	"oauth": {
+		// Routed through oauthFailureReason.
+		"oauth_timeout": true, "oauth_canceled": true,
+		"oauth_authorize_denied": true, "oauth_authorize_failed": true,
+		"oauth_state_mismatch": true, "oauth_missing_code": true,
+		"oauth_loopback_failed": true, "oauth_flow_error": true,
+		// Emitted as literals at their own call sites.
+		"internal_error": true, "headless_shell": true, "token_exchange_failed": true,
+	},
+	"api_key": {
+		"internal_error": true, "api_key_aborted": true, "api_key_invalid_input": true,
+	},
+	"device_code": {"device_code_unsupported": true},
+}
+
+// TestOAuthFailureReason_BoundedVocabulary pins only what the classifier
+// returns. Several reasons are emitted as bare literals at their own call
+// sites and would bypass it entirely, so scan the source too: a new literal
+// added without updating allowedLoginFailureReasons fails here.
+func TestAuthLoginFailedLiteralsAreInAllowedVocabulary(t *testing.T) {
+	src, err := os.ReadFile("auth_login.go")
+	if err != nil {
+		t.Fatalf("read auth_login.go: %v", err)
+	}
+	// Matches only literal/literal calls; the classifier-routed sites pass a
+	// function call and are covered by TestOAuthFailureReason.
+	re := regexp.MustCompile(`AuthLoginFailed\("([a-z_]+)",\s*"([a-z_]+)"\)`)
+	matches := re.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatal("no literal AuthLoginFailed call sites found — the scan would pass vacuously")
+	}
+	for _, m := range matches {
+		method, reason := m[1], m[2]
+		allowed, ok := allowedLoginFailureReasons[method]
+		if !ok {
+			t.Errorf("AuthLoginFailed uses unknown method %q; add it to allowedLoginFailureReasons", method)
+			continue
+		}
+		if !allowed[reason] {
+			t.Errorf("AuthLoginFailed(%q, %q) is not in the allowed vocabulary; these are analytics "+
+				"dimensions, so add it deliberately to allowedLoginFailureReasons", method, reason)
+		}
+	}
+}
+
+// The classifier's outputs must also live in the shared allowed set, so the
+// two pins cannot drift apart.
+func TestOAuthFailureReasonOutputsAreInAllowedVocabulary(t *testing.T) {
+	for _, err := range []error{
+		oauth.ErrLoopbackTimeout, oauth.ErrLoopbackCanceled,
+		oauth.ErrAuthorizeDenied, oauth.ErrAuthorizeFailed,
+		oauth.ErrStateMismatch, oauth.ErrMissingCode,
+		oauth.ErrLoopbackServer, errors.New("unmapped"),
+	} {
+		if got := oauthFailureReason(err); !allowedLoginFailureReasons["oauth"][got] {
+			t.Errorf("oauthFailureReason(%v) = %q, outside the allowed oauth vocabulary", err, got)
 		}
 	}
 }

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -826,8 +826,8 @@ func TestRunOAuthLogin_ParentContextCanceled_Telemetry(t *testing.T) {
 	}
 }
 
-// U4: the IdP rejecting the token exchange emits
-// failed(oauth, token_exchange_failed), no completed.
+// U4: the IdP rejecting the authorization code emits
+// failed(oauth, token_rejected), no completed.
 func TestRunOAuthLogin_TokenExchangeFailed_Telemetry(t *testing.T) {
 	spy := withLoginAnalyticsSpy(t)
 	configDir := t.TempDir()
@@ -853,11 +853,43 @@ func TestRunOAuthLogin_TokenExchangeFailed_Telemetry(t *testing.T) {
 		t.Fatalf("expected non-zero exit, got 0\nstderr: %s\nstdout: %s", res.Stderr, res.Stdout)
 	}
 
-	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "token_exchange_failed"}) {
-		t.Fatalf("failed = %v, want [{oauth token_exchange_failed}]", got)
+	// A 400 from the token endpoint is a rejected code, which needs a fresh
+	// login — not the generic bucket, and not a retryable failure.
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "token_rejected"}) {
+		t.Fatalf("failed = %v, want [{oauth token_rejected}]", got)
 	}
 	if len(spy.completed) != 0 {
 		t.Fatalf("completed = %v, want none", spy.completed)
+	}
+}
+
+// The end-to-end counterpart to the 400 case above: a 5xx must report as a
+// retryable server error rather than collapsing into the rejected reason.
+func TestRunOAuthLogin_TokenEndpoint5xx_Telemetry(t *testing.T) {
+	spy := withLoginAnalyticsSpy(t)
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
+
+	idp := newFakeIdP(t)
+	idp.tokenStatus = http.StatusInternalServerError
+	idp.tokenResponse = `upstream exploded`
+
+	cfg := oauthLoginConfig{
+		TokenURL: idp.server.URL + "/v1/oauth/token",
+		OpenBrowser: func(authURL string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				hitBrowserCallback(t, idp.expectedCode, authURL)
+			}()
+			return nil
+		},
+	}
+	res := runOAuthLoginForTest(t, cfg)
+	if res.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit, got 0\nstderr: %s", res.Stderr)
+	}
+	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"oauth", "token_server_error"}) {
+		t.Fatalf("failed = %v, want [{oauth token_server_error}]", got)
 	}
 }
 
@@ -1135,8 +1167,15 @@ var allowedLoginFailureReasons = map[string]map[string]bool{
 		"oauth_authorize_denied": true, "oauth_authorize_failed": true,
 		"oauth_state_mismatch": true, "oauth_missing_code": true,
 		"oauth_loopback_failed": true, "oauth_flow_error": true,
+		// Routed through tokenFailureReason.
+		"token_rejected": true, "token_canceled": true, "token_network_error": true,
+		"token_server_error": true, "token_http_error": true,
+		"token_rate_limited": true, "token_client_error": true,
+		"token_rejected_unclassified": true,
+		"token_response_invalid":      true, "token_request_failed": true,
+		"token_exchange_failed": true,
 		// Emitted as literals at their own call sites.
-		"internal_error": true, "headless_shell": true, "token_exchange_failed": true,
+		"internal_error": true, "headless_shell": true,
 	},
 	"api_key": {
 		"internal_error": true, "api_key_aborted": true, "api_key_invalid_input": true,
@@ -1154,7 +1193,8 @@ func TestAuthLoginFailedLiteralsAreInAllowedVocabulary(t *testing.T) {
 		t.Fatalf("read auth_login.go: %v", err)
 	}
 	// Matches only literal/literal calls; the classifier-routed sites pass a
-	// function call and are covered by TestOAuthFailureReason.
+	// function call and are covered by TestOAuthFailureReason and
+	// TestTokenFailureReason.
 	re := regexp.MustCompile(`AuthLoginFailed\("([a-z_]+)",\s*"([a-z_]+)"\)`)
 	matches := re.FindAllStringSubmatch(string(src), -1)
 	if len(matches) == 0 {
@@ -1185,6 +1225,66 @@ func TestOAuthFailureReasonOutputsAreInAllowedVocabulary(t *testing.T) {
 	} {
 		if got := oauthFailureReason(err); !allowedLoginFailureReasons["oauth"][got] {
 			t.Errorf("oauthFailureReason(%v) = %q, outside the allowed oauth vocabulary", err, got)
+		}
+	}
+}
+
+func TestTokenFailureReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"rejected code", oauth.ErrRejected, "token_rejected"},
+		{"canceled", oauth.ErrTokenCanceled, "token_canceled"},
+		{"network", oauth.ErrTokenNetwork, "token_network_error"},
+		{"5xx", oauth.ErrTokenServerError, "token_server_error"},
+		{"429", oauth.ErrTokenRateLimited, "token_rate_limited"},
+		{"client misconfigured", oauth.ErrTokenClientConfig, "token_client_error"},
+		{"rejection we inferred", fmt.Errorf("%w: %w", oauth.ErrRejected, oauth.ErrRejectionUnclassified), "token_rejected_unclassified"},
+		{"other non-2xx", oauth.ErrTokenUnexpectedStatus, "token_http_error"},
+		{"bad body", oauth.ErrTokenResponseInvalid, "token_response_invalid"},
+		{"build failure", oauth.ErrTokenRequestFailed, "token_request_failed"},
+		{"unmapped falls back", errors.New("something new"), "token_exchange_failed"},
+		{"wrapped still matches", fmt.Errorf("ctx: %w", oauth.ErrTokenNetwork), "token_network_error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tokenFailureReason(tt.err); got != tt.want {
+				t.Errorf("tokenFailureReason(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenFailureReasonOutputsAreInAllowedVocabulary(t *testing.T) {
+	for _, err := range []error{
+		oauth.ErrRejected, oauth.ErrTokenCanceled, oauth.ErrTokenNetwork,
+		oauth.ErrTokenServerError, oauth.ErrTokenUnexpectedStatus,
+		oauth.ErrTokenResponseInvalid, oauth.ErrTokenRequestFailed,
+		oauth.ErrTokenRateLimited, oauth.ErrTokenClientConfig,
+		fmt.Errorf("%w: %w", oauth.ErrRejected, oauth.ErrRejectionUnclassified),
+		errors.New("unmapped"),
+	} {
+		if got := tokenFailureReason(err); !allowedLoginFailureReasons["oauth"][got] {
+			t.Errorf("tokenFailureReason(%v) = %q, outside the allowed oauth vocabulary", err, got)
+		}
+	}
+}
+
+// A rejected code and a 5xx must not collapse into the same reason: one needs a
+// fresh login, the other is worth retrying. This is the whole point of the split.
+func TestTokenFailureReason_SeparatesRetryableFromTerminal(t *testing.T) {
+	terminal := tokenFailureReason(oauth.ErrRejected)
+	retryable := []string{
+		tokenFailureReason(oauth.ErrTokenNetwork),
+		tokenFailureReason(oauth.ErrTokenServerError),
+		tokenFailureReason(oauth.ErrTokenRateLimited),
+		tokenFailureReason(oauth.ErrTokenCanceled),
+	}
+	for _, r := range retryable {
+		if r == terminal {
+			t.Errorf("retryable reason %q collapses into the terminal reason %q", r, terminal)
 		}
 	}
 }

--- a/internal/auth/oauth/loopback.go
+++ b/internal/auth/oauth/loopback.go
@@ -19,6 +19,43 @@ import (
 // callers and pinable in tests.
 var ErrInvalidRedirectPath = errors.New("oauth: invalid redirect path")
 
+// Sentinels for every way a LoopbackResult can carry an error. Callers
+// classify with errors.Is rather than matching message text, so each
+// outcome gets its own analytics reason instead of collapsing into one
+// bucket. Every delivery site below must wrap exactly one of these.
+var (
+	// ErrLoopbackTimeout means the browser never hit the redirect URI
+	// within DefaultLoopbackTimeout. Overwhelmingly the user or agent
+	// walking away, not a fault.
+	ErrLoopbackTimeout = errors.New("oauth: timed out waiting for browser callback")
+
+	// ErrLoopbackCanceled means the caller's context was cancelled
+	// (Ctrl-C, parent shutdown) before the callback landed.
+	ErrLoopbackCanceled = errors.New("oauth: canceled waiting for browser callback")
+
+	// ErrAuthorizeDenied is the IdP reporting `error=access_denied`: the
+	// user actively declined. Split from ErrAuthorizeFailed because it is
+	// a normal outcome, whereas any other IdP error implies misconfiguration.
+	ErrAuthorizeDenied = errors.New("oauth: user denied authorization")
+
+	// ErrAuthorizeFailed is any non-access_denied `error=` from the IdP.
+	ErrAuthorizeFailed = errors.New("oauth: authorization server returned an error")
+
+	// ErrStateMismatch means the callback's state did not match the value
+	// generated alongside the PKCE pair. Possible CSRF.
+	ErrStateMismatch = errors.New("oauth: state mismatch")
+
+	// ErrMissingCode means the callback arrived without a `code` parameter.
+	ErrMissingCode = errors.New("oauth: redirect did not include code")
+
+	// ErrLoopbackServer means the local HTTP listener itself failed.
+	ErrLoopbackServer = errors.New("oauth: loopback server failed")
+)
+
+// accessDeniedCode is the RFC 6749 error code for a user-declined
+// authorization request.
+const accessDeniedCode = "access_denied"
+
 // DefaultLoopbackTimeout is how long StartLoopbackServer waits for the
 // browser to hit the redirect URI before giving up.
 const DefaultLoopbackTimeout = 5 * time.Minute
@@ -26,6 +63,8 @@ const DefaultLoopbackTimeout = 5 * time.Minute
 // LoopbackResult carries the OAuth callback parameters captured by the
 // loopback server. Either Code is populated (success) or Err is
 // populated (state mismatch, IdP error, timeout, etc.) — never both.
+// A non-nil Err always wraps one of the sentinels above, so callers can
+// classify it with errors.Is.
 type LoopbackResult struct {
 	Code        string
 	State       string
@@ -64,6 +103,16 @@ func StartLoopbackServer(
 	ctx context.Context,
 	redirectPath, expectedState string,
 ) (*LoopbackServer, <-chan LoopbackResult, func(), error) {
+	return startLoopbackServer(ctx, redirectPath, expectedState, DefaultLoopbackTimeout)
+}
+
+// startLoopbackServer takes the timeout explicitly so tests can drive the
+// timer path without a five-minute wait.
+func startLoopbackServer(
+	ctx context.Context,
+	redirectPath, expectedState string,
+	timeout time.Duration,
+) (*LoopbackServer, <-chan LoopbackResult, func(), error) {
 	if redirectPath == "" || redirectPath[0] != '/' {
 		return nil, nil, nil, fmt.Errorf("%w: must start with '/', got %q", ErrInvalidRedirectPath, redirectPath)
 	}
@@ -80,7 +129,7 @@ func StartLoopbackServer(
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("oauth: bind loopback listener: %w", err)
+		return nil, nil, nil, fmt.Errorf("%w: bind loopback listener: %w", ErrLoopbackServer, err)
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", port, redirectPath)
@@ -110,7 +159,7 @@ func StartLoopbackServer(
 		// DefaultLoopbackTimeout window.
 		err := lb.server.Serve(listener)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			lb.deliver(LoopbackResult{Err: fmt.Errorf("oauth: loopback server: %w", err)})
+			lb.deliver(LoopbackResult{Err: fmt.Errorf("%w: %w", ErrLoopbackServer, err)})
 			lb.shutdown()
 		}
 	}()
@@ -118,15 +167,15 @@ func StartLoopbackServer(
 	// Wire up timeout + context cancellation. The driver-level timeout is
 	// belt-and-braces alongside the caller-supplied context, so the
 	// browser-side hang never wedges a CLI shell longer than ~5 min.
-	timer := time.NewTimer(DefaultLoopbackTimeout)
+	timer := time.NewTimer(timeout)
 	go func() {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			lb.deliver(LoopbackResult{Err: fmt.Errorf("oauth: loopback cancelled: %w", ctx.Err())})
+			lb.deliver(LoopbackResult{Err: fmt.Errorf("%w: %w", ErrLoopbackCanceled, ctx.Err())})
 			lb.shutdown()
 		case <-timer.C:
-			lb.deliver(LoopbackResult{Err: fmt.Errorf("oauth: loopback timed out after %s", DefaultLoopbackTimeout)})
+			lb.deliver(LoopbackResult{Err: fmt.Errorf("%w after %s", ErrLoopbackTimeout, timeout)})
 			lb.shutdown()
 		case <-lb.done:
 			timer.Stop()
@@ -189,10 +238,29 @@ func (lb *LoopbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 	}
 
 	q := r.URL.Query()
+
+	// State is validated before `error`, not after. RFC 6749 §4.1.2.1
+	// requires the IdP to echo `state` on error responses too, so an
+	// unvalidated error branch would let anyone able to reach this
+	// ephemeral port abort a live login (and forge its telemetry) with a
+	// single unauthenticated GET. Order is load-bearing: do not move the
+	// `error` check above this.
+	state := q.Get("state")
+	if state == "" || subtle.ConstantTimeCompare([]byte(state), []byte(lb.ExpectedState)) != 1 {
+		writeErrorPage(w, http.StatusBadRequest, "invalid_state", "State parameter did not match.")
+		lb.deliver(LoopbackResult{Err: fmt.Errorf("%w — possible CSRF, aborting", ErrStateMismatch), RedirectURI: lb.RedirectURI})
+		go lb.shutdown()
+		return
+	}
+
 	if oauthErr := q.Get("error"); oauthErr != "" {
 		desc := q.Get("error_description")
 		writeErrorPage(w, http.StatusBadRequest, oauthErr, desc)
-		err := fmt.Errorf("oauth: authorize returned error: %s", oauthErr)
+		sentinel := ErrAuthorizeFailed
+		if oauthErr == accessDeniedCode {
+			sentinel = ErrAuthorizeDenied
+		}
+		err := fmt.Errorf("%w: %s", sentinel, oauthErr)
 		if desc != "" {
 			err = fmt.Errorf("%w — %s", err, desc)
 		}
@@ -201,18 +269,10 @@ func (lb *LoopbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	state := q.Get("state")
-	if state == "" || subtle.ConstantTimeCompare([]byte(state), []byte(lb.ExpectedState)) != 1 {
-		writeErrorPage(w, http.StatusBadRequest, "invalid_state", "State parameter did not match.")
-		lb.deliver(LoopbackResult{Err: errors.New("oauth: state mismatch — possible CSRF, aborting"), RedirectURI: lb.RedirectURI})
-		go lb.shutdown()
-		return
-	}
-
 	code := q.Get("code")
 	if code == "" {
 		writeErrorPage(w, http.StatusBadRequest, "missing_code", "Authorization code is missing from the redirect.")
-		lb.deliver(LoopbackResult{Err: errors.New("oauth: redirect did not include `code`"), RedirectURI: lb.RedirectURI})
+		lb.deliver(LoopbackResult{Err: ErrMissingCode, RedirectURI: lb.RedirectURI})
 		go lb.shutdown()
 		return
 	}

--- a/internal/auth/oauth/loopback_test.go
+++ b/internal/auth/oauth/loopback_test.go
@@ -113,6 +113,7 @@ func TestStartLoopbackServer_PropagatesIdPError(t *testing.T) {
 	cbURL := lb.RedirectURI + "?" + url.Values{
 		"error":             {"access_denied"},
 		"error_description": {"user said no"},
+		"state":             {"the-state"},
 	}.Encode()
 	resp, err := http.Get(cbURL) //nolint:noctx // test client
 	if err != nil {
@@ -229,5 +230,149 @@ func TestStartLoopbackServer_ValidatesArgs(t *testing.T) {
 				t.Errorf("did not expect ErrInvalidRedirectPath, got %v", err)
 			}
 		})
+	}
+}
+
+// Every callback-reachable error result must wrap a sentinel: the CLI
+// maps them to distinct analytics reasons with errors.Is, so an
+// unwrapped error silently collapses back into the catch-all bucket.
+// Non-callback deliveries live elsewhere: the timer in
+// TestStartLoopbackServer_TimerDeliversTimeoutSentinel, cancellation in
+// TestStartLoopbackServer_ContextCancelDelivers.
+func TestStartLoopbackServer_ErrorsWrapSentinels(t *testing.T) {
+	tests := []struct {
+		name  string
+		query url.Values
+		want  error
+	}{
+		{
+			name:  "user declined",
+			query: url.Values{"error": {"access_denied"}, "error_description": {"user said no"}, "state": {"the-state"}},
+			want:  ErrAuthorizeDenied,
+		},
+		{
+			name:  "other IdP error",
+			query: url.Values{"error": {"invalid_scope"}, "state": {"the-state"}},
+			want:  ErrAuthorizeFailed,
+		},
+		{
+			name:  "error response with wrong state is a state mismatch, not a denial",
+			query: url.Values{"error": {"access_denied"}, "state": {"attacker-state"}},
+			want:  ErrStateMismatch,
+		},
+		{
+			name:  "error response with no state is a state mismatch, not a denial",
+			query: url.Values{"error": {"access_denied"}},
+			want:  ErrStateMismatch,
+		},
+		{
+			name:  "state mismatch",
+			query: url.Values{"code": {"the-code"}, "state": {"wrong-state"}},
+			want:  ErrStateMismatch,
+		},
+		{
+			name:  "missing code",
+			query: url.Values{"state": {"the-state"}},
+			want:  ErrMissingCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			lb, results, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "the-state")
+			if err != nil {
+				t.Fatalf("StartLoopbackServer: %v", err)
+			}
+			defer stop()
+
+			resp, err := http.Get(lb.RedirectURI + "?" + tt.query.Encode()) //nolint:noctx // test client
+			if err != nil {
+				t.Fatalf("GET callback: %v", err)
+			}
+			_ = resp.Body.Close()
+
+			select {
+			case r := <-results:
+				if !errors.Is(r.Err, tt.want) {
+					t.Errorf("err = %v, want wrapping %v", r.Err, tt.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for result")
+			}
+		})
+	}
+}
+
+// access_denied must not fall into ErrAuthorizeFailed: the two are split
+// so telemetry can separate a user declining (expected) from an IdP
+// misconfiguration (our bug).
+func TestStartLoopbackServer_DeniedIsNotGenericAuthorizeFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lb, results, stop, err := StartLoopbackServer(ctx, "/oauth/callback", "the-state")
+	if err != nil {
+		t.Fatalf("StartLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	resp, err := http.Get(lb.RedirectURI + "?error=access_denied&state=the-state") //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("GET callback: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case r := <-results:
+		if !errors.Is(r.Err, ErrAuthorizeDenied) {
+			t.Fatalf("err = %v, want ErrAuthorizeDenied", r.Err)
+		}
+		if errors.Is(r.Err, ErrAuthorizeFailed) {
+			t.Errorf("access_denied must not match ErrAuthorizeFailed, got %v", r.Err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}
+
+// The timer path is what produced ~68% of production login failures, so
+// it gets a real test via the unexported timeout seam rather than a
+// five-minute wait. Covers the seam's timer branch, not the exported
+// wrapper's choice of duration.
+func TestStartLoopbackServer_TimerDeliversTimeoutSentinel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, results, stop, err := startLoopbackServer(ctx, "/oauth/callback", "the-state", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("startLoopbackServer: %v", err)
+	}
+	defer stop()
+
+	select {
+	case r := <-results:
+		if !errors.Is(r.Err, ErrLoopbackTimeout) {
+			t.Errorf("err = %v, want ErrLoopbackTimeout", r.Err)
+		}
+		// Must NOT look like cancellation: the two map to different
+		// analytics reasons and the caller distinguishes them.
+		if errors.Is(r.Err, ErrLoopbackCanceled) {
+			t.Errorf("timer result must not match ErrLoopbackCanceled, got %v", r.Err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for timer result")
+	}
+}
+
+// Pins the shipped timeout value only. It does NOT prove the exported
+// wrapper still forwards it — the timer is not observable without
+// waiting it out — so treat this as a guard against the constant
+// drifting, not against the wiring changing.
+func TestDefaultLoopbackTimeout_Unchanged(t *testing.T) {
+	if DefaultLoopbackTimeout != 5*time.Minute {
+		t.Errorf("DefaultLoopbackTimeout = %v, want 5m", DefaultLoopbackTimeout)
 	}
 }

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -232,7 +232,7 @@ func (c *Client) postTokenForm(
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.TokenURL,
 		strings.NewReader(form.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("oauth: build %s request: %w", grant, err)
+		return nil, fmt.Errorf("%w (%s): %w", ErrTokenRequestFailed, grant, err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
@@ -247,39 +247,52 @@ func (c *Client) postTokenForm(
 	requestSent := c.Now()
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("oauth: %s request: %w", grant, err)
+		return nil, classifyTransportErr(ctx, err, grant)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("oauth: read %s response: %w", grant, err)
+		// A truncated body is the same family as Do failing, and can equally be
+		// caused by the caller cancelling, so it goes through the same classifier.
+		return nil, classifyTransportErr(ctx, err, "read "+grant+" response")
 	}
 
 	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
-		// 400/401 here is the "the code/refresh was rejected" path. The
-		// PR-2 CLI surface will map this to a "log in again" UX; for now
-		// we surface a typed error with the server detail attached.
+		// 400/401 is the "rejected" family, but it covers two situations that
+		// need opposite responses: the supplied code/refresh token is unusable
+		// (re-login fixes it) versus our own client registration or request shape
+		// is wrong (re-login cannot). RFC 6749 §5.2 distinguishes them via the
+		// `error` field, so read it rather than inferring from the status alone.
 		return nil, &TokenError{
 			Status:  resp.StatusCode,
 			Grant:   grant,
 			Body:    truncate(string(body), 500),
-			Wrapped: errRejected,
+			Wrapped: sentinelForOAuthErrorCode(body),
 		}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("oauth: %s endpoint returned HTTP %d: %s",
-			grant, resp.StatusCode, truncate(string(body), 500))
+		// Three classes, three actions: retry a 5xx, back off on a 429, and treat
+		// anything else (403, a redirect) as neither.
+		sentinel := ErrTokenUnexpectedStatus
+		switch {
+		case resp.StatusCode >= 500:
+			sentinel = ErrTokenServerError
+		case resp.StatusCode == http.StatusTooManyRequests:
+			sentinel = ErrTokenRateLimited
+		}
+		return nil, fmt.Errorf("%w: %s endpoint returned HTTP %d: %s",
+			sentinel, grant, resp.StatusCode, truncate(string(body), 500))
 	}
 
 	var raw map[string]any
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("oauth: decode %s response: %w (body: %s)",
-			grant, err, truncate(string(body), 500))
+		return nil, fmt.Errorf("%w: decode %s response: %w (body: %s)",
+			ErrTokenResponseInvalid, grant, err, truncate(string(body), 500))
 	}
 	tok, err := parseTokenResponse(raw)
 	if err != nil {
-		return nil, fmt.Errorf("oauth: %s response invalid: %w", grant, err)
+		return nil, fmt.Errorf("%w: %s response: %w", ErrTokenResponseInvalid, grant, err)
 	}
 	tok.IssuedAt = requestSent
 	return tok, nil
@@ -291,8 +304,11 @@ func (c *Client) postTokenForm(
 var errRejected = errors.New("oauth: credential rejected by token endpoint")
 
 // TokenError is returned by ExchangeAuthorizationCode / RefreshAccessToken
-// when the IdP returns 400 or 401. Callers can use errors.Is(err, ErrRejected)
-// to drive a re-login UX.
+// when the IdP returns 400 or 401. Wrapped carries the classification: either
+// ErrTokenClientConfig (our request or registration is wrong, re-login will not
+// help) or ErrRejected, optionally alongside ErrRejectionUnclassified when the
+// body stated no reason. errors.Is(err, ErrRejected) remains the signal for a
+// re-login UX.
 type TokenError struct {
 	Status  int
 	Grant   string
@@ -306,8 +322,122 @@ func (e *TokenError) Error() string {
 
 func (e *TokenError) Unwrap() error { return e.Wrapped }
 
-// ErrRejected is the sentinel for a 400/401 from the token endpoint.
+// ErrRejected is the sentinel for a 400/401 from the token endpoint whose error
+// code blames the supplied credential (or that carries no usable code).
 var ErrRejected = errRejected
+
+// clientConfigErrorCodes are the RFC 6749 §5.2 codes that indicate the request
+// or the client itself is at fault, not the credential being presented.
+// invalid_grant is deliberately absent: that one IS the credential.
+var clientConfigErrorCodes = map[string]bool{
+	"invalid_request":        true,
+	"invalid_client":         true,
+	"unauthorized_client":    true,
+	"unsupported_grant_type": true,
+	"invalid_scope":          true,
+}
+
+// ErrRejectionUnclassified marks a 400/401 that could not be attributed to a
+// specific RFC 6749 §5.2 code — an unparseable body, a missing `error` field, or
+// a well-formed code outside the six core ones — so "the credential was
+// refused" is inferred from the status rather than stated by the IdP.
+//
+// It is wrapped ALONGSIDE ErrRejected, not instead of it. internal/client keys
+// its re-login prompt off ErrRejected, and a 400/401 from a token endpoint
+// overwhelmingly does mean a refused credential — gateway and infrastructure
+// failures arrive as 5xx, which is classified separately. Demoting this case
+// out of ErrRejected would leave a user holding a dead refresh token with no
+// prompt to re-authenticate, which is a worse failure than occasionally
+// suggesting a re-login that turns out to be unnecessary. The marker exists so
+// telemetry can separate a verified invalid_grant from an inferred rejection
+// without changing that behavior.
+var ErrRejectionUnclassified = errRejectionUnclassified
+
+var errRejectionUnclassified = errors.New("oauth: rejection reason not stated by the IdP")
+
+// sentinelForOAuthErrorCode picks the 400/401 sentinel from the response body's
+// RFC 6749 §5.2 `error` field.
+func sentinelForOAuthErrorCode(body []byte) error {
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil || parsed.Error == "" {
+		return fmt.Errorf("%w: %w", errRejected, errRejectionUnclassified)
+	}
+	if clientConfigErrorCodes[parsed.Error] {
+		return ErrTokenClientConfig
+	}
+	if parsed.Error == "invalid_grant" {
+		return errRejected
+	}
+	// A well-formed but unrecognized code: still a rejection for behavior
+	// purposes, still not one we can attribute.
+	return fmt.Errorf("%w: %w", errRejected, errRejectionUnclassified)
+}
+
+// classifyTransportErr distinguishes the caller giving up from the transport
+// failing. It reads ctx.Err() rather than inspecting err, because an
+// http.Client.Timeout error also satisfies errors.Is(err,
+// context.DeadlineExceeded) while the caller's context is still live — matching
+// on the chain would report a slow IdP as a user cancellation.
+func classifyTransportErr(ctx context.Context, err error, what string) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("%w (%s): %w", ErrTokenCanceled, what, err)
+	}
+	return fmt.Errorf("%w (%s): %w", ErrTokenNetwork, what, err)
+}
+
+// Sentinels for the token-endpoint failures that are NOT a credential
+// rejection. ErrRejected already covers 400/401; these cover the rest, so a
+// caller can tell "retry this" from "log in again" from "the IdP is broken"
+// instead of collapsing all of them into one bucket.
+//
+// Three mutually exclusive behavioral classes: transient (network, canceled,
+// server error, rate limited), terminal-for-the-client (client config, response
+// invalid, request failed), and credential-rejected (ErrRejected). Every
+// non-nil error out of postTokenForm wraps exactly one of them — with one
+// deliberate overlap: an unattributable rejection wraps ErrRejected AND
+// ErrRejectionUnclassified, so behavior stays put while telemetry can tell them
+// apart. See ErrRejectionUnclassified.
+var (
+	// ErrTokenRequestFailed means the request could not even be built
+	// (malformed token URL). Programmer error, not a runtime condition.
+	ErrTokenRequestFailed = errors.New("oauth: could not build token request")
+
+	// ErrTokenNetwork means the request never completed: DNS, TLS, connection
+	// reset, or a truncated response body. Retryable.
+	ErrTokenNetwork = errors.New("oauth: token request did not complete")
+
+	// ErrTokenCanceled means the CALLER's context ended mid-exchange (Ctrl-C or
+	// an agent-imposed deadline). Nothing is wrong upstream, which is why it is
+	// separate from ErrTokenNetwork. Determined from ctx.Err(), never from the
+	// returned error: an http.Client.Timeout error also satisfies
+	// errors.Is(err, context.DeadlineExceeded) even when the caller's context is
+	// perfectly healthy, so matching on the chain would mislabel it.
+	ErrTokenCanceled = errors.New("oauth: token request canceled by caller")
+
+	// ErrTokenServerError is a 5xx from the token endpoint. Retryable.
+	ErrTokenServerError = errors.New("oauth: token endpoint server error")
+
+	// ErrTokenRateLimited is a 429. Retryable, but only with backoff — which is
+	// why it is not folded into ErrTokenUnexpectedStatus.
+	ErrTokenRateLimited = errors.New("oauth: token endpoint rate limited")
+
+	// ErrTokenUnexpectedStatus is any other non-2xx that is not 400/401, 429, or
+	// 5xx — e.g. 403 or a redirect.
+	ErrTokenUnexpectedStatus = errors.New("oauth: token endpoint returned an unexpected status")
+
+	// ErrTokenClientConfig is a 400/401 whose RFC 6749 §5.2 error code blames the
+	// client or the request rather than the supplied credential (invalid_client,
+	// unauthorized_client, invalid_request, unsupported_grant_type,
+	// invalid_scope). Split from ErrRejected because re-authenticating cannot fix
+	// it — the CLI's own registration or request shape is wrong.
+	ErrTokenClientConfig = errors.New("oauth: token request rejected as malformed or unauthorized client")
+
+	// ErrTokenResponseInvalid means a 2xx body that could not be decoded or was
+	// missing required fields. The IdP is misbehaving; retrying will not help.
+	ErrTokenResponseInvalid = errors.New("oauth: token response invalid")
+)
 
 func parseTokenResponse(obj map[string]any) (*TokenResponse, error) {
 	accessToken, ok := stringField(obj, "access_token")

--- a/internal/auth/oauth/oauth_test.go
+++ b/internal/auth/oauth/oauth_test.go
@@ -354,3 +354,304 @@ func TestExchangeAuthorizationCode_ContextCancellation(t *testing.T) {
 		t.Fatal("expected timeout error")
 	}
 }
+
+// Every token-endpoint failure must wrap a distinct sentinel. The CLI maps them
+// to separate analytics reasons with errors.Is, so an unwrapped error collapses
+// back into the catch-all bucket this split exists to eliminate.
+func TestPostTokenForm_ErrorsWrapSentinels(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler func(w http.ResponseWriter, r *http.Request)
+		want    error
+		notWant error
+	}{
+		{
+			name: "400 rejected code",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+			},
+			want:    ErrRejected,
+			notWant: ErrTokenServerError,
+		},
+		{
+			name: "401 invalid_client blames our config, not the credential",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"invalid_client"}`, http.StatusUnauthorized)
+			},
+			want:    ErrTokenClientConfig,
+			notWant: ErrRejected,
+		},
+		{
+			name: "400 unsupported_grant_type is also a client error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"unsupported_grant_type"}`, http.StatusBadRequest)
+			},
+			want:    ErrTokenClientConfig,
+			notWant: ErrRejected,
+		},
+		{
+			name: "400 invalid_grant is a verified rejection",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+			},
+			want:    ErrRejected,
+			notWant: ErrRejectionUnclassified,
+		},
+		{
+			name: "400 invalid_request is a client error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"invalid_request"}`, http.StatusBadRequest)
+			},
+			want:    ErrTokenClientConfig,
+			notWant: ErrRejected,
+		},
+		{
+			name: "401 unauthorized_client is a client error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"unauthorized_client"}`, http.StatusUnauthorized)
+			},
+			want:    ErrTokenClientConfig,
+			notWant: ErrRejected,
+		},
+		{
+			name: "400 invalid_scope is a client error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"invalid_scope"}`, http.StatusBadRequest)
+			},
+			want:    ErrTokenClientConfig,
+			notWant: ErrRejected,
+		},
+		{
+			name: "400 with an unparseable body is an unclassified rejection",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `<html>gateway</html>`, http.StatusBadRequest)
+			},
+			want:    ErrRejectionUnclassified,
+			notWant: ErrTokenClientConfig,
+		},
+		{
+			name: "400 with no error field is an unclassified rejection",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"detail":"nope"}`, http.StatusBadRequest)
+			},
+			want:    ErrRejectionUnclassified,
+			notWant: ErrTokenClientConfig,
+		},
+		{
+			name: "400 with an unrecognized code is an unclassified rejection",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, `{"error":"some_future_code"}`, http.StatusBadRequest)
+			},
+			want:    ErrRejectionUnclassified,
+			notWant: ErrTokenClientConfig,
+		},
+		{
+			name:    "500 is a server error, not a rejection",
+			handler: func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "boom", http.StatusInternalServerError) },
+			want:    ErrTokenServerError,
+			notWant: ErrRejected,
+		},
+		{
+			name: "503 is a server error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			},
+			want:    ErrTokenServerError,
+			notWant: ErrRejected,
+		},
+		{
+			name:    "403 is neither rejection nor server error",
+			handler: func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "nope", http.StatusForbidden) },
+			want:    ErrTokenUnexpectedStatus,
+			notWant: ErrRejected,
+		},
+		{
+			name:    "429 needs backoff, so it is its own class",
+			handler: func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "slow down", http.StatusTooManyRequests) },
+			want:    ErrTokenRateLimited,
+			notWant: ErrTokenUnexpectedStatus,
+		},
+		{
+			name: "unparseable body",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `not json at all`)
+			},
+			want:    ErrTokenResponseInvalid,
+			notWant: ErrRejected,
+		},
+		{
+			name: "200 without access_token",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"token_type":"Bearer","expires_in":3600}`)
+			},
+			want:    ErrTokenResponseInvalid,
+			notWant: ErrTokenNetwork,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idp := newFakeIdP(t)
+			idp.tokenHandler = tt.handler
+			c := idp.client(t)
+
+			_, err := c.ExchangeAuthorizationCode(context.Background(), "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !errors.Is(err, tt.want) {
+				t.Errorf("err = %v, want wrapping %v", err, tt.want)
+			}
+			if errors.Is(err, tt.notWant) {
+				t.Errorf("err = %v must NOT match %v — the two reasons drive different actions", err, tt.notWant)
+			}
+		})
+	}
+}
+
+// A cancelled context is not an upstream fault and must not report as a network
+// failure; the CLI reports them as different reasons.
+func TestPostTokenForm_CanceledContextIsNotNetworkError(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"AT"}`)
+	}
+	c := idp.client(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.ExchangeAuthorizationCode(ctx, "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, ErrTokenCanceled) {
+		t.Errorf("err = %v, want wrapping ErrTokenCanceled", err)
+	}
+	if errors.Is(err, ErrTokenNetwork) {
+		t.Errorf("err = %v must not also match ErrTokenNetwork", err)
+	}
+}
+
+// An unreachable endpoint is a transport failure, distinct from every
+// server-response case above.
+func TestPostTokenForm_UnreachableEndpointIsNetworkError(t *testing.T) {
+	c := NewClient(WithTokenURL("http://127.0.0.1:1/v1/oauth/token"))
+
+	_, err := c.ExchangeAuthorizationCode(context.Background(), "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, ErrTokenNetwork) {
+		t.Errorf("err = %v, want wrapping ErrTokenNetwork", err)
+	}
+	if errors.Is(err, ErrRejected) || errors.Is(err, ErrTokenServerError) {
+		t.Errorf("err = %v must not match a server-response sentinel", err)
+	}
+}
+
+// An http.Client.Timeout error satisfies errors.Is(err,
+// context.DeadlineExceeded) even when the caller's context is untouched, so a
+// classifier that inspected the error chain would report a slow IdP as a user
+// cancellation. ctx.Err() is the only signal that actually means "the caller
+// gave up".
+func TestPostTokenForm_ClientTimeoutIsNetworkNotCanceled(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+	}
+	c := idp.client(t)
+	c.HTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+
+	// Background context: never cancelled, so only Client.Timeout fires.
+	_, err := c.ExchangeAuthorizationCode(context.Background(), "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("precondition failed: Client.Timeout error should match context.DeadlineExceeded, got %v", err)
+	}
+	if !errors.Is(err, ErrTokenNetwork) {
+		t.Errorf("err = %v, want wrapping ErrTokenNetwork", err)
+	}
+	if errors.Is(err, ErrTokenCanceled) {
+		t.Errorf("err = %v must NOT be ErrTokenCanceled — the caller never cancelled", err)
+	}
+}
+
+// A URL the request builder cannot parse is a programmer error, and the only
+// path that produces ErrTokenRequestFailed.
+func TestPostTokenForm_UnbuildableRequest(t *testing.T) {
+	c := NewClient(WithTokenURL("http://\x7f invalid/v1/oauth/token"))
+
+	_, err := c.ExchangeAuthorizationCode(context.Background(), "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+	if err == nil {
+		t.Fatal("expected a request-build error")
+	}
+	if !errors.Is(err, ErrTokenRequestFailed) {
+		t.Errorf("err = %v, want wrapping ErrTokenRequestFailed", err)
+	}
+	if errors.Is(err, ErrTokenNetwork) {
+		t.Errorf("err = %v must not look like a transport failure — nothing was sent", err)
+	}
+}
+
+// internal/client keys its re-login prompt off ErrRejected, so an unclassified
+// rejection MUST keep matching it. Demoting that case would leave a user with a
+// dead refresh token and no prompt to re-authenticate — a worse outcome than
+// occasionally suggesting an unnecessary re-login.
+func TestUnclassifiedRejectionStillMatchesErrRejected(t *testing.T) {
+	for _, body := range []string{`<html>gateway</html>`, `{"detail":"nope"}`, `{"error":"some_future_code"}`} {
+		t.Run(body, func(t *testing.T) {
+			idp := newFakeIdP(t)
+			idp.tokenHandler = func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, body, http.StatusBadRequest)
+			}
+			c := idp.client(t)
+
+			_, err := c.ExchangeAuthorizationCode(context.Background(), "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+			if !errors.Is(err, ErrRejected) {
+				t.Errorf("err = %v must still match ErrRejected — internal/client drives re-login off it", err)
+			}
+			if !errors.Is(err, ErrRejectionUnclassified) {
+				t.Errorf("err = %v should also carry ErrRejectionUnclassified for telemetry", err)
+			}
+		})
+	}
+}
+
+// The body-read path goes through the same classifier as Do, so cancelling
+// mid-read must report as cancellation rather than a transport fault. Serves a
+// Content-Length larger than the bytes actually written so ReadAll blocks.
+func TestPostTokenForm_CanceledDuringBodyRead(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.tokenHandler = func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "4096")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			_, _ = io.WriteString(w, `{"access_token":"AT"`)
+			f.Flush()
+		}
+		time.Sleep(2 * time.Second)
+	}
+	c := idp.client(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	_, err := c.ExchangeAuthorizationCode(ctx, "the-code", "the-verifier", "http://127.0.0.1:8080/cb")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, ErrTokenCanceled) {
+		t.Errorf("err = %v, want wrapping ErrTokenCanceled", err)
+	}
+	if errors.Is(err, ErrTokenNetwork) {
+		t.Errorf("err = %v must not also match ErrTokenNetwork", err)
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -282,7 +282,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		refreshed, refreshErr := c.refreshIfTokenUnchanged(ctx, credSnap.AccessToken)
 		if refreshErr != nil {
 			// Discriminate between "IdP said no" (rejected) and any other
-			// transient failure (network, 5xx, ctx cancel). Only the
+			// non-rejection failure — transient (network, 5xx, ctx cancel) or
+			// terminal for us (a malformed request / bad client registration). Only the
 			// rejected branch tells the user re-login is needed; the
 			// transient branch surfaces the underlying error as-is so
 			// the executor renders something accurate. (W1)
@@ -417,8 +418,9 @@ func (c *Client) ensureFreshOAuthToken(ctx context.Context) (bool, error) {
 
 	if _, err := c.forceRefresh(ctx); err != nil {
 		// Same W1 discrimination as the post-401 path: only an IdP
-		// rejection signals re-login is needed; transient failures
-		// surface as-is so the executor can render a useful error.
+		// rejection signals re-login is needed. Everything else — transient
+		// or terminal-for-us — surfaces as-is so the executor renders
+		// something accurate.
 		if errors.Is(err, oauth.ErrRejected) {
 			return false, fmt.Errorf("%w: %v", ErrReLoginNeeded, err)
 		}
@@ -453,7 +455,9 @@ func (c *Client) needsRefresh() bool {
 // in-memory credential + persists the new tokens. Returns true when a
 // new access token was minted. Callers handle the err side: a real
 // network/IdP failure stays a refresh error; an IdP 400/401 (token
-// rejected) bubbles up wrapped in oauth.ErrRejected so callers can
+// rejected) bubbles up wrapped in oauth.ErrRejected — including the case where
+// the IdP stated no reason, which also carries oauth.ErrRejectionUnclassified —
+// so callers can
 // errors.Is-discriminate the re-login case.
 func (c *Client) forceRefresh(ctx context.Context) (bool, error) {
 	if c.oauthClient == nil {


### PR DESCRIPTION
## Scope

**Surfaces:** CLI | **Module:** Auth (OAuth login)

## Summary

Every OAuth loopback failure reported the same `AUTH_LOGIN_FAILED` telemetry reason, so a single bucket held "user clicked Deny", "possible CSRF", and "nobody was at the keyboard for five minutes" indistinguishably. Each outcome now gets its own reason. While fixing the callback handler this also corrected an ordering bug where the OAuth `state` parameter was not validated before an `error=` response was trusted.

## Root cause

`StartLoopbackServer` can deliver a `LoopbackResult` error from six structurally different places: its own timer, context cancellation, an IdP `error=` response, a state mismatch, a redirect missing `code`, and a `Serve()` failure. All six built untyped errors, so the caller could only flatten them into one reason string.

A second path made this worse. `runOAuthLogin` selected on both the results channel and `cmdCtx`, where `cmdCtx` was `DefaultLoopbackTimeout + 30s`. The intent was a watchdog strictly outliving the inner timer, but `context.WithTimeout` takes the *earlier* of the parent deadline and the new one, so whenever the parent had a shorter deadline (Ctrl-C, an agent-imposed timeout) both arms fired in the same instant and whichever won decided the reason. Two observers of one deadline cannot be ordered.

Twenty-one days of production telemetry show the effect precisely: the catch-all reason appeared 1,093 times against exactly one occurrence of the timeout reason, even though 68% of failed `heygen auth login` runs have a `duration_ms` median of exactly 300000ms, which is `DefaultLoopbackTimeout` firing.

Separately, `handleCallback` branched on the `error` query parameter before validating `state`, so anyone able to reach the ephemeral loopback port could abort a live login with an unauthenticated `GET /oauth/callback?error=access_denied`.

## Fix

The loopback package exports a sentinel per outcome and wraps exactly one at every delivery site. The CLI classifies with `errors.Is`. Unrecognized errors keep the historical catch-all value, so a future delivery site that forgets a sentinel stays visible in telemetry rather than dropping out of the series.

`access_denied` is split from other IdP errors deliberately: a user declining is a normal outcome we want to exclude from the defect rate, whereas any other code implies misconfiguration.

The reason vocabulary is a fixed set of string literals and never interpolates IdP-supplied text, since these are analytics dimensions and unbounded cardinality would be unusable. A test scans every literal `AuthLoginFailed` call site — not just the classifiers' outputs — against one shared allowed set, so a new reason added anywhere has to be a deliberate edit.

The `cmdCtx` arm of the select is removed. `cmdCtx` already governs the loopback and is turned into exactly one delivered result, so observing it twice only created the race; blocking on the channel alone makes the reason deterministic. Timeout protection is unchanged.

`state` is now validated before the `error` branch, per RFC 6749 §4.1.2.1, which requires the authorization server to echo `state` on error responses. The ordering is marked load-bearing in a comment. Listener bind failures now carry the loopback-server sentinel and are classified at the call site instead of falling through to a generic `internal_error`.

### Token exchange, same defect

`token_exchange_failed` had the identical problem 50 lines below the loopback code, and the first pass missed it because the telemetry evidence only pointed at the loopback. One reason string covered a rejected authorization code, a 5xx, a transport failure, a 403, a 429, an unparseable 2xx body, and a cancelled context.

`postTokenForm` now wraps a sentinel per outcome, and the caller classifies with `errors.Is` the same way. Three points worth calling out:

**Caller cancellation is read from `ctx.Err()`, not the error chain.** An `http.Client.Timeout` error satisfies `errors.Is(err, context.DeadlineExceeded)` even when the caller's context is untouched — verified with a standalone probe — so chain matching would report a slow IdP as a user cancellation. Client timeouts fold into the network reason rather than getting their own, since the caller action is identical.

**400/401 reads the RFC 6749 §5.2 `error` code.** `invalid_client`, `unauthorized_client`, `invalid_request`, `unsupported_grant_type`, and `invalid_scope` are a separate class from `invalid_grant`: re-authenticating cannot fix our own client registration or request shape. 429 is also split out, since it is the one that needs backoff.

**An unattributable 400/401 wraps two sentinels on purpose.** `ErrRejected` is not only a telemetry label — `internal/client` keys its re-login prompt off it. So an unparseable body, a missing `error` field, or an unrecognized code keeps matching `ErrRejected` (preserving that prompt) while also carrying `ErrRejectionUnclassified` so telemetry does not claim a verified `invalid_grant`. Demoting it out of `ErrRejected` would leave a user with a dead refresh token stuck behind a generic recurring failure, which is worse than occasionally suggesting an unnecessary re-login.

No change to the successful login path.

**One behavioral risk worth flagging:** if the deployed authorization server omits `state` on Deny redirects, genuine denials will surface as a state mismatch rather than a denial. The RFC requires it and this client always sends a non-empty state, but the server's actual behavior could not be verified from this repo. The new reason split makes it immediately visible if it happens.

## Testing

Loopback package: table-driven coverage that every callback-reachable error wraps its sentinel, including new cases proving `error=access_denied` with a wrong state and with no state both yield a state mismatch rather than a denial; a test that `access_denied` does not match the generic IdP-error sentinel; and a test driving the timer path through an unexported timeout seam so the five-minute branch is exercised in 50ms rather than skipped.

CLI: the classifier is pinned per sentinel, including that a wrapped sentinel still matches and that an unmapped error falls back to the catch-all. A second test pins the reason vocabulary to its allowed set so adding a value requires a deliberate edit. The existing timeout-telemetry test was renamed to match what it actually exercises (parent-context cancellation) and now asserts the cancellation reason.

Token endpoint: every outcome is driven through a fake IdP and asserted on both the sentinel it wraps and one it must NOT match, since the whole point is that retryable and terminal reasons stay distinct. All six RFC 6749 §5.2 core codes are pinned, plus the three unattributable shapes (unparseable body, missing `error`, unrecognized code). One test pins the invariant that an unattributable rejection still matches `ErrRejected`, so the re-login prompt in `internal/client` cannot be broken by a future narrowing. A client-timeout test asserts the `ctx.Err()` behavior described above.

`make lint` reports 0 issues, `make test` passes, and the changed packages also pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
