### PR TITLE
feat(auth): add device authorization login

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Run `heygen completion --help` for per-shell install instructions.
 
 ## Authenticate
 
-Choose one of the options below. The first three are agent- and CI-friendly; the last two are for humans.
+Choose one of the options below. The first three are agent- and CI-friendly; the remaining options are for humans.
 
 **1. Environment variable** — agents, CI; ephemeral, no file on disk:
 
@@ -85,7 +85,15 @@ heygen auth login --api-key
 heygen auth login --oauth
 ```
 
-**5. Interactive picker** — humans, no flag: a TTY prompt lets you choose between API key (uses API credits) and OAuth (uses subscription credits):
+**5. Device OAuth** — humans in an attended SSH/headless terminal; open the displayed URL on any browser and enter the one-time code:
+
+```bash
+heygen auth login --device
+```
+
+Device OAuth is refused in CI and `HEYGEN_NONINTERACTIVE` mode. Unattended agents must use an API key.
+
+**6. Interactive picker** — humans, no flag: a TTY prompt lets you choose between API key (uses API credits) and OAuth (uses subscription credits):
 
 ```bash
 heygen auth login

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,11 @@ Official CLI for the HeyGen video generation API. 30+ commands auto-generated fr
 - **Install**: `curl -fsSL https://static.heygen.ai/cli/install.sh | bash`
 - **Auth**: Requires `HEYGEN_API_KEY` environment variable. The key must be provisioned by a user from https://app.heygen.com/settings/api
 
+For attended human setup in a remote/headless terminal, `heygen auth login
+--device` can provision the shared `~/.heygen/credentials` OAuth session.
+Agents and CI must continue using `HEYGEN_API_KEY`; device login deliberately
+refuses unattended environments.
+
 ## Key Commands
 
 ```bash

--- a/cmd/heygen/auth.go
+++ b/cmd/heygen/auth.go
@@ -8,7 +8,7 @@ import (
 
 // authGuidance is the single source of truth for how to set up CLI auth.
 // Referenced by auth_login.go, auth_status.go, and the auth group help below.
-var authGuidance = `Two ways to authenticate:
+var authGuidance = `Three ways to authenticate:
 
   1. API key (uses API credits, interactive prompt or piped on stdin):
        heygen auth login --api-key
@@ -17,10 +17,17 @@ var authGuidance = `Two ways to authenticate:
   2. Browser OAuth (uses subscription credits — opens https://app.heygen.com):
        heygen auth login --oauth
 
+  3. Device OAuth (attended remote/headless terminal):
+       heygen auth login --device
+
 In an interactive shell, plain "heygen auth login" presents a picker
 defaulted to the API-key path. Non-interactive shells (piped stdin,
 CI=true, HEYGEN_NONINTERACTIVE=1) skip the picker and run the API-key
 flow so agents and scripts keep working unchanged.
+
+Device OAuth is for a human operating a remote terminal. It is refused
+in CI and HEYGEN_NONINTERACTIVE mode; unattended automation must use an
+API key.
 
 The HEYGEN_API_KEY environment variable always takes priority over
 any stored credential when both are set.

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -66,6 +66,19 @@ type oauthLoginConfig struct {
 	Now            func() time.Time
 }
 
+type deviceLoginConfig struct {
+	ClientID               string
+	DeviceAuthorizationURL string
+	TokenURL               string
+	RevokeURL              string
+	UsersMeBaseURL         string
+	Resource               string
+	Scopes                 string
+	Now                    func() time.Time
+	Sleep                  func(context.Context, time.Duration) error
+	Attended               func() bool
+}
+
 var defaultOAuthLoginConfig = oauthLoginConfig{
 	AuthorizeURL: oauth.DefaultAuthorizeURL,
 	TokenURL:     oauth.DefaultTokenURL,
@@ -133,6 +146,7 @@ func isHeadlessOAuthShell() bool {
 func newAuthLoginCmd(ctx *cmdContext) *cobra.Command {
 	var apiKeyMode bool
 	var oauthMode bool
+	var deviceMode bool
 	var deviceCodeMode bool
 
 	cmd := &cobra.Command{
@@ -154,6 +168,7 @@ so unattended agents and scripts keep working unchanged.
 Flags skip the picker:
   --api-key   Read an API key from stdin (interactive prompt or pipe)
   --oauth     Start the browser OAuth flow directly
+  --device    Start an attended device-code flow for remote terminals
 
 The OAuth flow opens your default browser to
 https://app.heygen.com/oauth/authorize and waits for the redirect on a
@@ -175,14 +190,17 @@ time. heygen auth status reports which is active.`,
 			return runAuthLogin(cmd, ctx, authLoginFlags{
 				apiKeyMode:     apiKeyMode,
 				oauthMode:      oauthMode,
+				deviceMode:     deviceMode,
 				deviceCodeMode: deviceCodeMode,
 			})
 		},
 	}
 	cmd.Flags().BoolVar(&apiKeyMode, "api-key", false, "Skip the picker and use API-key login (read key from stdin)")
 	cmd.Flags().BoolVar(&oauthMode, "oauth", false, "Skip the picker and start the browser OAuth flow")
-	cmd.Flags().BoolVar(&deviceCodeMode, "device-code", false, "Use device-code OAuth flow (not yet supported)")
-	cmd.MarkFlagsMutuallyExclusive("api-key", "oauth")
+	cmd.Flags().BoolVar(&deviceMode, "device", false, "Start attended device-code login (remote/headless terminals)")
+	cmd.Flags().BoolVar(&deviceCodeMode, "device-code", false, "Alias for --device")
+	_ = cmd.Flags().MarkHidden("device-code")
+	cmd.MarkFlagsMutuallyExclusive("api-key", "oauth", "device", "device-code")
 	return cmd
 }
 
@@ -192,6 +210,7 @@ time. heygen auth status reports which is active.`,
 type authLoginFlags struct {
 	apiKeyMode     bool
 	oauthMode      bool
+	deviceMode     bool
 	deviceCodeMode bool
 }
 
@@ -206,6 +225,7 @@ type runAuthLoginDeps struct {
 	nonInteractive   func() bool
 	runPicker        func(ctx context.Context, stdin io.Reader, stderr io.Writer) (loginChoice, error)
 	runOAuth         func(cmd *cobra.Command, ctx *cmdContext) error
+	runDevice        func(cmd *cobra.Command, ctx *cmdContext) error
 	runAPIKey        func(cmd *cobra.Command, ctx *cmdContext) error
 }
 
@@ -219,14 +239,6 @@ var runAuthLoginTestDeps *runAuthLoginDeps
 // picker if both stdin and stdout are TTYs AND no non-interactive
 // override is in effect, else we default to the API-key flow.
 func runAuthLogin(cmd *cobra.Command, ctx *cmdContext, flags authLoginFlags) error {
-	if flags.deviceCodeMode {
-		loginAnalytics.AuthLoginStarted("device_code")
-		loginAnalytics.AuthLoginFailed("device_code", "device_code_unsupported")
-		return clierrors.NewUsage(
-			"--device-code is not yet supported; use the default browser flow or --api-key",
-		)
-	}
-
 	deps := runAuthLoginDeps{}
 	if runAuthLoginTestDeps != nil {
 		deps = *runAuthLoginTestDeps
@@ -248,11 +260,19 @@ func runAuthLogin(cmd *cobra.Command, ctx *cmdContext, flags authLoginFlags) err
 			return runOAuthLogin(c, x, defaultOAuthLoginConfig)
 		}
 	}
+	if deps.runDevice == nil {
+		deps.runDevice = func(c *cobra.Command, x *cmdContext) error {
+			return runDeviceLogin(c, x, deviceLoginConfigFromEnvironment(x))
+		}
+	}
 	if deps.runAPIKey == nil {
 		deps.runAPIKey = runAPIKeyLogin
 	}
 
 	switch {
+	case flags.deviceMode || flags.deviceCodeMode:
+		loginAnalytics.AuthLoginStarted("device")
+		return deps.runDevice(cmd, ctx)
 	case flags.oauthMode:
 		loginAnalytics.AuthLoginStarted("oauth")
 		return deps.runOAuth(cmd, ctx)
@@ -521,6 +541,191 @@ func tokenFailureReason(err error) string {
 	}
 }
 
+func deviceLoginConfigFromEnvironment(ctx *cmdContext) deviceLoginConfig {
+	resource := strings.TrimSpace(os.Getenv("HEYGEN_OAUTH_RESOURCE"))
+	if resource == "" && ctx.configProvider != nil {
+		resource = ctx.configProvider.BaseURL()
+	}
+	return deviceLoginConfig{
+		ClientID:               strings.TrimSpace(os.Getenv("HEYGEN_OAUTH_CLIENT_ID")),
+		DeviceAuthorizationURL: strings.TrimSpace(os.Getenv("HEYGEN_OAUTH_DEVICE_URL")),
+		TokenURL:               strings.TrimSpace(os.Getenv("HEYGEN_OAUTH_TOKEN_URL")),
+		RevokeURL:              strings.TrimSpace(os.Getenv("HEYGEN_OAUTH_REVOKE_URL")),
+		Resource:               resource,
+		Scopes:                 oauth.DefaultScopes,
+		Attended: func() bool {
+			return stdinIsTerminalFunc() && stdoutIsTerminalFunc() && !nonInteractiveEnvFunc()
+		},
+	}
+}
+
+// runDeviceLogin drives an explicitly attended RFC 8628 flow. Unlike the
+// legacy browser flow, it treats /v3/users/me as part of authentication:
+// tokens are not written until identity verification succeeds, and any minted
+// tokens are revoked if verification or the atomic credential write fails.
+func runDeviceLogin(cmd *cobra.Command, ctx *cmdContext, cfg deviceLoginConfig) (err error) {
+	reported := false
+	defer func() {
+		if err != nil && !reported {
+			loginAnalytics.AuthLoginFailed("device", "internal_error")
+		}
+	}()
+
+	attended := cfg.Attended
+	if attended == nil {
+		attended = func() bool {
+			return stdinIsTerminalFunc() && stdoutIsTerminalFunc() && !nonInteractiveEnvFunc()
+		}
+	}
+	if !attended() {
+		reported = true
+		loginAnalytics.AuthLoginFailed("device", "unattended_environment")
+		return clierrors.NewUsage(
+			"device login requires an attended terminal (TTY stdin/stdout) and is disabled in CI or HEYGEN_NONINTERACTIVE mode",
+		)
+	}
+
+	opts := make([]oauth.Option, 0, 7)
+	if cfg.ClientID != "" {
+		opts = append(opts, oauth.WithClientID(cfg.ClientID))
+	}
+	if cfg.DeviceAuthorizationURL != "" {
+		opts = append(opts, oauth.WithDeviceAuthorizationURL(cfg.DeviceAuthorizationURL))
+	}
+	if cfg.TokenURL != "" {
+		opts = append(opts, oauth.WithTokenURL(cfg.TokenURL))
+	}
+	if cfg.RevokeURL != "" {
+		opts = append(opts, oauth.WithRevokeURL(cfg.RevokeURL))
+	}
+	if cfg.Now != nil {
+		opts = append(opts, oauth.WithNow(cfg.Now))
+	}
+	if cfg.Sleep != nil {
+		opts = append(opts, oauth.WithSleep(cfg.Sleep))
+	}
+	oc := oauth.NewClient(opts...)
+
+	resource := strings.TrimRight(cfg.Resource, "/")
+	authorization, err := oc.RequestDeviceAuthorization(
+		cmd.Context(),
+		cfg.Scopes,
+		resource,
+	)
+	if err != nil {
+		reported = true
+		loginAnalytics.AuthLoginFailed("device", "authorization_request_failed")
+		return clierrors.New(fmt.Sprintf("device login could not start: %v", err))
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "Open %s\n", authorization.VerificationURI)
+	fmt.Fprintf(cmd.ErrOrStderr(), "Enter code: %s\n", authorization.UserCode)
+	fmt.Fprintln(cmd.ErrOrStderr(), "Waiting for approval…")
+
+	tok, err := oc.PollDeviceToken(
+		cmd.Context(),
+		authorization.DeviceCode,
+		authorization.Interval,
+		authorization.ExpiresIn,
+	)
+	if err != nil {
+		reported = true
+		reason := "token_poll_failed"
+		var deviceErr *oauth.DeviceAuthorizationError
+		if errors.As(err, &deviceErr) {
+			reason = deviceErr.Code
+		}
+		loginAnalytics.AuthLoginFailed("device", reason)
+		return clierrors.New(fmt.Sprintf("device login failed: %v", err))
+	}
+
+	probeBase := cfg.UsersMeBaseURL
+	if probeBase == "" && ctx.configProvider != nil {
+		probeBase = ctx.configProvider.BaseURL()
+	}
+	userInfo, err := verifyCurrentUser(cmd.Context(), tok.AccessToken, probeBase)
+	if err != nil {
+		revokeMintedDeviceTokens(cmd.Context(), oc, tok)
+		reported = true
+		loginAnalytics.AuthLoginFailed("device", "identity_verification_failed")
+		return clierrors.NewAuth(
+			"device login minted a token, but /v3/users/me identity verification failed; nothing was saved",
+			"Retry `heygen auth login --device`; if this persists, verify the OAuth client resource and scopes.",
+		)
+	}
+
+	expiresAt := time.Time{}
+	if tok.ExpiresIn > 0 {
+		expiresAt = tok.IssuedAt.Add(time.Duration(tok.ExpiresIn) * time.Second)
+	}
+	clearedAPIKey, err := auth.SaveVerifiedOAuthSession(auth.OAuthTokens{
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		ExpiresAt:    expiresAt,
+		Scope:        tok.Scope,
+		TokenType:    tok.TokenType,
+	}, userInfo)
+	if err != nil {
+		revokeMintedDeviceTokens(cmd.Context(), oc, tok)
+		reported = true
+		loginAnalytics.AuthLoginFailed("device", "credential_persistence_failed")
+		return clierrors.New(fmt.Sprintf("device login could not save credentials; minted tokens were revoked: %v", err))
+	}
+
+	if id := identityKey(userInfo); id != "" {
+		loginAnalytics.IdentifyAccount(id)
+	}
+	credPath := filepath.Join(paths.ConfigDir(), "credentials")
+	message := "Signed in via device authorization; credentials saved to " + credPath
+	if clearedAPIKey {
+		message += " (cleared previously-stored API key)"
+	}
+	payload := map[string]any{
+		"message":         message,
+		"scope":           tok.Scope,
+		"expires_at":      "",
+		"cleared_api_key": clearedAPIKey,
+	}
+	if !expiresAt.IsZero() {
+		payload["expires_at"] = expiresAt.UTC().Format(time.RFC3339)
+	}
+	if userInfo.Username != "" {
+		payload["username"] = userInfo.Username
+	}
+	if userInfo.Email != "" {
+		payload["email"] = userInfo.Email
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return clierrors.New(fmt.Sprintf("failed to encode response: %v", err))
+	}
+	if display := userInfo.DisplayName(); display != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in as %s\n", display)
+	} else {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Logged in.")
+	}
+	if err = ctx.formatter.Data(data, "", nil); err != nil {
+		return err
+	}
+	reported = true
+	loginAnalytics.AuthLoginCompleted("device")
+	return nil
+}
+
+func revokeMintedDeviceTokens(ctx context.Context, client *oauth.Client, tok *oauth.TokenResponse) {
+	seen := make(map[string]struct{}, 2)
+	for _, token := range []string{tok.AccessToken, tok.RefreshToken} {
+		if token == "" {
+			continue
+		}
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		_ = client.RevokeToken(ctx, token)
+	}
+}
+
 // runOAuthLogin drives the browser + PKCE + loopback dance and persists
 // the resulting tokens.
 func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (err error) {
@@ -551,7 +756,8 @@ func runOAuthLogin(cmd *cobra.Command, ctx *cmdContext, cfg oauthLoginConfig) (e
 		return clierrors.NewUsage(
 			"cannot complete browser OAuth flow in a headless shell " +
 				"(no TTY and BROWSER=none / HEYGEN_NO_BROWSER=1).\n" +
-				"Use `heygen auth login --api-key` instead, or unset " +
+				"Use `heygen auth login --device` for an attended remote login, " +
+				"use `heygen auth login --api-key`, or unset " +
 				"HEYGEN_NO_BROWSER and re-run from an interactive shell.",
 		)
 	}
@@ -760,6 +966,55 @@ func lookupCurrentUser(ctx context.Context, accessToken, baseURL string) auth.Us
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("User-Agent", "heygen-cli/oauth-login")
 	return runUsersMeRequest(req)
+}
+
+func verifyCurrentUser(ctx context.Context, accessToken, baseURL string) (auth.UserInfo, error) {
+	if accessToken == "" {
+		return auth.UserInfo{}, errors.New("empty access token")
+	}
+	req, err := buildUsersMeRequest(ctx, baseURL)
+	if err != nil {
+		return auth.UserInfo{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("User-Agent", "heygen-cli/device-login")
+	hc := &http.Client{Timeout: 10 * time.Second}
+	resp, err := hc.Do(req) //nolint:gosec // G704: configured HeyGen API or explicit test endpoint
+	if err != nil {
+		return auth.UserInfo{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+		return auth.UserInfo{}, fmt.Errorf("users/me returned HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return auth.UserInfo{}, err
+	}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil ||
+		len(envelope.Data) == 0 ||
+		string(envelope.Data) == "null" {
+		return auth.UserInfo{}, errors.New("users/me returned an invalid response")
+	}
+	var data struct {
+		Username  string `json:"username"`
+		Email     string `json:"email"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+	}
+	if err := json.Unmarshal(envelope.Data, &data); err != nil {
+		return auth.UserInfo{}, errors.New("users/me returned an invalid data object")
+	}
+	return auth.UserInfo{
+		Username:  data.Username,
+		Email:     data.Email,
+		FirstName: data.FirstName,
+		LastName:  data.LastName,
+	}, nil
 }
 
 // lookupCurrentUserAPIKey is the api_key equivalent of

--- a/cmd/heygen/auth_login.go
+++ b/cmd/heygen/auth_login.go
@@ -630,12 +630,7 @@ func runDeviceLogin(cmd *cobra.Command, ctx *cmdContext, cfg deviceLoginConfig) 
 	)
 	if err != nil {
 		reported = true
-		reason := "token_poll_failed"
-		var deviceErr *oauth.DeviceAuthorizationError
-		if errors.As(err, &deviceErr) {
-			reason = deviceErr.Code
-		}
-		loginAnalytics.AuthLoginFailed("device", reason)
+		loginAnalytics.AuthLoginFailed("device", deviceFailureReason(err))
 		return clierrors.New(fmt.Sprintf("device login failed: %v", err))
 	}
 
@@ -710,6 +705,29 @@ func runDeviceLogin(cmd *cobra.Command, ctx *cmdContext, cfg deviceLoginConfig) 
 	reported = true
 	loginAnalytics.AuthLoginCompleted("device")
 	return nil
+}
+
+// deviceFailureReason maps server-provided RFC 8628 error codes into a fixed
+// analytics vocabulary. Never emit DeviceAuthorizationError.Code directly:
+// an OAuth server may return arbitrary text, which would create unbounded
+// PostHog dimensions and could copy attacker-controlled data into telemetry.
+func deviceFailureReason(err error) string {
+	var deviceErr *oauth.DeviceAuthorizationError
+	if !errors.As(err, &deviceErr) {
+		return "token_poll_failed"
+	}
+	switch deviceErr.Code {
+	case "access_denied":
+		return "device_access_denied"
+	case "expired_token":
+		return "device_code_expired"
+	case "invalid_client":
+		return "device_invalid_client"
+	case "invalid_grant":
+		return "device_invalid_grant"
+	default:
+		return "device_oauth_error"
+	}
 }
 
 func revokeMintedDeviceTokens(ctx context.Context, client *oauth.Client, tok *oauth.TokenResponse) {

--- a/cmd/heygen/auth_login_device_test.go
+++ b/cmd/heygen/auth_login_device_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/heygen-com/heygen-cli/internal/analytics"
+	"github.com/heygen-com/heygen-cli/internal/auth"
+	"github.com/heygen-com/heygen-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestRunAuthLoginDeviceDispatchesExplicitDeviceFlag(t *testing.T) {
+	spy := &dispatchSpy{}
+	deps := spy.deps()
+	deviceCalls := 0
+	deps.runDevice = func(*cobra.Command, *cmdContext) error {
+		deviceCalls++
+		return nil
+	}
+	runAuthLoginTestDeps = deps
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
+
+	cmd, ctx := makeDispatchCmd(t)
+	if err := runAuthLogin(cmd, ctx, authLoginFlags{deviceMode: true}); err != nil {
+		t.Fatalf("runAuthLogin: %v", err)
+	}
+	if deviceCalls != 1 || spy.oauthCalls != 0 || spy.apiKeyCalls != 0 {
+		t.Fatalf("device=%d oauth=%d apiKey=%d", deviceCalls, spy.oauthCalls, spy.apiKeyCalls)
+	}
+}
+
+func TestRunDeviceLoginVerifiesIdentityBeforePersisting(t *testing.T) {
+	var tokenPolls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/device":
+			_, _ = w.Write([]byte(`{
+				"device_code":"device-secret",
+				"user_code":"ABCD-EFGH",
+				"verification_uri":"` + "http://" + r.Host + `/verify",
+				"expires_in":600,
+				"interval":1
+			}`))
+		case "/token":
+			tokenPolls.Add(1)
+			_, _ = w.Write([]byte(`{
+				"access_token":"access",
+				"refresh_token":"refresh",
+				"expires_in":3600,
+				"scope":"openid profile",
+				"token_type":"Bearer"
+			}`))
+		case "/v3/users/me":
+			if r.Header.Get("Authorization") != "Bearer access" {
+				t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
+			}
+			_, _ = w.Write([]byte(`{"data":{"email":"device@example.com","username":"device-user"}}`))
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configDir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+	result := runDeviceLoginForTest(t, deviceLoginConfig{
+		ClientID:               "device-client",
+		DeviceAuthorizationURL: server.URL + "/device",
+		TokenURL:               server.URL + "/token",
+		RevokeURL:              server.URL + "/revoke",
+		UsersMeBaseURL:         server.URL,
+		Resource:               server.URL,
+		Attended:               func() bool { return true },
+		Sleep:                  func(context.Context, time.Duration) error { return nil },
+	})
+	if result.ExitCode != 0 {
+		t.Fatalf("exit=%d stderr=%s stdout=%s", result.ExitCode, result.Stderr, result.Stdout)
+	}
+	if tokenPolls.Load() != 1 {
+		t.Fatalf("polls=%d, want 1", tokenPolls.Load())
+	}
+	tokens, err := auth.LoadOAuthTokens()
+	if err != nil {
+		t.Fatalf("LoadOAuthTokens: %v", err)
+	}
+	if tokens.AccessToken != "access" || tokens.RefreshToken != "refresh" {
+		t.Fatalf("tokens=%+v", tokens)
+	}
+	user, err := auth.LoadUserInfo()
+	if err != nil {
+		t.Fatalf("LoadUserInfo: %v", err)
+	}
+	if user.Email != "device@example.com" {
+		t.Fatalf("user=%+v", user)
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "device-secret") {
+		t.Fatal("device bearer credential leaked to output")
+	}
+	if !strings.Contains(result.Stderr, "ABCD-EFGH") ||
+		!strings.Contains(result.Stderr, "/verify") {
+		t.Fatalf("stderr missing user instructions: %s", result.Stderr)
+	}
+}
+
+func TestRunDeviceLoginRevokesAndDoesNotPersistWhenIdentityFails(t *testing.T) {
+	var revokeCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/device":
+			_, _ = w.Write([]byte(`{
+				"device_code":"device-secret",
+				"user_code":"ABCD-EFGH",
+				"verification_uri":"` + "http://" + r.Host + `/verify",
+				"expires_in":600,
+				"interval":1
+			}`))
+		case "/token":
+			_, _ = w.Write([]byte(`{
+				"access_token":"access",
+				"refresh_token":"refresh",
+				"expires_in":3600
+			}`))
+		case "/v3/users/me":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		case "/revoke":
+			revokeCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	result := runDeviceLoginForTest(t, deviceLoginConfig{
+		ClientID:               "device-client",
+		DeviceAuthorizationURL: server.URL + "/device",
+		TokenURL:               server.URL + "/token",
+		RevokeURL:              server.URL + "/revoke",
+		UsersMeBaseURL:         server.URL,
+		Resource:               server.URL,
+		Attended:               func() bool { return true },
+		Sleep:                  func(context.Context, time.Duration) error { return nil },
+	})
+	if result.ExitCode == 0 {
+		t.Fatalf("expected identity failure, stdout=%s", result.Stdout)
+	}
+	if revokeCalls.Load() != 2 {
+		t.Fatalf("revoke calls=%d, want access+refresh", revokeCalls.Load())
+	}
+	if _, err := auth.LoadOAuthTokens(); err == nil {
+		t.Fatal("tokens persisted before identity verification")
+	}
+}
+
+func TestRunDeviceLoginRevokesWhenAtomicCredentialWriteFails(t *testing.T) {
+	var revokeCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/device":
+			_, _ = w.Write([]byte(`{
+				"device_code":"device-secret",
+				"user_code":"ABCD-EFGH",
+				"verification_uri":"` + "http://" + r.Host + `/verify",
+				"expires_in":600,
+				"interval":1
+			}`))
+		case "/token":
+			_, _ = w.Write([]byte(`{
+				"access_token":"access",
+				"refresh_token":"refresh",
+				"expires_in":3600
+			}`))
+		case "/v3/users/me":
+			_, _ = w.Write([]byte(`{"data":{"email":"device@example.com"}}`))
+		case "/revoke":
+			revokeCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	// Make HEYGEN_CONFIG_DIR a regular file. The atomic store cannot create
+	// <file>/credentials, which deterministically exercises write rollback.
+	badConfigDir := t.TempDir() + "/not-a-directory"
+	if err := os.WriteFile(badConfigDir, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HEYGEN_CONFIG_DIR", badConfigDir)
+	result := runDeviceLoginForTest(t, deviceLoginConfig{
+		ClientID:               "device-client",
+		DeviceAuthorizationURL: server.URL + "/device",
+		TokenURL:               server.URL + "/token",
+		RevokeURL:              server.URL + "/revoke",
+		UsersMeBaseURL:         server.URL,
+		Resource:               server.URL,
+		Attended:               func() bool { return true },
+		Sleep:                  func(context.Context, time.Duration) error { return nil },
+	})
+	if result.ExitCode == 0 {
+		t.Fatal("expected credential write failure")
+	}
+	if revokeCalls.Load() != 2 {
+		t.Fatalf("revoke calls=%d, want access+refresh", revokeCalls.Load())
+	}
+	if strings.Contains(result.Stdout+result.Stderr, "device-secret") {
+		t.Fatal("device bearer credential leaked to output")
+	}
+}
+
+func TestRunDeviceLoginRefusesUnattendedEnvironment(t *testing.T) {
+	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	result := runDeviceLoginForTest(t, deviceLoginConfig{
+		Attended: func() bool { return false },
+	})
+	if result.ExitCode == 0 {
+		t.Fatal("expected unattended device login to fail")
+	}
+	if !strings.Contains(result.Stderr, "attended") {
+		t.Fatalf("stderr=%q", result.Stderr)
+	}
+}
+
+func runDeviceLoginForTest(t *testing.T, cfg deviceLoginConfig) cmdResult {
+	t.Helper()
+	var stdout, stderr strings.Builder
+	formatter := formatterForArgs([]string{"auth", "login", "--device"}, &stdout, &stderr)
+	if os.Getenv("HEYGEN_CONFIG_DIR") == "" {
+		t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	}
+	t.Setenv("HEYGEN_NO_ANALYTICS", "1")
+	ctx := &cmdContext{
+		formatter: formatter,
+		version:   "test",
+		configProvider: &config.LayeredProvider{
+			Env:  &config.EnvProvider{},
+			File: &config.FileProvider{},
+		},
+	}
+	_ = analytics.New("test", false)
+	cmd := newAuthLoginCmd(ctx)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		return runDeviceLogin(c, ctx, cfg)
+	}
+	exitCode := 0
+	if err := cmd.Execute(); err != nil {
+		exitCode = 1
+		_, _ = stderr.WriteString(err.Error())
+	}
+	return cmdResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: exitCode}
+}

--- a/cmd/heygen/auth_login_dispatch_test.go
+++ b/cmd/heygen/auth_login_dispatch_test.go
@@ -70,6 +70,7 @@ func (erroringReader) Read(_ []byte) (int, error) {
 // without spinning up the real OAuth / API-key flows.
 type dispatchSpy struct {
 	oauthCalls   int
+	deviceCalls  int
 	apiKeyCalls  int
 	pickerCalls  int
 	pickerChoice loginChoice
@@ -87,6 +88,10 @@ func (s *dispatchSpy) deps() *runAuthLoginDeps {
 		},
 		runOAuth: func(c *cobra.Command, x *cmdContext) error {
 			s.oauthCalls++
+			return nil
+		},
+		runDevice: func(c *cobra.Command, x *cmdContext) error {
+			s.deviceCalls++
 			return nil
 		},
 		runAPIKey: func(c *cobra.Command, x *cmdContext) error {
@@ -119,6 +124,7 @@ func TestRunAuthLogin_Dispatch(t *testing.T) {
 		nonInteractive  bool
 		pickerChoice    loginChoice
 		wantOAuthCalls  int
+		wantDeviceCalls int
 		wantAPIKeyCalls int
 		wantPickerCalls int
 		wantErr         bool
@@ -174,9 +180,9 @@ func TestRunAuthLogin_Dispatch(t *testing.T) {
 			wantAPIKeyCalls: 1,
 		},
 		{
-			name:    "device-code flag is rejected with usage error",
-			flags:   authLoginFlags{deviceCodeMode: true},
-			wantErr: true,
+			name:            "device-code compatibility alias routes to device runner",
+			flags:           authLoginFlags{deviceCodeMode: true},
+			wantDeviceCalls: 1,
 		},
 	}
 
@@ -203,6 +209,9 @@ func TestRunAuthLogin_Dispatch(t *testing.T) {
 			}
 			if spy.oauthCalls != tc.wantOAuthCalls {
 				t.Errorf("oauthCalls = %d, want %d", spy.oauthCalls, tc.wantOAuthCalls)
+			}
+			if spy.deviceCalls != tc.wantDeviceCalls {
+				t.Errorf("deviceCalls = %d, want %d", spy.deviceCalls, tc.wantDeviceCalls)
 			}
 			if spy.apiKeyCalls != tc.wantAPIKeyCalls {
 				t.Errorf("apiKeyCalls = %d, want %d", spy.apiKeyCalls, tc.wantAPIKeyCalls)
@@ -400,23 +409,24 @@ func TestRunAuthLogin_PickerCancel_NoTelemetry(t *testing.T) {
 	}
 }
 
-// U4: --device-code emits started(device_code) then
-// failed(device_code, device_code_unsupported) — the reason is explicitly
-// named in the plan's enum, so this implementation instruments it rather
-// than silently dropping telemetry for the flag.
+// U4: the hidden --device-code compatibility alias uses the same device
+// telemetry as the public --device spelling.
 func TestRunAuthLogin_DeviceCode_Telemetry(t *testing.T) {
 	spy := withLoginAnalyticsSpy(t)
+	dispatchTestSpy := &dispatchSpy{}
+	runAuthLoginTestDeps = dispatchTestSpy.deps()
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
 
 	cmd, ctx := makeDispatchCmd(t)
-	if err := runAuthLogin(cmd, ctx, authLoginFlags{deviceCodeMode: true}); err == nil {
-		t.Fatal("want usage error, got nil")
+	if err := runAuthLogin(cmd, ctx, authLoginFlags{deviceCodeMode: true}); err != nil {
+		t.Fatalf("runAuthLogin: %v", err)
 	}
 
-	if got := spy.started; len(got) != 1 || got[0] != "device_code" {
-		t.Fatalf("started = %v, want [device_code]", got)
+	if got := spy.started; len(got) != 1 || got[0] != "device" {
+		t.Fatalf("started = %v, want [device]", got)
 	}
-	if got := spy.failed; len(got) != 1 || got[0] != (loginAnalyticsFailedCall{"device_code", "device_code_unsupported"}) {
-		t.Fatalf("failed = %v, want [{device_code device_code_unsupported}]", got)
+	if len(spy.failed) != 0 {
+		t.Fatalf("failed = %v, want none", spy.failed)
 	}
 }
 

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -1184,6 +1184,14 @@ var allowedLoginFailureReasons = map[string]map[string]bool{
 	"api_key": {
 		"internal_error": true, "api_key_aborted": true, "api_key_invalid_input": true,
 	},
+	"device": {
+		"internal_error": true, "unattended_environment": true,
+		"authorization_request_failed": true, "identity_verification_failed": true,
+		"credential_persistence_failed": true, "token_poll_failed": true,
+		"device_access_denied": true, "device_code_expired": true,
+		"device_invalid_client": true, "device_invalid_grant": true,
+		"device_oauth_error": true,
+	},
 	"device_code": {"device_code_unsupported": true},
 }
 
@@ -1230,6 +1238,33 @@ func TestOAuthFailureReasonOutputsAreInAllowedVocabulary(t *testing.T) {
 		if got := oauthFailureReason(err); !allowedLoginFailureReasons["oauth"][got] {
 			t.Errorf("oauthFailureReason(%v) = %q, outside the allowed oauth vocabulary", err, got)
 		}
+	}
+}
+
+func TestDeviceFailureReasonOutputsAreInAllowedVocabulary(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"access denied", &oauth.DeviceAuthorizationError{Code: "access_denied"}, "device_access_denied"},
+		{"expired", &oauth.DeviceAuthorizationError{Code: "expired_token"}, "device_code_expired"},
+		{"invalid client", &oauth.DeviceAuthorizationError{Code: "invalid_client"}, "device_invalid_client"},
+		{"invalid grant", &oauth.DeviceAuthorizationError{Code: "invalid_grant"}, "device_invalid_grant"},
+		{"unknown server code", &oauth.DeviceAuthorizationError{Code: "attacker-controlled"}, "device_oauth_error"},
+		{"non-oauth error", errors.New("network down"), "token_poll_failed"},
+		{"wrapped code", fmt.Errorf("poll: %w", &oauth.DeviceAuthorizationError{Code: "access_denied"}), "device_access_denied"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deviceFailureReason(tt.err)
+			if got != tt.want {
+				t.Fatalf("deviceFailureReason(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+			if !allowedLoginFailureReasons["device"][got] {
+				t.Fatalf("deviceFailureReason(%v) = %q, outside the allowed device vocabulary", tt.err, got)
+			}
+		})
 	}
 }
 

--- a/cmd/heygen/auth_login_oauth_test.go
+++ b/cmd/heygen/auth_login_oauth_test.go
@@ -460,17 +460,21 @@ func TestAuthLogin_CredentialConflict_SelfHeals(t *testing.T) {
 	}
 }
 
-// TestAuthLogin_DeviceCode_NotYetSupported guards the placeholder flag.
-func TestAuthLogin_DeviceCode_NotYetSupported(t *testing.T) {
+// TestAuthLogin_DeviceCodeCompatibilityAlias keeps the pre-release
+// --device-code spelling working while the public help uses --device.
+func TestAuthLogin_DeviceCodeCompatibilityAlias(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	spy := &dispatchSpy{}
+	runAuthLoginTestDeps = spy.deps()
+	t.Cleanup(func() { runAuthLoginTestDeps = nil })
 
 	res := runCommandWithInput(t, "http://example.invalid", "", strings.NewReader(""),
 		"auth", "login", "--device-code")
-	if res.ExitCode != 2 {
-		t.Fatalf("ExitCode = %d, want 2", res.ExitCode)
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%s", res.ExitCode, res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, "not yet supported") {
-		t.Fatalf("stderr = %q, want 'not yet supported'", res.Stderr)
+	if spy.deviceCalls != 1 {
+		t.Fatalf("deviceCalls = %d, want 1", spy.deviceCalls)
 	}
 }
 

--- a/cmd/heygen/auth_logout.go
+++ b/cmd/heygen/auth_logout.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/auth"
@@ -17,10 +19,24 @@ import (
 // best-effort revoke without spawning network requests.
 type authLogoutConfig struct {
 	RevokeURL string
+	ClientID  string
 }
 
 var defaultAuthLogoutConfig = authLogoutConfig{
 	RevokeURL: oauth.DefaultRevokeURL,
+	ClientID:  oauth.DefaultClientID,
+}
+
+func authLogoutConfigFromEnvironment() authLogoutConfig {
+	revokeURL := strings.TrimSpace(os.Getenv("HEYGEN_OAUTH_REVOKE_URL"))
+	if revokeURL == "" {
+		revokeURL = defaultAuthLogoutConfig.RevokeURL
+	}
+	clientID := strings.TrimSpace(os.Getenv("HEYGEN_OAUTH_CLIENT_ID"))
+	if clientID == "" {
+		clientID = defaultAuthLogoutConfig.ClientID
+	}
+	return authLogoutConfig{RevokeURL: revokeURL, ClientID: clientID}
 }
 
 func newAuthLogoutCmd(ctx *cmdContext) *cobra.Command {
@@ -42,7 +58,7 @@ clear is authoritative.
 If only HEYGEN_API_KEY is configured (no stored credentials), there is
 nothing to log out of and the command is a no-op.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAuthLogout(cmd, ctx, defaultAuthLogoutConfig)
+			return runAuthLogout(cmd, ctx, authLogoutConfigFromEnvironment())
 		},
 	}
 	return cmd
@@ -64,7 +80,10 @@ func runAuthLogout(cmd *cobra.Command, ctx *cmdContext, cfg authLogoutConfig) er
 	}
 
 	if hadOAuthSession && tok.RefreshToken != "" {
-		oc := oauth.NewClient(oauth.WithRevokeURL(cfg.RevokeURL))
+		oc := oauth.NewClient(
+			oauth.WithRevokeURL(cfg.RevokeURL),
+			oauth.WithClientID(cfg.ClientID),
+		)
 		// Best-effort revoke; RevokeToken swallows network failures
 		// internally (logout must not hang on a 5xx IdP).
 		revokeCtx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)

--- a/cmd/heygen/auth_logout_test.go
+++ b/cmd/heygen/auth_logout_test.go
@@ -57,6 +57,20 @@ func TestAuthLogout_ClearsOAuthBlock(t *testing.T) {
 	}
 }
 
+func TestAuthLogoutConfigFromEnvironmentUsesRevokeOverride(t *testing.T) {
+	t.Setenv("HEYGEN_OAUTH_REVOKE_URL", "http://127.0.0.1:18080/v1/oauth/revoke")
+	t.Setenv("HEYGEN_OAUTH_CLIENT_ID", "local-device-client")
+
+	got := authLogoutConfigFromEnvironment()
+
+	if got.RevokeURL != "http://127.0.0.1:18080/v1/oauth/revoke" {
+		t.Fatalf("RevokeURL = %q, want environment override", got.RevokeURL)
+	}
+	if got.ClientID != "local-device-client" {
+		t.Fatalf("ClientID = %q, want environment override", got.ClientID)
+	}
+}
+
 // TestAuthLogout_ClearsBothBlocks: with the single-credential
 // normalization invariant a fresh post-this-change file holds only one
 // of api_key / oauth, but logout still has to be safe against

--- a/cmd/heygen/auth_status_test.go
+++ b/cmd/heygen/auth_status_test.go
@@ -121,7 +121,7 @@ func TestAuthStatus_NoKey(t *testing.T) {
 		t.Fatalf("stderr = %s, want missing API key message", res.Stderr)
 	}
 	// context.go enriches cold-start auth errors with authGuidance.
-	if !strings.Contains(res.Stderr, "Two ways to authenticate") {
+	if !strings.Contains(res.Stderr, "Three ways to authenticate") {
 		t.Fatalf("stderr = %s, want auth guidance", res.Stderr)
 	}
 	if !strings.Contains(res.Stderr, "app.heygen.com/settings?nav=API") {

--- a/cmd/heygen/context_test.go
+++ b/cmd/heygen/context_test.go
@@ -90,7 +90,7 @@ func TestEnrichAuthHint_ExistingHint_Preserved(t *testing.T) {
 	if res.ExitCode != clierrors.ExitAuth {
 		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitAuth, res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, "Two ways to authenticate") {
+	if !strings.Contains(res.Stderr, "Three ways to authenticate") {
 		t.Fatalf("no-key error should preserve authGuidance hint:\n%s", res.Stderr)
 	}
 }

--- a/internal/auth/oauth/device.go
+++ b/internal/auth/oauth/device.go
@@ -1,0 +1,239 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+	maxDevicePollDelay  = 60 * time.Second
+	maxDeviceLifetime   = 30 * time.Minute
+)
+
+// DeviceAuthorization is the safe-to-display subset of an RFC 8628
+// authorization response. DeviceCode is a bearer secret and must never be
+// logged or included in errors.
+type DeviceAuthorization struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// DeviceAuthorizationError is a stable, redacted OAuth error from the device
+// flow. It deliberately excludes error_description because a buggy upstream
+// may echo the device bearer credential there.
+type DeviceAuthorizationError struct {
+	Code string
+}
+
+func (e *DeviceAuthorizationError) Error() string {
+	return "oauth device authorization failed: " + e.Code
+}
+
+// RequestDeviceAuthorization starts an RFC 8628 flow. The returned
+// verification URI is restricted to HTTPS, or loopback HTTP for local tests.
+func (c *Client) RequestDeviceAuthorization(
+	ctx context.Context,
+	scope string,
+	resource string,
+) (*DeviceAuthorization, error) {
+	form := url.Values{"client_id": {c.ClientID}}
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+	if resource != "" {
+		form.Set("resource", strings.TrimRight(resource, "/"))
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.DeviceAuthorizationURL,
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: build device authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: device authorization request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return nil, fmt.Errorf("oauth: read device authorization response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, decodeRedactedDeviceError(body, resp.StatusCode)
+	}
+	var result DeviceAuthorization
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, errors.New("oauth: invalid device authorization response")
+	}
+	if result.DeviceCode == "" || result.UserCode == "" ||
+		result.VerificationURI == "" || result.ExpiresIn <= 0 {
+		return nil, errors.New("oauth: incomplete device authorization response")
+	}
+	if result.Interval <= 0 {
+		result.Interval = 5
+	}
+	if !safeVerificationURI(result.VerificationURI) {
+		return nil, errors.New("oauth: unsafe device verification URI")
+	}
+	return &result, nil
+}
+
+// PollDeviceToken waits according to RFC 8628 until the user approves, denies,
+// the code expires, or the caller cancels. The first request is delayed by the
+// server-provided interval; slow_down increases subsequent waits by five
+// seconds.
+func (c *Client) PollDeviceToken(
+	ctx context.Context,
+	deviceCode string,
+	intervalSeconds int,
+	expiresInSeconds int,
+) (*TokenResponse, error) {
+	if deviceCode == "" {
+		return nil, errors.New("oauth: device code must be non-empty")
+	}
+	if intervalSeconds <= 0 {
+		intervalSeconds = 5
+	}
+	if expiresInSeconds <= 0 {
+		return nil, errors.New("oauth: device authorization lifetime must be positive")
+	}
+	lifetime := time.Duration(expiresInSeconds) * time.Second
+	if lifetime > maxDeviceLifetime {
+		lifetime = maxDeviceLifetime
+	}
+	deadline := c.Now().Add(lifetime)
+	delay := time.Duration(intervalSeconds) * time.Second
+
+	for {
+		if delay > maxDevicePollDelay {
+			delay = maxDevicePollDelay
+		}
+		if !c.Now().Add(delay).Before(deadline) {
+			return nil, &DeviceAuthorizationError{Code: "expired_token"}
+		}
+		if err := c.Sleep(ctx, delay); err != nil {
+			return nil, fmt.Errorf("oauth: device polling canceled: %w", err)
+		}
+
+		tok, code, err := c.pollDeviceTokenOnce(ctx, deviceCode)
+		if err != nil {
+			return nil, err
+		}
+		switch code {
+		case "":
+			return tok, nil
+		case "authorization_pending":
+			continue
+		case "slow_down":
+			delay += 5 * time.Second
+			continue
+		default:
+			return nil, &DeviceAuthorizationError{Code: code}
+		}
+	}
+}
+
+func (c *Client) pollDeviceTokenOnce(
+	ctx context.Context,
+	deviceCode string,
+) (*TokenResponse, string, error) {
+	form := url.Values{
+		"grant_type":  {deviceCodeGrantType},
+		"device_code": {deviceCode},
+		"client_id":   {c.ClientID},
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.TokenURL,
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("oauth: build device token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	requestSent := c.Now()
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("oauth: device token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return nil, "", fmt.Errorf("oauth: read device token response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var payload struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &payload) == nil && payload.Error != "" {
+			return nil, payload.Error, nil
+		}
+		return nil, "", decodeRedactedDeviceError(body, resp.StatusCode)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, "", errors.New("oauth: invalid device token response")
+	}
+	tok, err := parseTokenResponse(raw)
+	if err != nil {
+		return nil, "", fmt.Errorf("oauth: invalid device token response: %w", err)
+	}
+	tok.IssuedAt = requestSent
+	return tok, "", nil
+}
+
+func decodeRedactedDeviceError(body []byte, status int) error {
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) == nil && payload.Error != "" {
+		return &DeviceAuthorizationError{Code: payload.Error}
+	}
+	return fmt.Errorf("oauth: device endpoint returned HTTP %d", status)
+}
+
+func safeVerificationURI(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.User != nil || parsed.Hostname() == "" {
+		return false
+	}
+	if parsed.Scheme == "https" {
+		return true
+	}
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := parsed.Hostname()
+	return host == "localhost" || net.ParseIP(host) != nil && net.ParseIP(host).IsLoopback()
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/auth/oauth/device.go
+++ b/internal/auth/oauth/device.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -86,6 +87,9 @@ func (c *Client) RequestDeviceAuthorization(
 	if result.DeviceCode == "" || result.UserCode == "" ||
 		result.VerificationURI == "" || result.ExpiresIn <= 0 {
 		return nil, errors.New("oauth: incomplete device authorization response")
+	}
+	if !safeUserCode(result.UserCode) {
+		return nil, errors.New("oauth: unsafe device user code")
 	}
 	if result.Interval <= 0 {
 		result.Interval = 5
@@ -188,6 +192,11 @@ func (c *Client) pollDeviceTokenOnce(
 		if json.Unmarshal(body, &payload) == nil && payload.Error != "" {
 			return nil, payload.Error, nil
 		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			// Some gateways return a bare 429 instead of the RFC 8628
+			// slow_down payload. Preserve the protocol's backoff behavior.
+			return nil, "slow_down", nil
+		}
 		return nil, "", decodeRedactedDeviceError(body, resp.StatusCode)
 	}
 	var raw map[string]any
@@ -210,6 +219,15 @@ func decodeRedactedDeviceError(body []byte, status int) error {
 		return &DeviceAuthorizationError{Code: payload.Error}
 	}
 	return fmt.Errorf("oauth: device endpoint returned HTTP %d", status)
+}
+
+func safeUserCode(value string) bool {
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
 }
 
 func safeVerificationURI(raw string) bool {

--- a/internal/auth/oauth/device.go
+++ b/internal/auth/oauth/device.go
@@ -91,7 +91,7 @@ func (c *Client) RequestDeviceAuthorization(
 	if !safeUserCode(result.UserCode) {
 		return nil, errors.New("oauth: unsafe device user code")
 	}
-	if result.Interval <= 0 {
+	if result.Interval < 5 {
 		result.Interval = 5
 	}
 	if !safeVerificationURI(result.VerificationURI) {
@@ -113,7 +113,7 @@ func (c *Client) PollDeviceToken(
 	if deviceCode == "" {
 		return nil, errors.New("oauth: device code must be non-empty")
 	}
-	if intervalSeconds <= 0 {
+	if intervalSeconds < 5 {
 		intervalSeconds = 5
 	}
 	if expiresInSeconds <= 0 {

--- a/internal/auth/oauth/device_test.go
+++ b/internal/auth/oauth/device_test.go
@@ -78,6 +78,27 @@ func TestRequestDeviceAuthorizationRejectsUnsafeVerificationURI(t *testing.T) {
 	}
 }
 
+func TestRequestDeviceAuthorizationRejectsTerminalControlInUserCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      "device-secret",
+			"user_code":        "ABCD-\x1b[31mEFGH",
+			"verification_uri": "https://app.heygen.com/oauth/device",
+			"expires_in":       600,
+			"interval":         5,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithDeviceAuthorizationURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	if _, err := client.RequestDeviceAuthorization(context.Background(), "", ""); err == nil {
+		t.Fatal("expected terminal control characters in user_code to be rejected")
+	}
+}
+
 func TestPollDeviceTokenPendingSlowDownThenSuccess(t *testing.T) {
 	var mu sync.Mutex
 	polls := 0
@@ -130,6 +151,49 @@ func TestPollDeviceTokenPendingSlowDownThenSuccess(t *testing.T) {
 		t.Fatalf("token = %+v", tok)
 	}
 	want := []time.Duration{5 * time.Second, 5 * time.Second, 10 * time.Second}
+	if len(waits) != len(want) {
+		t.Fatalf("waits = %v, want %v", waits, want)
+	}
+	for i := range want {
+		if waits[i] != want[i] {
+			t.Fatalf("waits = %v, want %v", waits, want)
+		}
+	}
+}
+
+func TestPollDeviceTokenTreatsBare429AsSlowDown(t *testing.T) {
+	var polls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		polls++
+		if polls == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("rate limited"))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	now := time.Unix(1_000, 0)
+	var waits []time.Duration
+	client := NewClient(
+		WithTokenURL(server.URL),
+		WithHTTPClient(server.Client()),
+		WithNow(func() time.Time { return now }),
+		WithSleep(func(_ context.Context, d time.Duration) error {
+			waits = append(waits, d)
+			now = now.Add(d)
+			return nil
+		}),
+	)
+	if _, err := client.PollDeviceToken(context.Background(), "device-secret", 5, 600); err != nil {
+		t.Fatalf("PollDeviceToken: %v", err)
+	}
+	want := []time.Duration{5 * time.Second, 10 * time.Second}
 	if len(waits) != len(want) {
 		t.Fatalf("waits = %v, want %v", waits, want)
 	}

--- a/internal/auth/oauth/device_test.go
+++ b/internal/auth/oauth/device_test.go
@@ -57,6 +57,31 @@ func TestRequestDeviceAuthorization(t *testing.T) {
 	}
 }
 
+func TestRequestDeviceAuthorizationClampsIntervalToMinimum(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      "device-secret",
+			"user_code":        "ABCD-EFGH",
+			"verification_uri": "https://app.heygen.com/oauth/device",
+			"expires_in":       600,
+			"interval":         1,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithDeviceAuthorizationURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	got, err := client.RequestDeviceAuthorization(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("RequestDeviceAuthorization: %v", err)
+	}
+	if got.Interval != 5 {
+		t.Fatalf("interval = %d, want 5", got.Interval)
+	}
+}
+
 func TestRequestDeviceAuthorizationRejectsUnsafeVerificationURI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -158,6 +183,36 @@ func TestPollDeviceTokenPendingSlowDownThenSuccess(t *testing.T) {
 		if waits[i] != want[i] {
 			t.Fatalf("waits = %v, want %v", waits, want)
 		}
+	}
+}
+
+func TestPollDeviceTokenClampsIntervalToMinimum(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	now := time.Unix(1_000, 0)
+	var waits []time.Duration
+	client := NewClient(
+		WithTokenURL(server.URL),
+		WithHTTPClient(server.Client()),
+		WithNow(func() time.Time { return now }),
+		WithSleep(func(_ context.Context, d time.Duration) error {
+			waits = append(waits, d)
+			now = now.Add(d)
+			return nil
+		}),
+	)
+	if _, err := client.PollDeviceToken(context.Background(), "device-secret", 1, 600); err != nil {
+		t.Fatalf("PollDeviceToken: %v", err)
+	}
+	if len(waits) != 1 || waits[0] != 5*time.Second {
+		t.Fatalf("waits = %v, want [5s]", waits)
 	}
 }
 

--- a/internal/auth/oauth/device_test.go
+++ b/internal/auth/oauth/device_test.go
@@ -1,0 +1,169 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRequestDeviceAuthorization(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/device" {
+			t.Fatalf("path = %q, want /device", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.PostForm
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      "device-secret",
+			"user_code":        "ABCD-EFGH",
+			"verification_uri": "https://app.heygen.com/oauth/device",
+			"expires_in":       600,
+			"interval":         5,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithClientID("cli-id"),
+		WithDeviceAuthorizationURL(server.URL+"/device"),
+		WithHTTPClient(server.Client()),
+	)
+	gotResponse, err := client.RequestDeviceAuthorization(
+		context.Background(),
+		"openid profile",
+		"https://api.heygen.com",
+	)
+	if err != nil {
+		t.Fatalf("RequestDeviceAuthorization: %v", err)
+	}
+	if got.Get("client_id") != "cli-id" ||
+		got.Get("scope") != "openid profile" ||
+		got.Get("resource") != "https://api.heygen.com" {
+		t.Fatalf("form = %#v", got)
+	}
+	if gotResponse.DeviceCode != "device-secret" ||
+		gotResponse.UserCode != "ABCD-EFGH" ||
+		gotResponse.Interval != 5 {
+		t.Fatalf("response = %+v", gotResponse)
+	}
+}
+
+func TestRequestDeviceAuthorizationRejectsUnsafeVerificationURI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      "device-secret",
+			"user_code":        "ABCD-EFGH",
+			"verification_uri": "http://attacker.example/oauth/device",
+			"expires_in":       600,
+			"interval":         5,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithDeviceAuthorizationURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	if _, err := client.RequestDeviceAuthorization(context.Background(), "", ""); err == nil {
+		t.Fatal("expected unsafe verification URI to be rejected")
+	}
+}
+
+func TestPollDeviceTokenPendingSlowDownThenSuccess(t *testing.T) {
+	var mu sync.Mutex
+	polls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if r.PostForm.Get("device_code") != "device-secret" {
+			t.Fatalf("device_code = %q", r.PostForm.Get("device_code"))
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		polls++
+		switch polls {
+		case 1:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+		case 2:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"slow_down"}`))
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "access",
+				"refresh_token": "refresh",
+				"expires_in":    3600,
+				"scope":         "openid profile",
+				"token_type":    "Bearer",
+			})
+		}
+	}))
+	defer server.Close()
+
+	now := time.Unix(1_000, 0)
+	var waits []time.Duration
+	client := NewClient(
+		WithTokenURL(server.URL),
+		WithHTTPClient(server.Client()),
+		WithNow(func() time.Time { return now }),
+		WithSleep(func(_ context.Context, d time.Duration) error {
+			waits = append(waits, d)
+			now = now.Add(d)
+			return nil
+		}),
+	)
+	tok, err := client.PollDeviceToken(context.Background(), "device-secret", 5, 600)
+	if err != nil {
+		t.Fatalf("PollDeviceToken: %v", err)
+	}
+	if tok.AccessToken != "access" || tok.RefreshToken != "refresh" {
+		t.Fatalf("token = %+v", tok)
+	}
+	want := []time.Duration{5 * time.Second, 5 * time.Second, 10 * time.Second}
+	if len(waits) != len(want) {
+		t.Fatalf("waits = %v, want %v", waits, want)
+	}
+	for i := range want {
+		if waits[i] != want[i] {
+			t.Fatalf("waits = %v, want %v", waits, want)
+		}
+	}
+}
+
+func TestPollDeviceTokenTerminalErrorsDoNotEchoResponseBody(t *testing.T) {
+	for _, code := range []string{"access_denied", "expired_token", "invalid_grant"} {
+		t.Run(code, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"` + code + `","error_description":"device-secret"}`))
+			}))
+			defer server.Close()
+
+			client := NewClient(
+				WithTokenURL(server.URL),
+				WithHTTPClient(server.Client()),
+				WithSleep(func(context.Context, time.Duration) error { return nil }),
+			)
+			_, err := client.PollDeviceToken(context.Background(), "device-secret", 1, 30)
+			if err == nil {
+				t.Fatal("expected terminal error")
+			}
+			if strings.Contains(err.Error(), "device-secret") {
+				t.Fatalf("error leaked device code: %q", err)
+			}
+			if !strings.Contains(err.Error(), code) {
+				t.Fatalf("error = %q, want %q", err, code)
+			}
+		})
+	}
+}

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -29,9 +29,10 @@ const DefaultScopes = "openid profile email"
 // cookies); token + revoke live on the api2.heygen.com server-to-server
 // API. See hyperframes-CLI's oauth.ts for the live verification notes.
 const (
-	DefaultAuthorizeURL = "https://app.heygen.com/oauth/authorize"
-	DefaultTokenURL     = "https://api2.heygen.com/v1/oauth/token"
-	DefaultRevokeURL    = "https://api2.heygen.com/v1/oauth/revoke"
+	DefaultAuthorizeURL           = "https://app.heygen.com/oauth/authorize"
+	DefaultDeviceAuthorizationURL = "https://api2.heygen.com/v1/oauth/device_authorization"
+	DefaultTokenURL               = "https://api2.heygen.com/v1/oauth/token"
+	DefaultRevokeURL              = "https://api2.heygen.com/v1/oauth/revoke"
 )
 
 // DefaultExchangeTimeout caps each token-endpoint round trip.
@@ -47,16 +48,20 @@ const DefaultRevokeTimeout = 5 * time.Second
 // overridable so tests can swap in an httptest.Server. Production
 // callers should call NewClient() with no options.
 type Client struct {
-	ClientID     string
-	AuthorizeURL string
-	TokenURL     string
-	RevokeURL    string
+	ClientID               string
+	AuthorizeURL           string
+	DeviceAuthorizationURL string
+	TokenURL               string
+	RevokeURL              string
 
 	// HTTPClient is used for the token + revoke round trips. Defaults
 	// to an http.Client with sensible timeouts.
 	HTTPClient *http.Client
 	// Now is the wall-clock source, overridable for deterministic tests.
 	Now func() time.Time
+	// Sleep waits between RFC 8628 polling attempts. Tests replace it
+	// with a deterministic clock advance.
+	Sleep func(context.Context, time.Duration) error
 }
 
 // Option configures a Client.
@@ -70,6 +75,11 @@ func WithClientID(id string) Option {
 // WithAuthorizeURL overrides the authorize endpoint URL.
 func WithAuthorizeURL(u string) Option {
 	return func(c *Client) { c.AuthorizeURL = u }
+}
+
+// WithDeviceAuthorizationURL overrides the RFC 8628 issuance endpoint.
+func WithDeviceAuthorizationURL(u string) Option {
+	return func(c *Client) { c.DeviceAuthorizationURL = u }
 }
 
 // WithTokenURL overrides the token endpoint URL.
@@ -93,16 +103,23 @@ func WithNow(now func() time.Time) Option {
 	return func(c *Client) { c.Now = now }
 }
 
+// WithSleep overrides the RFC 8628 polling wait.
+func WithSleep(sleep func(context.Context, time.Duration) error) Option {
+	return func(c *Client) { c.Sleep = sleep }
+}
+
 // NewClient returns a Client with sensible defaults, optionally
 // overridden by opts.
 func NewClient(opts ...Option) *Client {
 	c := &Client{
-		ClientID:     DefaultClientID,
-		AuthorizeURL: DefaultAuthorizeURL,
-		TokenURL:     DefaultTokenURL,
-		RevokeURL:    DefaultRevokeURL,
-		HTTPClient:   &http.Client{Timeout: DefaultExchangeTimeout},
-		Now:          time.Now,
+		ClientID:               DefaultClientID,
+		AuthorizeURL:           DefaultAuthorizeURL,
+		DeviceAuthorizationURL: DefaultDeviceAuthorizationURL,
+		TokenURL:               DefaultTokenURL,
+		RevokeURL:              DefaultRevokeURL,
+		HTTPClient:             &http.Client{Timeout: DefaultExchangeTimeout},
+		Now:                    time.Now,
+		Sleep:                  sleepContext,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/internal/auth/oauth_store.go
+++ b/internal/auth/oauth_store.go
@@ -16,6 +16,49 @@ type OAuthTokens struct {
 	TokenType    string
 }
 
+// SaveVerifiedOAuthSession atomically installs a newly verified OAuth session,
+// its friendly user metadata, and removes any API key it replaces. Device
+// authorization uses this single write so a persistence failure cannot leave a
+// partially-installed credential.
+func SaveVerifiedOAuthSession(tok OAuthTokens, user UserInfo) (clearedAPIKey bool, err error) {
+	if tok.AccessToken == "" {
+		return false, fmt.Errorf("auth: verified OAuth session has no access token")
+	}
+	path := credentialFilePath()
+	existing, format, err := loadCredentialsFile(path)
+	if err != nil {
+		if format != formatAbsent {
+			return false, fmt.Errorf("%w; delete the file and re-run `heygen auth login`", err)
+		}
+		existing = jsonCredentials{}
+	}
+	clearedAPIKey = existing.APIKey != ""
+	existing.APIKey = ""
+	existing.OAuth = &jsonOAuthTokens{
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		Scope:        tok.Scope,
+		TokenType:    tok.TokenType,
+	}
+	if !tok.ExpiresAt.IsZero() {
+		existing.OAuth.ExpiresAt = tok.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	if user.IsZero() {
+		existing.User = nil
+	} else {
+		existing.User = &jsonUserInfo{
+			Email:     user.Email,
+			FirstName: user.FirstName,
+			LastName:  user.LastName,
+			Username:  user.Username,
+		}
+	}
+	if err := writeCredentialsFile(path, existing); err != nil {
+		return false, err
+	}
+	return clearedAPIKey, nil
+}
+
 // SaveOAuthTokens writes the OAuth block to the shared credentials file,
 // preserving any co-located api_key. The file is created with 0600 in a
 // 0700 parent directory.

--- a/internal/errors/codes_test.go
+++ b/internal/errors/codes_test.go
@@ -99,7 +99,14 @@ func TestNoUnregisteredCLICodes(t *testing.T) {
 
 	// Codes the CLI never originates: relayed from tests as API-response bodies,
 	// or test-only fixtures. These are not CLI-minted, so exclude them.
-	ignore := map[string]bool{}
+	ignore := map[string]bool{
+		// RFC 8628 token-endpoint errors are protocol values relayed by the
+		// authorization server, not CLI-originated error envelope codes.
+		"authorization_pending": true,
+		"slow_down":             true,
+		"access_denied":         true,
+		"expired_token":         true,
+	}
 
 	for _, dir := range []string{"cmd", "internal"} {
 		err := filepath.WalkDir(filepath.Join(root, dir), func(path string, d os.DirEntry, err error) error {


### PR DESCRIPTION
## Summary

`heygen auth login --device` now supports attended remote-terminal sign-in without copying an API key or relying on a loopback browser callback. The existing interactive picker, browser OAuth, and non-interactive API-key behavior remain unchanged.

## Security and persistence

- Device login is explicit and refuses CI or non-TTY execution.
- RFC 8628 polling waits before the first request, handles pending and slowdown responses, and has bounded time and response sizes.
- Verification URLs must be HTTPS or loopback HTTP, and server errors never echo the device bearer secret.
- `/v3/users/me` must accept the minted access token before anything is written locally.
- Verification and persistence failures revoke both minted tokens.
- The verified OAuth session, friendly identity, and API-key replacement are committed atomically while preserving foreign credential fields.
- DEV endpoints, client ID, resource, clock, and polling are injectable for exact-SHA certification.

## Test plan

- `make test` — all Go packages passed
- `make lint` with golangci-lint v2.11.4 — 0 issues

End-to-end DEV certification is pending the unmerged EF endpoint and Pacific consent UI.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)
