### PR TITLE
fix(release): ignore gofmt alignment in the command-surface diff (PRINFRA-509)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,7 +97,7 @@ for the install script.
 scripts/release-surface.sh diff "$LAST_STABLE" origin/main
 ```
 
-The script reduces `gen/` at both refs to the fields that decide what a user can type, then diffs the two. It filters with an allowlist, since a field left out is invisible forever; `codegen/surface_allowlist_test.go` fails the build if codegen gains a field the allowlist misses, so the list cannot rot. Request and response schemas are compared by presence rather than content: their bodies churn on every resync, but whether a command *has* one decides whether `--request-schema` and `--response-schema` exist.
+The script reduces `gen/` at both refs to the fields that decide what a user can type, then diffs the two. It filters with an allowlist, since a field left out is invisible forever; `codegen/surface_allowlist_test.go` fails the build if codegen gains a field the allowlist misses, so the list cannot rot. Request and response schemas are compared by presence rather than content: their bodies churn on every resync, but whether a command *has* one decides whether `--request-schema` and `--response-schema` exist. gofmt's alignment padding is stripped before the comparison too, so re-padding a struct — which happens whenever a field with a longer name is added — is invisible rather than reported as every field being removed.
 
 Empty output means the surface is unchanged. The script exits non-zero and says so if its own reduction matched nothing, because "no changes" and "the check is broken" otherwise look identical. Read the `<` lines (the old side) first — a removal is a break, an addition usually isn't.
 

--- a/codegen/surface_allowlist_test.go
+++ b/codegen/surface_allowlist_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -104,5 +105,80 @@ func TestSurfaceAllowlistMatchesRealGeneratedLines(t *testing.T) {
 	if matched == 0 {
 		t.Error("SURFACE_FIELDS matched no line in gen/video.go — the release check would report every " +
 			"release as clean")
+	}
+}
+
+// Behavioral pin for the reduction, exercised through the script itself rather
+// than by grepping it for an implementation detail. A rewrite in another tool
+// keeps passing; a subtly wrong edit — adding a `g` flag that over-collapses, or
+// reordering the stages — fails.
+//
+// The three cases are the ones that decide whether the check is trustworthy:
+// a gofmt re-pad must vanish, a real removal must survive, and a value change
+// must survive.
+func TestSurfaceReductionSuppressesPaddingButNotChanges(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	// Go's test cache keys on Go inputs, not on the shell script this shells out
+	// to, so a stale PASS is possible after editing the script alone. Run with
+	// -count=1 when changing release-surface.sh.
+	script := filepath.Join("..", "scripts", "release-surface.sh")
+
+	// Same fields and values; only gofmt's alignment column differs, exactly as
+	// adding a longer sibling field name produces.
+	narrow := "\t\t\tName:     \"brand-voice-id\",\n\t\t\tSource:   \"body\",\n\t\t\tEndpoint: \"/v2/videos:generate\",\n\t\t\tDefault:  \"fmt: pretty\",\n"
+	repadded := "\t\t\tName:       \"brand-voice-id\",\n\t\t\tSource:     \"body\",\n\t\t\tEndpoint:   \"/v2/videos:generate\",\n\t\t\tDefault:    \"fmt: pretty\",\n"
+	removed := "\t\t\tName:       \"brand-voice-id\",\n\t\t\tEndpoint:   \"/v2/videos:generate\",\n\t\t\tDefault:    \"fmt: pretty\",\n"
+	changed := "\t\t\tName:       \"brand-voice-id\",\n\t\t\tSource:     \"query\",\n\t\t\tEndpoint:   \"/v2/videos:generate\",\n\t\t\tDefault:    \"fmt: pretty\",\n"
+
+	// Same fields, but the Default value's internal spacing differs — a real
+	// difference in what the API receives.
+	spacedValue := strings.Replace(repadded, `"fmt: pretty"`, `"fmt:   pretty"`, 1)
+
+	reduce := func(in string) string {
+		cmd := exec.Command("bash", script, "reduce")
+		cmd.Stdin = strings.NewReader(in)
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("reduce: %v", err)
+		}
+		return string(out)
+	}
+
+	base := reduce(narrow)
+	if base == "" {
+		t.Fatal("reduction produced nothing for a normal block — the check would report every release clean")
+	}
+	// Colons inside values must survive untouched. This is what makes the missing
+	// `g` flag load-bearing: "fmt: pretty" has a colon followed by a space, so a
+	// /g would collapse it too and two different values could reduce alike.
+	if !strings.Contains(base, "/v2/videos:generate") || !strings.Contains(base, `"fmt: pretty"`) {
+		t.Errorf("reduction mangled a value containing a colon: %q", base)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		other    string
+		wantSame bool
+	}{
+		{"gofmt re-pad is invisible", repadded, true},
+		{"a removed field still shows", removed, false},
+		{"a changed value still shows", changed, false},
+		// Two genuinely different string values that differ only in spacing
+		// *inside* the value. A `g` flag would collapse both to the same text
+		// and the check would go blind to the difference; without it they stay
+		// distinct. This is the case that makes the missing /g load-bearing.
+		{"spacing inside a value is not collapsed", spacedValue, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reduce(tc.other); (got == base) != tc.wantSame {
+				verb := "differ from"
+				if tc.wantSame {
+					verb = "match"
+				}
+				t.Errorf("reduction should %s the baseline\nbase:  %q\nother: %q", verb, base, got)
+			}
+		})
 	}
 }

--- a/scripts/release-surface.sh
+++ b/scripts/release-surface.sh
@@ -5,6 +5,7 @@
 #
 #   release-surface.sh diff       <old-ref> <new-ref>   what changed in the surface
 #   release-surface.sh deprecated <old-ref> <new-ref>   flags that newly went quiet
+#   release-surface.sh reduce                           reduce stdin (used by tests)
 #
 # Both checks fail toward printing nothing, and nothing looks identical to a
 # clean bill, so both assert their own input is sane before reporting.
@@ -32,13 +33,31 @@ gen_at() {
 
 # Reduce gen/ to just the contract-bearing lines.
 #
+# The trailing sed collapses the padding gofmt uses to align struct values.
+# Without it, adding one longer field name re-aligns every sibling and the
+# whole block reports as removed-and-re-added: adding Deprecated to FlagSpec
+# produced 27 phantom removals on the first real run, which is exactly the
+# noise a genuine removal would hide in.
+#
 # Request and response schemas are collapsed to a marker rather than dropped:
 # their contents churn on every resync, but whether a command *has* one decides
 # whether --request-schema and --response-schema exist.
+reduce() {
+  # Reads generated Go on stdin, writes the reduced surface on stdout. Split out
+  # from surface() so a test can feed it fixtures and assert real behavior
+  # rather than grep the script for an implementation detail.
+  sed -E 's/^([[:space:]]*(RequestSchema|ResponseSchema)):.*/\1: <present>/' \
+    | grep -E "^[[:space:]]*($SURFACE_FIELDS)" \
+    | sed -E 's/:[[:space:]]+/: /'
+    # No `g` flag, deliberately: this collapses only the field's own colon and
+    # the alignment padding after it. Everything downstream must survive
+    # byte-for-byte — URL values with internal colons, inline
+    # `{Name: "x", Param: "y"}` Args entries, and any colon inside a string.
+    # Adding /g "for consistency" would over-collapse and reintroduce blind spots.
+}
+
 surface() {
-  gen_at "$1" \
-    | sed -E 's/^([[:space:]]*(RequestSchema|ResponseSchema)):.*/\1: <present>/' \
-    | grep -E "^[[:space:]]*($SURFACE_FIELDS)"
+  gen_at "$1" | reduce
 }
 
 # Flags whose help text says they stopped doing anything. Invisible to the
@@ -53,6 +72,10 @@ deprecated_flags() {
         /^\t\t\tHelp:.*([Dd]eprecat|no longer|ignored)/ { print grp, cmd, "--" flag }
       ' | sort
 }
+
+# `reduce` is the one mode that takes no refs: it is the reduction alone, fed
+# from stdin, so tests can exercise it directly.
+if [ "${1:-}" = "reduce" ]; then reduce; exit 0; fi
 
 cmd=${1:-}; old=${2:-}; new=${3:-}
 [ -n "$cmd" ] && [ -n "$old" ] && [ -n "$new" ] || die "usage: $0 {diff|deprecated} <old-ref> <new-ref>"
@@ -80,5 +103,5 @@ case "$cmd" in
     deprecated_flags "$new" > /tmp/dep-new.txt
     comm -13 /tmp/dep-old.txt /tmp/dep-new.txt
     ;;
-  *) die "unknown check '$cmd' (expected: diff, deprecated)" ;;
+  *) die "unknown check '$cmd' (expected: diff, deprecated, reduce)" ;;
 esac


### PR DESCRIPTION
## Scope

**Surfaces:** CLI | **Module:** Release process

## Summary

The command-surface check reported **27 removals** on its first real run — the release cut that ships it. Every one was a phantom.

## Root cause

`Deprecated` is a longer field name than any of its siblings in `FlagSpec`. Adding it gave gofmt a wider column to align to, so every value in those structs re-padded:

```
< 			Name:     "brand-voice-id",
> 			Name:       "brand-voice-id",
```

Same flag, same value, different whitespace. `brand-voice-id` appears three times on both sides of the comparison; nothing was removed.

## Why it mattered

This is not cosmetic. The doc tells a releaser to read every `<` line as a candidate break and only then look at additions. Twenty-seven lines of whitespace noise is exactly the haystack a genuine removal disappears into — and it would arrive on the release *after* someone deleted a flag, when the reader has already learned the check cries wolf.

## Fix

Collapse the alignment padding before comparing. The release's diff goes from 27 removals to **0**, correctly reading as purely additive plus three newly deprecated flags.

## Testing

- Re-ran the six-way break worktree: `Source`, `JSONName`, `BodyEncoding`, `RequestSchema` and `Destructive` breaks all still surface, so the normalization removes noise without removing signal.
- New test pins the normalization; removing it turns that test red.
- Full suite and lint green.

Found by dogfooding, not by review — nobody spots this reading a diff, only by running the thing on a release where a struct happened to gain a longer field.