### PR TITLE
fix(help): strip backticks from spec-derived flag help

### DIFF
--- a/cmd/heygen/builder.go
+++ b/cmd/heygen/builder.go
@@ -369,9 +369,30 @@ func restoreRequiredFlagAnnotations(cmd *cobra.Command) {
 	})
 }
 
+// stripBackticks removes backticks from flag help text.
+//
+// pflag's UnquoteUsage treats the first backticked word in a usage string as the
+// flag's value-type placeholder: it prints that word where "string" would go and
+// strips the quotes from the text. Help comes verbatim from OpenAPI descriptions,
+// where backticks are ordinary Markdown, so `next_token` in a sentence renders as
+// "--token next_token" and misreports the flag's type. Drop them at registration
+// rather than policing prose in the spec.
+func stripBackticks(s string) string {
+	return strings.ReplaceAll(s, "`", "")
+}
+
 // registerFlag adds a typed flag to the Cobra command based on the FlagSpec.
 func registerFlag(cmd *cobra.Command, flag command.FlagSpec) {
-	helpText := flag.Help
+	// Only the description is sanitized. Descriptions are Markdown prose, where a
+	// backtick is formatting; enum members are wire values compared verbatim by
+	// validateFlag, so this never rewrites one.
+	//
+	// The distinction is about what we're willing to alter, not about rendered
+	// output: pflag strips the first backtick pair while rendering regardless, so
+	// a (hypothetical) backticked enum member displays without its backticks
+	// either way. No enum in the spec carries one, and none plausibly would —
+	// they are identifiers the client sends, not documentation.
+	helpText := stripBackticks(flag.Help)
 	if flag.Required {
 		helpText += " (required)"
 	}

--- a/cmd/heygen/builder_test.go
+++ b/cmd/heygen/builder_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/heygen-com/heygen-cli/internal/analytics"
 	"github.com/heygen-com/heygen-cli/internal/command"
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
@@ -365,6 +367,73 @@ func TestGenBuilder_HelpShowsRequiredAnnotation(t *testing.T) {
 	}
 	if strings.Contains(res.Stdout, "Video orientation (required)") {
 		t.Fatalf("stdout = %s, optional flag should not be marked required", res.Stdout)
+	}
+}
+
+// Backticks are ordinary Markdown in OpenAPI descriptions, but pflag reads the
+// first backticked word as the flag's value-type placeholder. Untreated, the
+// shipped help reads "--token next_token" instead of "--token string".
+func TestGenBuilder_HelpStripsBackticksFromSpecDescriptions(t *testing.T) {
+	spec := &command.Spec{
+		Group:    "brand",
+		Name:     "glossaries list",
+		Summary:  "List Brand Glossaries",
+		Endpoint: "/v3/brand-glossaries",
+		Method:   "GET",
+		Flags: []command.FlagSpec{
+			{Name: "token", Type: "string", Source: "query", JSONName: "token",
+				Help: "Opaque pagination cursor from a previous response's `next_token`. Omit for the first page."},
+		},
+		Examples: []string{"heygen brand glossaries list"},
+	}
+
+	res := runGenCommand(t, "http://example.test", "test-key", spec, "glossaries", "list", "--help")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "--token string") {
+		t.Errorf("stdout should show the flag's real type:\n%s", res.Stdout)
+	}
+	if strings.Contains(res.Stdout, "--token next_token") {
+		t.Errorf("backticked word leaked into the type placeholder:\n%s", res.Stdout)
+	}
+	// The word itself must survive in the prose, just without the backticks.
+	if !strings.Contains(res.Stdout, "previous response's next_token") {
+		t.Errorf("help text should keep the word, minus backticks:\n%s", res.Stdout)
+	}
+	if strings.Contains(res.Stdout, "`") {
+		t.Errorf("no backticks should reach the rendered help:\n%s", res.Stdout)
+	}
+}
+
+// Sanitizing must reach the description and stop there. Enum members are compared
+// verbatim when the flag is validated, so an "allowed:" list that differs from
+// what is accepted is worse than a mangled type placeholder: it documents a value
+// the command rejects.
+//
+// Asserts on the registered usage string rather than on --help output, because
+// pflag rewrites backticks as it renders. Only the stored string distinguishes
+// "we left the enum alone" from "pflag hid the difference".
+func TestRegisterFlag_SanitizesProseButNotEnumValues(t *testing.T) {
+	cmd := &cobra.Command{Use: "create"}
+	registerFlag(cmd, command.FlagSpec{
+		Name:     "mode",
+		Type:     "string",
+		Source:   "body",
+		JSONName: "mode",
+		Help:     "Rendering mode for `output`",
+		// A backticked enum member is a spec bug; the CLI must still report the
+		// value it will actually accept.
+		Enum: []string{"`fast`", "quality"},
+	})
+
+	usage := cmd.Flags().Lookup("mode").Usage
+	if strings.Contains(usage, "`output`") {
+		t.Errorf("description backticks should be stripped, got: %q", usage)
+	}
+	if !strings.Contains(usage, "(allowed: `fast`, quality)") {
+		t.Errorf("enum members must survive verbatim, got: %q", usage)
 	}
 }
 


### PR DESCRIPTION
## Scope

**Surfaces:** CLI | **Module:** Codegen / help output

## Summary

Flag help comes verbatim from OpenAPI descriptions, where backticks are ordinary Markdown. pflag reads the first backticked word in a usage string as the flag's *value-type placeholder*, so a description mentioning `` `next_token` `` made `--token` advertise itself as taking a `next_token`. Strip backticks when registering the flag.

## Root cause

`pflag.UnquoteUsage` implements a documented convenience: back-quote a word in a flag's usage string and pflag uses it as the type name shown in help, stripping the quotes from the text.

```go
cmd.Flags().String("count", "", "number of `items` to fetch")
// renders: --count items   number of items to fetch
```

That's fine when help strings are authored for pflag. Ours are not — they are API reference prose, and a backtick there means code formatting, not "this is the type". `registerFlag` passed `flag.Help` through untouched, so any spec description containing a backtick silently hijacked the placeholder:

```
--token next_token                   Opaque pagination cursor from a previous response's next_token.
--brand-voice-id brand_glossary_id   Legacy field name for brand_glossary_id.
```

Both are wrong in the same way: the flag takes a `string`, and the help now misreports the type of the very flag it documents. `--token next_token` reads as though a literal `next_token` value is expected.

This is not tied to any one endpoint. It fires wherever upstream writes a backtick, so it recurs whenever the API team formats a field name in a description. `--token next_token` has shipped since the brand glossary endpoints landed; `--brand-voice-id brand_glossary_id` arrived with the most recent spec resync.

## Fix

`registerFlag` strips backticks from the help text before handing it to pflag. The word survives in the prose; only the quoting disappears, so `--token` renders as `string` and the sentence still reads naturally.

Fixed at registration rather than in the spec or in codegen, for two reasons. It is the single choke point through which every spec-derived flag description passes, so one line covers the whole generated surface and every future endpoint. And the alternative — policing backticks in OpenAPI prose upstream — asks API authors to avoid ordinary Markdown because of a downstream CLI rendering quirk, which would silently regress the moment someone forgets.

No behavior changes beyond help rendering: nothing parses the help string.

## Testing

One test asserting a backticked description renders `--token string`, keeps the word in the prose, and leaves no backtick in the output. Confirmed it fails without the fix.

Also swept the built binary across every command: the only remaining non-standard type placeholders are `--timeout duration`, which is a genuine `time.Duration`.
