### PR TITLE
docs: fix e2e write-path prompt and changelog resync guidance

### DIFF
--- a/.claude/skills/changelog-cli/SKILL.md
+++ b/.claude/skills/changelog-cli/SKILL.md
@@ -67,7 +67,17 @@ Group changes into these categories (omit empty categories):
 - **New** - new commands, features, or capabilities
 - **Improved** - enhancements to existing behavior
 - **Fixed** - bug fixes
-- **Internal** - codegen, CI, docs, refactors (collapsed, less detail)
+- **Internal** - changes with no user-visible effect (CI, refactors, docs)
+
+A codegen resync is not automatically Internal. What it did to the command
+surface is what a user cares about, so a resync that added a command or a flag
+is a **New** entry naming that command or flag, carrying the resync's PR number.
+List a resync under Internal only when it changed nothing a user can type.
+
+The commit subject does not tell you which case you are in -- every resync reads
+`codegen: resync gen/ from EF <sha>`. Get the surface change from the resync PR's
+body, which lists new and changed commands, or from
+`scripts/release-surface.sh diff <last-stable> origin/main`.
 
 ## Step 4: Format the output
 
@@ -86,7 +96,6 @@ Output the changelog in this format:
 - **Short title.** One-sentence description. (#PR)
 
 ### Internal
-- Codegen resync from EF abcdef1 (#PR)
 - Updated CI workflow (#PR)
 ```
 
@@ -97,8 +106,10 @@ Rules:
   was fixed, not what code changed.
 - Include the PR number in parentheses at the end of each entry.
 - Do not fabricate changes. Only include what is in the git log.
-- Collapse codegen resyncs, CI changes, and doc updates into the Internal section
-  with minimal detail.
+- Collapse CI changes and doc updates into the Internal section with minimal detail.
+- Never let an Internal entry restate something already listed above it. If a
+  resync's only content is the command it added, that command's New entry is the
+  whole story and a second Internal line for the same PR adds nothing.
 
 ## Step 5: Present for review
 

--- a/.claude/skills/e2e-cli-test/SKILL.md
+++ b/.claude/skills/e2e-cli-test/SKILL.md
@@ -155,13 +155,17 @@ auth test only; restore the real key afterward.
 This phase must always clean up, even on failure.
 
 ```bash
-# Create a short video
-./bin/heygen video-agent create --prompt "Say hello world" --wait
+# Create a short video. Keep the prompt phrased as a video request -- the agent
+# answers a conversational one ("Say hello world") in chat and never generates,
+# so the phase burns the full --wait timeout and reports FAIL on a healthy CLI.
+./bin/heygen video-agent create --prompt "Create a short 5 second video of an avatar saying: Hello world." --wait
 ```
 
 - Accept exit 0 (completed) or exit 4 (poll timeout) as success
-- Extract `video_id` from stdout (present in both cases)
-- If exit code is anything other than 0 or 4, or `video_id` is missing, fail immediately but still run cleanup below
+- Extract the video id from stdout as `.data.id`. Under `--wait` the CLI prints the
+  polled video object, not the create response, in both the completed and the
+  timeout case -- so there is no `.data.video_id` to read here
+- If exit code is anything other than 0 or 4, or the id is missing, fail immediately but still run cleanup below
 
 ```bash
 # Verify the video exists


### PR DESCRIPTION
## Scope

**Surfaces:** repo tooling only, no change to the shipped binary | **Module:** Release process

## Summary

Two agent-run release checklists carried defects that surfaced while cutting v0.8.1. The E2E
write-path phase used a prompt the video agent answers conversationally, so it timed out and
reported FAIL against a healthy CLI. The changelog skill filed every codegen resync under
Internal, which hid a release's entire user-facing surface change. This fixes both.

## Root cause

**E2E Phase 7.** The phase created a video with `--prompt "Say hello world"`. That reads as
conversation rather than as a video request, so the agent replied in chat ("Hello world! I'm
Orby, your HeyGen AI assistant. How can I help you create something amazing today?") and the
session sat at `status: thinking`. No video was ever produced. `--wait` spent its full 20 minute
timeout, exited 4, and the video stayed `pending` through a further 10 minutes of polling. The
phase's failure signal therefore carried no information about CLI health.

The same block also told the operator to read `video_id` from stdout, "present in both cases".
It is present in neither. Under `--wait` the CLI prints the polled video object rather than the
create response, so the field is `id`.

**Changelog.** The rule was "collapse codegen resyncs, CI changes, and doc updates into the
Internal section". On a release whose commits are all resyncs, that routes the entire changelog
into Internal. The user-visible additions, for v0.8.1 two new commands and two new flags, cannot
be recovered from `git log` either, because every resync commit subject reads
`codegen: resync gen/ from EF <sha>`.

## Fix

The prompt is now phrased as a video request, with a comment recording why it has to stay that
way so it is not shortened back. The id instruction reads `.data.id` and states why no
`.data.video_id` exists on the wait path.

The changelog's Internal category becomes "changes with no user-visible effect", with two rules
added: a resync that added a command or flag is a **New** entry naming it, and Internal must
never restate an entry above it. Since the commit subject cannot distinguish the two cases, the
skill now points at the resync PR body and `scripts/release-surface.sh diff` as the sources for
what actually changed. The step 4 template no longer shows a resync line under Internal, which
was teaching the pattern the rules now forbid.

## Testing

`make lint` reports 0 issues and `make test` passes all 12 packages.

Both files are instruction documents, so the real validation was executing them. The new prompt
was exercised against the live API during the v0.8.1 cut and completed in 128 seconds, through
the full create, poll to `completed`, download and delete path, against the 30 minutes the old
prompt spent never generating. The revised changelog rules produced the published v0.8.1 release
notes.
