### PR TITLE
fix(release): correct the changelog baseline and stop minting dev tags per merge (PRINFRA-507)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,9 +1,13 @@
 name: Dev Release
 
+# On demand only. This used to also fire on every push to main, which tagged a
+# prerelease per merge — 78 of them against 22 stable releases, nearly all with
+# zero downloads. Worse, those tags sat between stable releases and became the
+# baseline GoReleaser computed the changelog from, so v0.7.0 published notes
+# covering one commit instead of five. Dev builds are still available whenever
+# someone wants one; they just are not minted automatically.
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
 
 permissions:
   contents: write

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -65,6 +65,31 @@ jobs:
           git tag "$version"
           git push origin "$version"
 
+      - name: Resolve previous stable tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # GoReleaser defaults the changelog baseline to the previous tag of any
+          # kind. Dev prereleases used to be minted per merge, so that baseline
+          # was routinely a dev tag cut minutes earlier and the notes covered a
+          # commit or two instead of the release. Pin it to the previous *stable*
+          # tag so the range is the release, whoever cuts it.
+          version="${{ github.event.inputs.version }}"
+          prev="$(git tag --list 'v*' --sort=-v:refname \
+                    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                    | grep -vFx "$version" \
+                    | head -n 1)"
+          if [ -z "$prev" ]; then
+            # First stable release: leave the override unset rather than passing
+            # an empty one. GoReleaser documents the env var as an override but
+            # not what an empty value means, and this is not the place to find out.
+            echo "no previous stable tag; leaving GoReleaser's own baseline in place"
+          else
+            echo "changelog baseline: $prev"
+            echo "GORELEASER_PREVIOUS_TAG=$prev" >> "$GITHUB_ENV"
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -73,6 +98,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.version }}
+          # GORELEASER_PREVIOUS_TAG is exported by the step above, and only when a
+          # previous stable tag exists.
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@ For install instructions, see [README.md](./README.md).
 
 ### Dev builds
 
-- Immutable prereleases tagged `v{base}-dev.{YYYYMMDD}.{shorthash}`
-- Built from `main`
+- Immutable prereleases tagged `v{base}-dev.{YYYYMMDDHHmm}`
+- Built from `main`, **cut on demand** — merging to `main` does not mint one
 - Intended for internal users and fast feedback
 
 ### Stable releases
@@ -81,13 +81,19 @@ for the install script.
 
 1. **Verify the release was published:**
    ```bash
-   gh release view v0.0.5
+   gh release view "$VERSION"
    ```
-2. **Verify the install script picks up the new version** (after CDN propagation):
+2. **Publish the changelog you wrote in step 7.** GoReleaser fills the release body with a commit list, which is a floor, not the notes. Replace it:
+   ```bash
+   gh release edit "$VERSION" --notes-file notes.md
+   ```
+   Nothing does this for you, and nothing fails if you skip it — the release just keeps the commit list. Read the body back afterwards to confirm it took.
+3. **Verify the install script picks up the new version** (after CDN propagation):
    ```bash
    curl -fsSL https://static.heygen.ai/cli/install.sh | bash
    heygen --version
    ```
+   Run the installed binary rather than trusting the CDN pointer — that is the artifact a user actually gets.
 
 ## Checking for Regressions
 


### PR DESCRIPTION
## Scope

**Surfaces:** CLI | **Module:** Release process

## Summary

v0.7.0 published release notes covering **one commit instead of five**. Device auth login, brand glossaries and the deprecation feature all shipped invisible to anyone reading the release page.

## Root cause

Not GoReleaser being unhelpful. `.goreleaser.yaml` has no `changelog:` block, so the baseline defaults to *the previous tag of any kind* — and `dev-release.yml` minted a prerelease on every push to `main`:

```
prev tag before v0.7.0:  v0.6.1-dev.202608120553   (cut minutes earlier)
commits in that range:   1
commits since v0.6.0:    5
```

Five dev tags sat between the two stable releases. The changelog was correct for the range it was given; the range was wrong.

## Fix

**Dev releases become on-demand.** The push trigger produced **78 prereleases against 22 stable**, nearly all with zero downloads — the last four have zero between them. RELEASE.md has always documented dev builds as manually dispatched (`gh workflow run dev-release.yml`) and never mentioned the push trigger, so this makes the workflow match the doc rather than changing the contract. Dev builds stay one dispatch away, preserving the occasional real use and the `heygen update` dev channel.

**`GORELEASER_PREVIOUS_TAG` pins the baseline to the previous stable tag**, reusing the filter the pre-release checklist already relies on. This is belt and braces: it keeps the range right if a dev tag ever lands in between again, and it is the safety net for a release cut without an agent driving the checklist.

**Post-release gains the missing step** — publishing the changelog from step 7. Nothing does it automatically and nothing fails if it is skipped, so the doc now says that plainly instead of leaving notes to be written and thrown away.

## Testing

Workflow changes, so verified by exercising the logic rather than by unit tests.

- Ran the baseline resolution against the repo's real tags: cutting `v0.7.0` resolves to `v0.6.0` and yields the **5** commits that actually shipped, versus the 1 that was published. Cutting `v0.8.0` resolves to `v0.7.0`.
- Both workflow files parse as YAML (checked with a real parser, not by eye — a syntax error in `release-stable.yml` would not surface until the next release attempt).
- `make lint` and the full suite green.

## Deliberately not included

GoReleaser `changelog:` grouping. With the baseline fixed the fallback is already a correct commit list for the release, and the curated notes replace it anyway — grouping would only ever polish a path that gets overwritten.

## Note for reviewers

One behavior change worth a conscious nod: anyone habitually pulling "the newest dev build" now has to ask for one. Download counts say nobody is, but that is inference from zeros, not proof.