### PR TITLE
chore: bump Go toolchain to 1.25.13 to clear stdlib advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Build
         run: make build
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - uses: golangci/golangci-lint-action@v9
         with:
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -121,7 +121,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Run tests
         run: make test

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Validate version
         shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heygen-com/heygen-cli
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/getkin/kin-openapi v0.137.0


### PR DESCRIPTION
## Description

The `govulncheck` job has been failing on every PR in this repo. Six advisories were published
against `go1.25.12`, and five of them are standard-library issues that govulncheck traces into code
this CLI genuinely calls:

```
GO-2026-5026, -5972, -6089, -6090, -6218
  Found in: net/http@go1.25.12
  Fixed in: net/http@go1.25.13
  #1: internal/auth/oauth/oauth.go:229  oauth.Client.RevokeToken calls http.Client.Do
  #2: internal/client/retry.go:56       client.retryTransport.RoundTrip calls http.Transport.RoundTrip
```

The sixth, `GO-2026-5932` (`x/crypto/openpgp`), is already allowlisted by that job for a documented
reason and is unaffected by this change.

`govulncheck` is not a required status check, so this was failing without blocking anything. That is
the part worth fixing rather than tolerating: a gate that is permanently red stops being read, and
the next genuine advisory would have landed in a job everyone had learned to ignore.

**The fix** bumps the toolchain to `1.25.13` in all six places it is pinned: the `go` directive in
`go.mod`, the four `setup-go` pins in `ci.yml`, and one each in `release-stable.yml` and
`dev-release.yml`.

The two release workflows are the easy ones to miss and the ones that matter most. They build the
binaries users actually download. Bumping only CI would have turned the gate green while continuing
to ship artifacts linked against the vulnerable stdlib, which is a worse state than a red check:
the signal would say fixed while the shipped thing was not.

Nothing else in the repo pins a Go version. There is no Dockerfile, `.tool-versions`, mise/asdf
config, or devcontainer, and `.goreleaser.yaml` pins no Go version. The README badge reads
`Go 1.25` (minor only), so a patch bump does not stale it.

One consequence worth naming: raising the `go` directive means a contributor running with
`GOTOOLCHAIN=local` and `go1.25.12` installed now gets a build error instead of a silent build
against the older stdlib. That is the intended direction. The default `GOTOOLCHAIN=auto` fetches
`1.25.13` transparently, and CI pins `GOTOOLCHAIN: local` alongside a `setup-go` that installs
`1.25.13`, so the two stay consistent.

## Testing

- Replayed the CI job's own allowlist shell logic against real `govulncheck` v1.1.4 output (the
  version `ci.yml` installs) on this branch: exit code 3, ids found = `GO-2026-5932` only,
  unallowlisted = none, so the gate passes for the reason it is meant to. All five stdlib advisories
  clear.
- `make test` passes on `go1.25.13`. `make lint` reports 0 issues.
- Confirmed the toolchain change moves no user-visible surface, two independent ways:
  - `scripts/release-surface.sh diff` reports no change, with non-empty inputs on both sides (2610
    contract-bearing lines each), so it is not the silent-empty result that script's own comments
    warn reads like a clean bill.
  - Built binaries from both toolchains with an identical pinned `ldflags` version string, dumped
    `--help` for all 289 command nodes from each, and diffed: byte-identical, same sha256.

The `surface-report` CI job only runs when `gen/` changes, so it will not report on this PR. The
local checks above stand in for it deliberately.
