### PR TITLE
feat(ci): report command-surface changes on PRs that touch gen/ (PRINFRA-509)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,79 @@ jobs:
         with:
           version: "~> v2"
           args: check
+
+  # Reports what a PR does to the generated command surface. Advisory only: it
+  # never fails, because reading the result needs judgment CI cannot supply — a
+  # removal can be correct when the same PR adds a deprecated alias. Blocking
+  # would also deadlock the codegen sync bot, which cannot add that alias itself.
+  surface-report:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: the report diffs against the base commit.
+          fetch-depth: 0
+
+      - name: Report command-surface changes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+
+          # Only speak up when the generated surface could have moved.
+          if git diff --quiet "$BASE_SHA" HEAD -- gen/; then
+            echo "gen/ untouched; nothing to report."
+            exit 0
+          fi
+
+          marker="<!-- command-surface-report -->"
+
+          if ! scripts/release-surface.sh report "$BASE_SHA" HEAD > /tmp/surface-report.md 2>/tmp/surface-err.txt; then
+            # Say so in the comment rather than only in the log. A silent
+            # failure leaves the previous report sitting there looking current,
+            # and the check stays green either way.
+            {
+              echo "$marker"
+              echo "### Command surface: report failed to generate"
+              echo
+              echo "This check could not read the surface, so it is telling you nothing about this PR."
+              echo "Run \`scripts/release-surface.sh diff <base> HEAD\` locally before merging."
+              echo
+              echo '```'
+              tail -5 /tmp/surface-err.txt 2>/dev/null || true
+              echo '```'
+            } > /tmp/surface-report.md
+            echo "::warning::surface report failed to generate; posting a failure notice, not blocking the PR"
+          fi
+
+          cat /tmp/surface-report.md >> "$GITHUB_STEP_SUMMARY"
+
+          # Update this job's own previous comment rather than posting a new one
+          # on every push. Keyed on the marker the report emits, not on author or
+          # position, so interleaved comments cannot confuse it.
+          # --paginate because issue comments come back 30 per page by default,
+          # so on a busy PR the marker falls off page one and this would post a
+          # duplicate every push - the exact thing the marker exists to prevent.
+          # --jq runs once PER PAGE, so emit every match and take the last
+          # overall; a per-page `last` would concatenate ids into a broken URL.
+          existing=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" 2>/dev/null | tail -1 || true)
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+              -F body=@/tmp/surface-report.md >/dev/null \
+              && echo "updated comment $existing" \
+              || echo "::warning::could not update the surface comment (fork PR?); summary still written"
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -F body=@/tmp/surface-report.md >/dev/null \
+              && echo "posted surface comment" \
+              || echo "::warning::could not post the surface comment (fork PR?); summary still written"
+          fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -105,6 +105,8 @@ scripts/release-surface.sh diff "$LAST_STABLE" origin/main
 
 The script reduces `gen/` at both refs to the fields that decide what a user can type, then diffs the two. It filters with an allowlist, since a field left out is invisible forever; `codegen/surface_allowlist_test.go` fails the build if codegen gains a field the allowlist misses, so the list cannot rot. Request and response schemas are compared by presence rather than content: their bodies churn on every resync, but whether a command *has* one decides whether `--request-schema` and `--response-schema` exist. gofmt's alignment padding is stripped before the comparison too, so re-padding a struct — which happens whenever a field with a longer name is added — is invisible rather than reported as every field being removed.
 
+CI runs this automatically on any PR that touches `gen/` and posts the result as a comment, so a resync's surface change is visible at review time rather than weeks later at the release cut. It never fails the build: reading the result takes judgment CI cannot supply, and a blocking check would deadlock the codegen sync bot, which cannot add a deprecated alias itself. Running it here is still part of the checklist, not an optional double-check: the CI comment is advisory and easy to scroll past, and it only covers changes that arrived through a PR.
+
 Empty output means the surface is unchanged. The script exits non-zero and says so if its own reduction matched nothing, because "no changes" and "the check is broken" otherwise look identical. Read the `<` lines (the old side) first — a removal is a break, an addition usually isn't.
 
 | A `<` line showing... | Effect | Action |

--- a/codegen/surface_allowlist_test.go
+++ b/codegen/surface_allowlist_test.go
@@ -182,3 +182,132 @@ func TestSurfaceReductionSuppressesPaddingButNotChanges(t *testing.T) {
 		})
 	}
 }
+
+// The CI job finds its own previous comment by this marker so it edits rather
+// than posting a new report on every push. The string lives in two files; if
+// they drift, nothing fails loudly — the PR just accumulates a comment per push
+// until someone notices the noise.
+func TestSurfaceReportMarkerMatchesCIWorkflow(t *testing.T) {
+	script, err := os.ReadFile(filepath.Join("..", "scripts", "release-surface.sh"))
+	if err != nil {
+		t.Fatalf("read release-surface.sh: %v", err)
+	}
+	workflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+
+	re := regexp.MustCompile(`<!-- [a-z-]+ -->`)
+	inScript := re.FindString(string(script))
+	if inScript == "" {
+		t.Fatal("release-surface.sh no longer emits an HTML comment marker; CI cannot find its own comment to update")
+	}
+	if !strings.Contains(string(workflow), inScript) {
+		t.Errorf("marker %q is in release-surface.sh but not in ci.yml — the surface job will post a new comment "+
+			"on every push instead of editing its previous one", inScript)
+	}
+}
+
+// Pins the report's classification against immutable history. v0.5.0 -> v0.6.0
+// added no commands and removed none; it changed existing ones. The distinction
+// is the whole point: a resync that adds commands is routine, one that changes
+// or removes an existing command is not, and a report that conflated them would
+// cry wolf on every resync until people stopped reading it.
+func TestSurfaceReportClassifiesChangeVsAddition(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	out, err := exec.Command("bash", filepath.Join("..", "scripts", "release-surface.sh"),
+		"report", "v0.5.0", "v0.6.0").Output()
+	if err != nil {
+		t.Skipf("tags unavailable (shallow clone?): %v", err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, "existing command(s) changed") {
+		t.Errorf("v0.5.0..v0.6.0 changed existing commands; headline should say so.\ngot: %s", firstLines(got, 3))
+	}
+	if strings.Contains(got, "REMOVED") {
+		t.Errorf("v0.5.0..v0.6.0 removed no commands, but the report claims a removal.\ngot: %s", firstLines(got, 3))
+	}
+	if !strings.Contains(got, "never blocking") {
+		t.Error("report should state that it is advisory; a reader who thinks it is a gate will treat a removal as pre-approved")
+	}
+}
+
+// The REMOVED headline is the branch a reader trusts most and the only one that
+// means "someone's script breaks". It was previously exercised only by hand.
+// Built from real refs so the fixture cannot drift from the generated format:
+// a worktree at v0.6.0 with one command deleted.
+func TestSurfaceReportHeadlinesRemovedCommands(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	if err := exec.Command("git", "-C", root, "rev-parse", "--verify", "v0.6.0").Run(); err != nil {
+		t.Skip("v0.6.0 unavailable (shallow clone?)")
+	}
+
+	dir := t.TempDir()
+	wt := filepath.Join(dir, "wt")
+	if out, err := exec.Command("git", "-C", root, "worktree", "add", "--detach", wt, "v0.6.0").CombinedOutput(); err != nil {
+		t.Skipf("worktree add: %v (%s)", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("git", "-C", root, "worktree", "remove", "--force", wt).Run()
+	})
+
+	// Delete one command from the generated surface, exactly as an upstream
+	// removal would arrive in a resync.
+	brand := filepath.Join(wt, "gen", "brand.go")
+	b, err := os.ReadFile(brand)
+	if err != nil {
+		t.Fatalf("read gen/brand.go: %v", err)
+	}
+	src := string(b)
+	start := strings.Index(src, "var BrandGlossariesGet")
+	end := strings.Index(src, "var BrandGlossariesList")
+	if start < 0 || end < 0 || end <= start {
+		t.Skip("gen/brand.go no longer has the expected specs at v0.6.0")
+	}
+	if err := os.WriteFile(brand, []byte(src[:start]+src[end:]), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for _, args := range [][]string{{"add", "-A"}, {"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "remove a command"}} {
+		if out, err := exec.Command("git", append([]string{"-C", wt}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	// Run from inside the worktree: the script anchors itself to the enclosing
+	// repo root, and HEAD must be the mutated commit, not the main checkout's.
+	cmd := exec.Command("bash", filepath.Join(root, "scripts", "release-surface.sh"),
+		"report", "v0.6.0", "HEAD")
+	cmd.Dir = wt
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("report: %v", err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, "REMOVED") {
+		t.Errorf("a deleted command must headline as REMOVED.\ngot: %s", firstLines(got, 3))
+	}
+	if !strings.Contains(got, "heygen brand glossaries get") {
+		t.Errorf("the report must name the removed command so it is actionable.\ngot: %s", firstLines(got, 8))
+	}
+	if !strings.Contains(got, "aliases.go") {
+		t.Error("the removal block should point at the remedy (a deprecated alias), not just state the problem")
+	}
+}
+
+func firstLines(s string, n int) string {
+	lines := strings.SplitN(s, "\n", n+1)
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/scripts/release-surface.sh
+++ b/scripts/release-surface.sh
@@ -6,6 +6,7 @@
 #   release-surface.sh diff       <old-ref> <new-ref>   what changed in the surface
 #   release-surface.sh deprecated <old-ref> <new-ref>   flags that newly went quiet
 #   release-surface.sh reduce                           reduce stdin (used by tests)
+#   release-surface.sh report     <old-ref> <new-ref>   markdown summary for a PR comment
 #
 # Both checks fail toward printing nothing, and nothing looks identical to a
 # clean bill, so both assert their own input is sane before reporting.
@@ -25,6 +26,10 @@ set -uo pipefail
 SURFACE_FIELDS='var [A-Za-z0-9_]+ = &command\.Spec\{|Group:|Name:|Endpoint:|Method:|BodyEncoding:|Paginated:|Destructive:|Deprecated:|RequestSchema:|ResponseSchema:|Required:|Enum:|Min:|Max:|Type:|Default:|Source:|JSONName:|SendDefaultWhenOmitted:|\{(Name|Param):'
 
 die() { echo "release-surface: $*" >&2; exit 1; }
+
+# Every git pathspec below is relative ("gen/"), so running from a subdirectory
+# would quietly match nothing rather than fail. Anchor to the repo root once.
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || die "not inside a git repository"
 
 gen_at() {
   # -r so a future move to subdirectories under gen/ is not silently dropped.
@@ -77,8 +82,129 @@ deprecated_flags() {
 # from stdin, so tests can exercise it directly.
 if [ "${1:-}" = "reduce" ]; then reduce; exit 0; fi
 
+# Key every surface line to the command that owns it, so a change can be
+# attributed to a command rather than reported as a floating line. Without this
+# a resync that adds a command looks the same as one that adds a required flag
+# to an existing command, and only the second breaks anyone.
+#
+# The key is the user-facing command path ("video-translate create"), not the
+# generated Go var name. Codegen derives that var from the command, so a rename
+# of the var alone is an implementation detail; keying on it would report an
+# unchanged command as removed-and-re-added.
+flatten() {
+  gen_at "$1" | reduce | awk '
+    function flush(   i, key) {
+      if (n == 0 || grp == "" || nm == "") { n = 0; return }
+      key = grp " " nm
+      for (i = 1; i <= n; i++) print key "\t" buf[i]
+      n = 0
+    }
+    # A new spec ends the previous one. Also reset at a file boundary so a
+    # stray surface-shaped line in a future non-spec file under gen/ cannot be
+    # attributed to the last command of the previous file.
+    /^var [A-Za-z0-9_]+ = &command\.Spec\{/ { flush(); grp = ""; nm = ""; seen = 1; next }
+    /^package / { flush(); grp = ""; nm = ""; seen = 0; next }
+    seen == 0 { next }
+    { buf[++n] = $0 }
+    /^\tGroup:/ { split($0, a, "\""); grp = a[2] }
+    /^\tName:/  { split($0, a, "\""); nm = a[2] }
+    END { flush() }
+  '
+}
+
+report() {
+  flatten "$1" > /tmp/surface-flat-old.txt
+  flatten "$2" > /tmp/surface-flat-new.txt
+  [ -s /tmp/surface-flat-old.txt ] && [ -s /tmp/surface-flat-new.txt ] \
+    || die "flatten produced nothing - the check is broken, do not read the result as clean"
+
+  cut -f1 /tmp/surface-flat-old.txt | sort -u > /tmp/surface-cmds-old.txt
+  cut -f1 /tmp/surface-flat-new.txt | sort -u > /tmp/surface-cmds-new.txt
+
+  local removed added changed
+  removed=$(comm -23 /tmp/surface-cmds-old.txt /tmp/surface-cmds-new.txt)
+  added=$(comm -13 /tmp/surface-cmds-old.txt /tmp/surface-cmds-new.txt)
+  changed=""
+  while read -r c; do
+    [ -n "$c" ] || continue
+    if ! diff -q <(grep "^$c	" /tmp/surface-flat-old.txt) <(grep "^$c	" /tmp/surface-flat-new.txt) >/dev/null 2>&1; then
+      changed="$changed$c"$'\n'
+    fi
+  done < <(comm -12 /tmp/surface-cmds-old.txt /tmp/surface-cmds-new.txt)
+
+  local n_removed n_added n_changed
+  n_removed=$(printf '%s' "$removed" | grep -c . || true)
+  n_added=$(printf '%s' "$added" | grep -c . || true)
+  n_changed=$(printf '%s' "$changed" | grep -c . || true)
+
+  echo "$SURFACE_COMMENT_MARKER"
+  # Headline states the answer, so the comment is readable from the PR list
+  # without opening it.
+  if [ "$n_removed" -gt 0 ]; then
+    echo "### Command surface: $n_removed command(s) REMOVED — read before merging"
+  elif [ "$n_changed" -gt 0 ]; then
+    echo "### Command surface: $n_changed existing command(s) changed"
+  elif [ "$n_added" -gt 0 ]; then
+    echo "### Command surface: additive only — $n_added new command(s)"
+  else
+    echo "### Command surface: no user-visible change"
+    echo
+    echo "\`gen/\` changed, but nothing that decides what a user can type."
+    return 0
+  fi
+  echo
+
+  if [ "$n_removed" -gt 0 ]; then
+    echo "**Removed — every script calling these breaks.** Re-register the old path in \`cmd/heygen/aliases.go\` or call it out in the release notes."
+    while read -r c; do
+      [ -n "$c" ] || continue
+      echo "- \`heygen $c\`"
+    done <<< "$removed"
+    echo
+  fi
+
+  if [ "$n_changed" -gt 0 ]; then
+    echo "**Changed — these already existed, so a change can break existing calls.**"
+    while read -r c; do
+      [ -n "$c" ] || continue
+      echo "<details><summary><code>heygen $c</code></summary>"
+      echo
+      echo '```diff'
+      diff <(grep "^$c	" /tmp/surface-flat-old.txt | cut -f2-) \
+           <(grep "^$c	" /tmp/surface-flat-new.txt | cut -f2-) \
+        | sed 's/^</-/; s/^>/+/' | grep -E '^[-+]' > /tmp/surface-cmd-diff.txt
+      head -40 /tmp/surface-cmd-diff.txt
+      local n_lines
+      n_lines=$(wc -l < /tmp/surface-cmd-diff.txt)
+      # Say so when truncating. A silently cut diff reads as the whole story.
+      if [ "$n_lines" -gt 40 ]; then
+        echo "... $((n_lines - 40)) more line(s); run scripts/release-surface.sh diff locally for the rest"
+      fi
+      echo '```'
+      echo
+      echo '</details>'
+    done <<< "$changed"
+    echo
+  fi
+
+  if [ "$n_added" -gt 0 ]; then
+    echo "**New commands — additive, nothing existing can break.**"
+    while read -r c; do
+      [ -n "$c" ] || continue
+      echo "- \`heygen $c\`"
+    done <<< "$added"
+    echo
+  fi
+
+  echo "<sub>Reference only, never blocking. See RELEASE.md \"Checking for Regressions\" for how to read this.</sub>"
+}
+
+# Marker so CI can find and update its own comment instead of posting a new one
+# on every push.
+SURFACE_COMMENT_MARKER="<!-- command-surface-report -->"
+
 cmd=${1:-}; old=${2:-}; new=${3:-}
-[ -n "$cmd" ] && [ -n "$old" ] && [ -n "$new" ] || die "usage: $0 {diff|deprecated} <old-ref> <new-ref>"
+[ -n "$cmd" ] && [ -n "$old" ] && [ -n "$new" ] || die "usage: $0 {diff|deprecated|report} <old-ref> <new-ref>"
 git rev-parse --verify --quiet "$old" >/dev/null || die "cannot resolve ref '$old'"
 git rev-parse --verify --quiet "$new" >/dev/null || die "cannot resolve ref '$new'"
 
@@ -103,5 +229,8 @@ case "$cmd" in
     deprecated_flags "$new" > /tmp/dep-new.txt
     comm -13 /tmp/dep-old.txt /tmp/dep-new.txt
     ;;
-  *) die "unknown check '$cmd' (expected: diff, deprecated, reduce)" ;;
+  report)
+    report "$old" "$new"
+    ;;
+  *) die "unknown check '$cmd' (expected: diff, deprecated, report, reduce)" ;;
 esac


### PR DESCRIPTION
## Scope

**Surfaces:** CLI | **Module:** CI / Release process

## Summary

The command-surface check only ran when a releaser remembered step 4 of the pre-release checklist. This runs it automatically on every PR that touches `gen/`, and posts the result as a comment.

## Why the resync PR, not the release cut

A resync that narrows the surface merges cleanly today. It surfaces weeks later at the release cut, interleaved with other resyncs, with nobody left who remembers the change. And the remedy — a deprecated alias in `cmd/heygen/aliases.go` — belongs to whoever reviews the resync, not to whoever happens to cut the next release.

Release-time stays as the backstop; RELEASE.md now says so.

## What the comment says

Deterministic template built by the script. Same input, same bytes — no model in the loop.

```
### Command surface: 1 command(s) REMOVED — read before merging

**Removed — every script calling these breaks.** Re-register the old path in
`cmd/heygen/aliases.go` or call it out in the release notes.
- `heygen brand glossaries update`
```

versus a routine resync:

```
### Command surface: additive only — 2 new command(s)
```

The headline states the answer so it reads from the PR list without opening anything.

## The part that took the work

**Attribution.** Counting raw diff lines is useless here. The v0.6.0→main range adds one `Required: true` and one `Args` entry — both on *brand-new commands*, where they break nothing. A naive report would flag those, so every routine resync would look identical to one that breaks callers, and people would stop reading it inside a month.

So the report keys every surface line to its owning command, then classifies: **removed** / **existing changed** / **new**. Only the first two can break anyone.

## Advisory, never blocking

Two reasons, and the second is the one that matters:

- Reading the result needs judgment CI cannot supply — a removal is correct when the same PR adds the alias.
- A blocking check would **deadlock the codegen sync bot**, which cannot write that alias itself. A legitimate rename would sit stuck until a human intervened. Non-blocking removes the need for a bypass label.

The job always exits 0, writes to the step summary, and upserts a single comment keyed on an HTML marker so it edits rather than accumulating one per push.

## Testing

- Marker consistency between the script and `ci.yml` is pinned by a test — if they drift nothing fails loudly, the PR just grows a comment per push.
- Classification pinned against immutable history (`v0.5.0`→`v0.6.0`: existing commands changed, none removed).
- Both mutation-verified: drifting the marker, and collapsing the changed/added distinction, each turn their own test red.
- Exercised the removal path end to end against a worktree with a command deleted; the report names it and says what to do.

## Incidental fix

The script anchored to the repo root. Every git pathspec in it is relative (`gen/`), so running it from a subdirectory silently matched nothing rather than failing. Found because a test *skipped* instead of passing — worth chasing rather than papering over.