### PR TITLE
auth: show API key permissions in status

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Device OAuth is refused in CI and `HEYGEN_NONINTERACTIVE` mode. Unattended agent
 heygen auth login
 ```
 
-Verify any of the above with `heygen auth status`. Get an API key at [app.heygen.com/settings/api](https://app.heygen.com/settings/api).
+Verify any of the above with `heygen auth status`. When an API key is active, the status includes its name, permission mode and scopes, and expiration. Get an API key at [app.heygen.com/settings/api](https://app.heygen.com/settings/api).
 
 > **Single-credential file.** The credentials file holds at most **one** of `api_key` / OAuth tokens at any time. Running `heygen auth login` (any method) clears the other on success — re-login overwrites, it does not merge. `heygen auth status` will tell you which one is active.
 >

--- a/SKILL.md
+++ b/SKILL.md
@@ -34,6 +34,9 @@ heygen video download <video-id>
 # Check for and install a newer release
 heygen update
 
+# Verify the active credential; API-key auth also returns its scopes and expiry
+heygen auth status
+
 # List resources
 heygen video list --limit 5
 heygen avatar list --limit 10

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -14,14 +15,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var apiKeySelfSpec = &command.Spec{
+	Endpoint: "/v3/api_keys/self",
+	Method:   http.MethodGet,
+}
+
 func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Verify the active credential (API key or OAuth) and show account info",
 		Long: "Verifies the credential currently in use by calling the HeyGen API.\n\n" +
-			"For OAuth credentials, also reports the credential type, source,\n" +
-			"expiry, scope, and refreshability so you can tell whether a\n" +
-			"refresh is imminent without inspecting the credentials file.\n\n" + authGuidance,
+			"For API keys, reports the key name, permission mode and scopes,\n" +
+			"creation and update times, and expiration. For OAuth credentials,\n" +
+			"reports the credential source, expiry, scope, and refreshability.\n\n" + authGuidance,
 		Example: "heygen auth status",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,37 +38,31 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Build the auth-status envelope: API user info on the
-			// existing `data` key, plus credential metadata on a new
-			// `credential` key. Existing api-key consumers see strictly
-			// additive output.
-			//
-			// The credential metadata is best-effort — if we can't
-			// re-resolve here we return the API response shape as-is
-			// so the api-key happy path is unchanged.
 			credMeta := credentialMetadata()
 			if credMeta == nil {
 				return ctx.formatter.Data(result, client.APIDataField, nil)
+			}
+			if credMeta["type"] == "api_key" {
+				apiKeyResult, err := ctx.client.Execute(apiKeySelfSpec, &command.Invocation{
+					PathParams:  make(map[string]string),
+					QueryParams: make(url.Values),
+				})
+				if err != nil {
+					return err
+				}
+				if err := mergeAPIKeyMetadata(apiKeyResult, credMeta); err != nil {
+					return clierrors.New("failed to assemble API key status: " + err.Error())
+				}
 			}
 			merged, err := mergeStatusEnvelope(result, credMeta)
 			if err != nil {
 				return clierrors.New("failed to assemble auth status: " + err.Error())
 			}
-			return ctx.formatter.Data(merged, client.APIDataField, nil)
+			return ctx.formatter.Data(merged, "", nil)
 		},
 	}
 }
 
-// credentialMetadata re-resolves the credential (same chain
-// initContext used) to describe its type/source/expiry without storing
-// any of the secret values themselves. Returns nil on any resolution
-// failure so the existing happy path remains unchanged for api-key
-// users.
-//
-// Also folds in the persisted friendly-display block (email / name /
-// username) under a `user` key so callers can surface "Logged in as
-// ..." without re-hitting /v3/users/me. The block is omitted when the
-// credentials file holds no user block (e.g. pre-this-change logins).
 func credentialMetadata() map[string]any {
 	resolver := &auth.ChainCredentialResolver{
 		Resolvers: []auth.CredentialResolver{
@@ -124,6 +124,22 @@ func credentialMetadata() map[string]any {
 		}
 	}
 	return meta
+}
+
+func mergeAPIKeyMetadata(raw json.RawMessage, credMeta map[string]any) error {
+	var envelope struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return errors.New("upstream response was not JSON")
+	}
+	if envelope.Data == nil {
+		return errors.New("upstream response did not contain API key metadata")
+	}
+	for key, value := range envelope.Data {
+		credMeta[key] = value
+	}
+	return nil
 }
 
 // mergeStatusEnvelope folds the credential metadata into the

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -31,27 +31,41 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 		Example: "heygen auth status",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			result, err := ctx.client.Execute(gen.UserMeGet, &command.Invocation{
-				PathParams:  make(map[string]string),
-				QueryParams: make(url.Values),
-			})
-			if err != nil {
-				return err
-			}
 			credMeta := credentialMetadata()
 			if credMeta == nil {
-				return ctx.formatter.Data(result, client.APIDataField, nil)
-			}
-			if credMeta["type"] == "api_key" {
-				apiKeyResult, err := ctx.client.Execute(apiKeySelfSpec, &command.Invocation{
-					PathParams:  make(map[string]string),
-					QueryParams: make(url.Values),
-				})
+				result, err := executeAuthStatusRequest(ctx, gen.UserMeGet)
 				if err != nil {
 					return err
 				}
-				if err := mergeAPIKeyMetadata(apiKeyResult, credMeta); err != nil {
+				return ctx.formatter.Data(result, client.APIDataField, nil)
+			}
+
+			isAPIKey := credMeta["type"] == "api_key"
+			if isAPIKey {
+				apiKeyResult, err := executeAuthStatusRequest(ctx, apiKeySelfSpec)
+				if err != nil {
+					if !hasHTTPStatus(err, http.StatusNotFound) {
+						return err
+					}
+					ctx.formatter.Warn("API key permission metadata is unavailable because this server does not support /v3/api_keys/self; showing legacy auth status")
+				} else if err := mergeAPIKeyMetadata(apiKeyResult, credMeta); err != nil {
 					return clierrors.New("failed to assemble API key status: " + err.Error())
+				}
+			}
+
+			result, err := executeAuthStatusRequest(ctx, gen.UserMeGet)
+			if err != nil {
+				if !isAPIKey || !isInsufficientAPIKeyScope(err) {
+					return err
+				}
+				result = json.RawMessage(`{"data":{}}`)
+			}
+			if !isAPIKey {
+				// The OAuth transport may have refreshed and persisted the
+				// credential while executing /v3/users/me. Re-resolve after
+				// that request so the status reflects the new expiry and scope.
+				if refreshedMeta := credentialMetadata(); refreshedMeta != nil {
+					credMeta = refreshedMeta
 				}
 			}
 			merged, err := mergeStatusEnvelope(result, credMeta)
@@ -61,6 +75,25 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 			return ctx.formatter.Data(merged, "", nil)
 		},
 	}
+}
+
+func executeAuthStatusRequest(ctx *cmdContext, spec *command.Spec) (json.RawMessage, error) {
+	return ctx.client.Execute(spec, &command.Invocation{
+		PathParams:  make(map[string]string),
+		QueryParams: make(url.Values),
+	})
+}
+
+func isInsufficientAPIKeyScope(err error) bool {
+	var cliErr *clierrors.CLIError
+	return errors.As(err, &cliErr) &&
+		cliErr.HTTPStatus == http.StatusForbidden &&
+		cliErr.Code == "insufficient_api_key_scope"
+}
+
+func hasHTTPStatus(err error, status int) bool {
+	var cliErr *clierrors.CLIError
+	return errors.As(err, &cliErr) && cliErr.HTTPStatus == status
 }
 
 func credentialMetadata() map[string]any {
@@ -136,7 +169,15 @@ func mergeAPIKeyMetadata(raw json.RawMessage, credMeta map[string]any) error {
 	if envelope.Data == nil {
 		return errors.New("upstream response did not contain API key metadata")
 	}
+	locallyOwned := map[string]struct{}{
+		"source": {},
+		"type":   {},
+		"user":   {},
+	}
 	for key, value := range envelope.Data {
+		if _, owned := locallyOwned[key]; owned {
+			continue
+		}
 		credMeta[key] = value
 	}
 	return nil

--- a/cmd/heygen/auth_status.go
+++ b/cmd/heygen/auth_status.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/heygen-com/heygen-cli/gen"
@@ -44,10 +45,15 @@ func newAuthStatusCmd(ctx *cmdContext) *cobra.Command {
 			if isAPIKey {
 				apiKeyResult, err := executeAuthStatusRequest(ctx, apiKeySelfSpec)
 				if err != nil {
-					if !hasHTTPStatus(err, http.StatusNotFound) {
+					reason, fatal := classifyAPIKeySelfFailure(err)
+					if fatal {
 						return err
 					}
-					ctx.formatter.Warn("API key permission metadata is unavailable because this server does not support /v3/api_keys/self; showing legacy auth status")
+					// Recorded inline as well as on stderr: a JSON consumer, or
+					// anyone piping stdout, has to be able to tell "we could not
+					// read this key's permissions" apart from "this key has none".
+					credMeta["permissions_unavailable"] = reason
+					ctx.formatter.Warn("/v3/api_keys/self did not return permission metadata — " + reason)
 				} else if err := mergeAPIKeyMetadata(apiKeyResult, credMeta); err != nil {
 					return clierrors.New("failed to assemble API key status: " + err.Error())
 				}
@@ -91,9 +97,42 @@ func isInsufficientAPIKeyScope(err error) bool {
 		cliErr.Code == "insufficient_api_key_scope"
 }
 
-func hasHTTPStatus(err error, status int) bool {
+// classifyAPIKeySelfFailure decides how a /v3/api_keys/self failure is reported,
+// returning the reason to show for a degrade and whether the failure is fatal.
+//
+// `auth status` is a diagnostic: it is run precisely when something already
+// looks wrong, so failing to *enrich* the credential with permission metadata
+// must not take down the answer the CLI can always give — which credential is
+// in use, and whether it authenticates. Only 401 is fatal, because "this
+// credential was rejected" is the one question this command must never answer
+// optimistically.
+//
+// Everything else degrades, but each class carries its own reason: the routine
+// pre-deploy state and a genuine server-side anomaly must never render
+// identically, or nobody goes looking when it is the anomaly.
+func classifyAPIKeySelfFailure(err error) (reason string, fatal bool) {
 	var cliErr *clierrors.CLIError
-	return errors.As(err, &cliErr) && cliErr.HTTPStatus == status
+	if !errors.As(err, &cliErr) || cliErr.HTTPStatus == 0 {
+		// Network failure, timeout, DNS — no HTTP response to classify.
+		return "the request did not complete (" + err.Error() + "), which is usually transient", false
+	}
+
+	switch status := cliErr.HTTPStatus; {
+	case status == http.StatusUnauthorized:
+		return "", true
+	case status == http.StatusNotFound:
+		return "this server does not support /v3/api_keys/self yet", false
+	case status == http.StatusForbidden:
+		// /v3/api_keys/self deliberately carries no x-heygen-required-scopes:
+		// any valid key may introspect itself. So a 403 here cannot be a
+		// legitimately under-scoped key, and must not be presented as the
+		// routine "not deployed yet" state.
+		return "unexpected — /v3/api_keys/self requires no scope grant, so a 403 points at a server-side scope-exemption regression or an upstream proxy intercepting the request", false
+	case status >= 500:
+		return "the server reported HTTP " + strconv.Itoa(status) + ", which is usually transient", false
+	default:
+		return "the server reported HTTP " + strconv.Itoa(status), false
+	}
 }
 
 func credentialMetadata() map[string]any {

--- a/cmd/heygen/auth_status_friendly_test.go
+++ b/cmd/heygen/auth_status_friendly_test.go
@@ -15,6 +15,7 @@ import (
 func TestAuthStatus_SurfacesPersistedUserInfo(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+	t.Setenv("HEYGEN_API_KEY", "")
 
 	// Seed: api_key + user block (post-login state).
 	if err := (&auth.FileCredentialStore{}).Save("hg_test"); err != nil {
@@ -34,6 +35,7 @@ func TestAuthStatus_SurfacesPersistedUserInfo(t *testing.T) {
 			StatusCode: 200,
 			Body:       `{"data":{"email":"jane@example.com","username":"jdoe"}}`,
 		},
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
 	})
 	defer srv.Close()
 
@@ -77,6 +79,7 @@ func TestAuthStatus_SurfacesPersistedUserInfo(t *testing.T) {
 func TestAuthStatus_NoUserBlock_FallsBack(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("HEYGEN_CONFIG_DIR", configDir)
+	t.Setenv("HEYGEN_API_KEY", "")
 
 	if err := (&auth.FileCredentialStore{}).Save("hg_legacy"); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -87,6 +90,7 @@ func TestAuthStatus_NoUserBlock_FallsBack(t *testing.T) {
 			StatusCode: 200,
 			Body:       `{"data":{"email":"u@example.com","username":"u"}}`,
 		},
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
 	})
 	defer srv.Close()
 
@@ -140,6 +144,7 @@ func TestAuthStatus_EnvSourceCredential_SkipsUserBlock(t *testing.T) {
 			StatusCode: 200,
 			Body:       `{"data":{"email":"env-user@example.com","username":"env"}}`,
 		},
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
 	})
 	defer srv.Close()
 

--- a/cmd/heygen/auth_status_oauth_test.go
+++ b/cmd/heygen/auth_status_oauth_test.go
@@ -17,6 +17,7 @@ func TestAuthStatus_APIKey_AddsCredentialMeta(t *testing.T) {
 			StatusCode: 200,
 			Body:       `{"data":{"email":"u@example.com","username":"demo"}}`,
 		},
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
 	})
 	defer srv.Close()
 
@@ -39,6 +40,18 @@ func TestAuthStatus_APIKey_AddsCredentialMeta(t *testing.T) {
 	if credMeta["source"] != "env" {
 		t.Errorf("credential.source = %v, want env", credMeta["source"])
 	}
+	if credMeta["key_name"] != "production automation" {
+		t.Errorf("credential.key_name = %v, want production automation", credMeta["key_name"])
+	}
+	if credMeta["scope_mode"] != "custom" {
+		t.Errorf("credential.scope_mode = %v, want custom", credMeta["scope_mode"])
+	}
+	if _, present := credMeta["key_id"]; present {
+		t.Errorf("credential.key_id should not be returned: %v", credMeta["key_id"])
+	}
+	if _, present := credMeta["user_type"]; present {
+		t.Errorf("credential.user_type should not be returned: %v", credMeta["user_type"])
+	}
 	// Data field still present + unchanged.
 	data, ok := parsed["data"].(map[string]any)
 	if !ok {
@@ -55,6 +68,7 @@ func TestAuthStatus_APIKey_AddsCredentialMeta(t *testing.T) {
 func TestAuthStatus_OAuth_ReportsExpiryAndScope(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HEYGEN_CONFIG_DIR", dir)
+	t.Setenv("HEYGEN_API_KEY", "")
 	// runCommand sets HEYGEN_API_KEY when non-empty — leave it blank so
 	// the file path wins.
 	if err := auth.SaveOAuthTokens(auth.OAuthTokens{

--- a/cmd/heygen/auth_status_oauth_test.go
+++ b/cmd/heygen/auth_status_oauth_test.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/heygen-com/heygen-cli/internal/auth"
+	"github.com/heygen-com/heygen-cli/internal/auth/oauth"
+	"github.com/heygen-com/heygen-cli/internal/client"
+	"github.com/heygen-com/heygen-cli/internal/output"
 )
 
 // TestAuthStatus_APIKey_AddsCredentialMeta verifies that the api-key
@@ -46,8 +52,8 @@ func TestAuthStatus_APIKey_AddsCredentialMeta(t *testing.T) {
 	if credMeta["scope_mode"] != "custom" {
 		t.Errorf("credential.scope_mode = %v, want custom", credMeta["scope_mode"])
 	}
-	if _, present := credMeta["key_id"]; present {
-		t.Errorf("credential.key_id should not be returned: %v", credMeta["key_id"])
+	if credMeta["key_id"] != "key-123" {
+		t.Errorf("credential.key_id = %v, want key-123", credMeta["key_id"])
 	}
 	if _, present := credMeta["user_type"]; present {
 		t.Errorf("credential.user_type should not be returned: %v", credMeta["user_type"])
@@ -115,6 +121,116 @@ func TestAuthStatus_OAuth_ReportsExpiryAndScope(t *testing.T) {
 	}
 	if _, ok := credMeta["expires_at"].(string); !ok {
 		t.Errorf("credential.expires_at missing or wrong type: %v", credMeta)
+	}
+}
+
+func TestAuthStatus_OAuthRefreshReportsUpdatedMetadata(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", dir)
+	t.Setenv("HEYGEN_API_KEY", "")
+	if err := auth.SaveOAuthTokens(auth.OAuthTokens{
+		AccessToken:  "stale_access_token",
+		RefreshToken: "old_refresh_token",
+		ExpiresAt:    time.Now().Add(-time.Hour),
+		Scope:        "openid old_scope",
+	}); err != nil {
+		t.Fatalf("SaveOAuthTokens: %v", err)
+	}
+
+	var apiAuthorization string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fresh_access_token","refresh_token":"new_refresh_token","token_type":"Bearer","expires_in":3600,"scope":"openid refreshed_scope"}`))
+		case "/v3/users/me":
+			apiAuthorization = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"email":"user@example.com"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cred, err := (&auth.FileCredentialResolver{}).ResolveCredential()
+	if err != nil {
+		t.Fatalf("ResolveCredential: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	formatter := output.NewJSONFormatter(&stdout, &stderr)
+	ctx := &cmdContext{
+		client: client.NewWithCredential(
+			*cred,
+			client.WithBaseURL(srv.URL),
+			client.WithOAuthClient(oauth.NewClient(
+				oauth.WithTokenURL(srv.URL+"/v1/oauth/token"),
+				oauth.WithHTTPClient(srv.Client()),
+			)),
+		),
+		formatter: formatter,
+	}
+
+	cmd := newAuthStatusCmd(ctx)
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("auth status: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if apiAuthorization != "Bearer fresh_access_token" {
+		t.Fatalf("Authorization = %q, want refreshed access token", apiAuthorization)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	credMeta := parsed["credential"].(map[string]any)
+	if credMeta["scope"] != "openid refreshed_scope" {
+		t.Fatalf("credential.scope = %v, want refreshed scope", credMeta["scope"])
+	}
+	if _, stale := credMeta["expired"]; stale {
+		t.Fatalf("credential metadata still reports expired after successful refresh: %v", credMeta)
+	}
+	expiresAt, err := time.Parse(time.RFC3339, credMeta["expires_at"].(string))
+	if err != nil {
+		t.Fatalf("credential.expires_at = %v: %v", credMeta["expires_at"], err)
+	}
+	if time.Until(expiresAt) < 50*time.Minute {
+		t.Fatalf("credential.expires_at = %s, want refreshed expiry", expiresAt)
+	}
+}
+
+func TestAuthStatus_OAuthHumanOutputIncludesAccountAndCredential(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEYGEN_CONFIG_DIR", dir)
+	t.Setenv("HEYGEN_API_KEY", "")
+	if err := auth.SaveOAuthTokens(auth.OAuthTokens{
+		AccessToken:  "at_fresh",
+		RefreshToken: "rt_for_refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		Scope:        "openid profile email",
+	}); err != nil {
+		t.Fatalf("SaveOAuthTokens: %v", err)
+	}
+
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"oauth@example.com"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "", "auth", "status", "--human")
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	for _, want := range []string{"Data:", "oauth@example.com", "Credential:", "Type", "oauth", "Scope", "openid profile email"} {
+		if !strings.Contains(res.Stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, res.Stdout)
+		}
 	}
 }
 

--- a/cmd/heygen/auth_status_test.go
+++ b/cmd/heygen/auth_status_test.go
@@ -8,12 +8,22 @@ import (
 	clierrors "github.com/heygen-com/heygen-cli/internal/errors"
 )
 
+func successfulAPIKeySelfHandler() testHandler {
+	return testHandler{
+		StatusCode: 200,
+		Body: `{"data":{"key_name":"production automation","status":"active","scope_mode":"custom","scopes":["video.read"],` +
+			`"created_at":"2026-09-01T12:00:00Z","updated_at":"2026-09-02T12:00:00Z","expires_at":"2026-10-01T12:00:00Z",` +
+			`"expires_in_seconds":2332800}}`,
+	}
+}
+
 func TestAuthStatus_Success(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
 		"GET /v3/users/me": {
 			StatusCode: 200,
 			Body:       `{"data":{"email":"user@example.com","username":"demo"}}`,
 		},
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
 	})
 	defer srv.Close()
 
@@ -36,6 +46,68 @@ func TestAuthStatus_Success(t *testing.T) {
 	}
 	if data["email"] != "user@example.com" {
 		t.Fatalf("data.email = %v, want %q", data["email"], "user@example.com")
+	}
+}
+
+func TestAuthStatus_APIKeySelfError(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"user@example.com"}}`,
+		},
+		"GET /v3/api_keys/self": {
+			StatusCode: 500,
+			Body:       `{"error":{"message":"failed to load API key metadata"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode != clierrors.ExitGeneral {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitGeneral, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "failed to load API key metadata") {
+		t.Fatalf("stderr = %s, want API key metadata error", res.Stderr)
+	}
+}
+
+func TestAuthStatus_APIKeyHumanOutputIncludesPolicy(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"user@example.com"}}`,
+		},
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status", "--human")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	for _, want := range []string{"Credential:", "Key Name", "production automation", "Scope Mode", "custom", "video.read", "Expires At"} {
+		if !strings.Contains(res.Stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, res.Stdout)
+		}
+	}
+}
+
+func TestMergeAPIKeyMetadata_RejectsInvalidResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "invalid JSON", raw: "not-json"},
+		{name: "missing data", raw: `{"meta":{}}`},
+		{name: "null data", raw: `{"data":null}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := mergeAPIKeyMetadata([]byte(tc.raw), map[string]any{}); err == nil {
+				t.Fatal("mergeAPIKeyMetadata() error = nil, want error")
+			}
+		})
 	}
 }
 

--- a/cmd/heygen/auth_status_test.go
+++ b/cmd/heygen/auth_status_test.go
@@ -11,7 +11,7 @@ import (
 func successfulAPIKeySelfHandler() testHandler {
 	return testHandler{
 		StatusCode: 200,
-		Body: `{"data":{"key_name":"production automation","status":"active","scope_mode":"custom","scopes":["video.read"],` +
+		Body: `{"data":{"key_id":"key-123","key_name":"production automation","status":"active","scope_mode":"custom","scopes":["videos:read"],` +
 			`"created_at":"2026-09-01T12:00:00Z","updated_at":"2026-09-02T12:00:00Z","expires_at":"2026-10-01T12:00:00Z",` +
 			`"expires_in_seconds":2332800}}`,
 	}
@@ -51,10 +51,6 @@ func TestAuthStatus_Success(t *testing.T) {
 
 func TestAuthStatus_APIKeySelfError(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
-		"GET /v3/users/me": {
-			StatusCode: 200,
-			Body:       `{"data":{"email":"user@example.com"}}`,
-		},
 		"GET /v3/api_keys/self": {
 			StatusCode: 500,
 			Body:       `{"error":{"message":"failed to load API key metadata"}}`,
@@ -69,6 +65,89 @@ func TestAuthStatus_APIKeySelfError(t *testing.T) {
 	}
 	if !strings.Contains(res.Stderr, "failed to load API key metadata") {
 		t.Fatalf("stderr = %s, want API key metadata error", res.Stderr)
+	}
+}
+
+func TestAuthStatus_APIKeySelfNotFoundFallsBack(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/api_keys/self": {
+			StatusCode: 404,
+			Body:       `{"error":{"code":"not_found","message":"route not found"}}`,
+		},
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"user@example.com"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"warning"`) || !strings.Contains(res.Stderr, "/v3/api_keys/self") {
+		t.Fatalf("stderr = %s, want structured endpoint-unavailable warning", res.Stderr)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, res.Stdout)
+	}
+	if parsed["data"].(map[string]any)["email"] != "user@example.com" {
+		t.Fatalf("legacy account data missing: %v", parsed)
+	}
+	credMeta, ok := parsed["credential"].(map[string]any)
+	if !ok || credMeta["type"] != "api_key" || credMeta["source"] != "env" {
+		t.Fatalf("local credential metadata missing: %v", parsed)
+	}
+}
+
+func TestAuthStatus_CustomAPIKeyWithoutAccountReadStillSucceeds(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
+		"GET /v3/users/me": {
+			StatusCode: 403,
+			Body:       `{"error":{"code":"insufficient_api_key_scope","message":"This API key does not have permission to perform this action. Required scope: account:read."}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, res.Stdout)
+	}
+	data, ok := parsed["data"].(map[string]any)
+	if !ok || len(data) != 0 {
+		t.Errorf("data should be an empty object when account.read is unavailable: %v", parsed["data"])
+	}
+	credMeta, ok := parsed["credential"].(map[string]any)
+	if !ok || credMeta["key_name"] != "production automation" {
+		t.Fatalf("credential metadata missing: %v", parsed)
+	}
+}
+
+func TestAuthStatus_APIKeyOtherForbiddenDoesNotDegrade(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
+		"GET /v3/users/me": {
+			StatusCode: 403,
+			Body:       `{"error":{"code":"resource_access_denied","message":"workspace policy denied account access"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode != clierrors.ExitAuth {
+		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitAuth, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, `"code":"resource_access_denied"`) {
+		t.Fatalf("stderr = %s, want non-scope 403 to propagate", res.Stderr)
 	}
 }
 
@@ -87,10 +166,33 @@ func TestAuthStatus_APIKeyHumanOutputIncludesPolicy(t *testing.T) {
 	if res.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	for _, want := range []string{"Credential:", "Key Name", "production automation", "Scope Mode", "custom", "video.read", "Expires At"} {
+	for _, want := range []string{"Data:", "Email", "user@example.com", "Credential:", "Key Name", "production automation", "Scope Mode", "custom", "videos:read", "Expires At"} {
 		if !strings.Contains(res.Stdout, want) {
 			t.Errorf("stdout missing %q:\n%s", want, res.Stdout)
 		}
+	}
+}
+
+func TestMergeAPIKeyMetadata_PreservesLocallyOwnedFields(t *testing.T) {
+	credMeta := map[string]any{
+		"source": "env",
+		"type":   "api_key",
+		"user":   map[string]any{"email": "local@example.com"},
+	}
+	raw := json.RawMessage(`{"data":{"source":"server","type":"future_type","user":{"email":"server@example.com"},"key_id":"key-123"}}`)
+
+	if err := mergeAPIKeyMetadata(raw, credMeta); err != nil {
+		t.Fatalf("mergeAPIKeyMetadata() error = %v", err)
+	}
+	if credMeta["source"] != "env" || credMeta["type"] != "api_key" {
+		t.Fatalf("locally owned credential fields were overwritten: %v", credMeta)
+	}
+	user := credMeta["user"].(map[string]any)
+	if user["email"] != "local@example.com" {
+		t.Fatalf("local user metadata was overwritten: %v", credMeta)
+	}
+	if credMeta["key_id"] != "key-123" {
+		t.Fatalf("unknown backend metadata was not copied through: %v", credMeta)
 	}
 }
 
@@ -113,7 +215,7 @@ func TestMergeAPIKeyMetadata_RejectsInvalidResponses(t *testing.T) {
 
 func TestAuthStatus_InvalidKey(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
-		"GET /v3/users/me": {
+		"GET /v3/api_keys/self": {
 			StatusCode: 401,
 			Body:       `{"error":{"message":"invalid API key"}}`,
 		},
@@ -137,7 +239,7 @@ func TestAuthStatus_InvalidKey(t *testing.T) {
 // source-aware auth hint from centralized enrichment in the error path.
 func TestAuthStatus_AuthError_AddsHint(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
-		"GET /v3/users/me": {
+		"GET /v3/api_keys/self": {
 			StatusCode: 401,
 			Body:       `{"error":{"message":"unauthorized"}}`,
 		},
@@ -163,6 +265,7 @@ func TestAuthStatus_AuthError_AddsHint(t *testing.T) {
 // not mutated by the centralized auth hint enrichment.
 func TestAuthStatus_NonAuthError_NoHintMutation(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/api_keys/self": successfulAPIKeySelfHandler(),
 		"GET /v3/users/me": {
 			StatusCode: 500,
 			Body:       `{"error":{"message":"internal server error"}}`,
@@ -183,6 +286,7 @@ func TestAuthStatus_NonAuthError_NoHintMutation(t *testing.T) {
 
 func TestAuthStatus_NoKey(t *testing.T) {
 	t.Setenv("HEYGEN_CONFIG_DIR", t.TempDir())
+	t.Setenv("HEYGEN_API_KEY", "")
 
 	res := runCommand(t, "http://example.invalid", "", "auth", "status")
 

--- a/cmd/heygen/auth_status_test.go
+++ b/cmd/heygen/auth_status_test.go
@@ -49,23 +49,111 @@ func TestAuthStatus_Success(t *testing.T) {
 	}
 }
 
-func TestAuthStatus_APIKeySelfError(t *testing.T) {
+// A 5xx on the enrichment call is transient and must not brick the command:
+// `auth status` still knows which credential is in use and that it authenticates.
+// This previously hard-failed; degrading is the deliberate change.
+func TestAuthStatus_APIKeySelfServerErrorDegrades(t *testing.T) {
 	srv := setupTestServer(t, map[string]testHandler{
 		"GET /v3/api_keys/self": {
 			StatusCode: 500,
 			Body:       `{"error":{"message":"failed to load API key metadata"}}`,
+		},
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"user@example.com"}}`,
 		},
 	})
 	defer srv.Close()
 
 	res := runCommand(t, srv.URL, "test-key", "auth", "status")
 
-	if res.ExitCode != clierrors.ExitGeneral {
-		t.Fatalf("ExitCode = %d, want %d\nstderr: %s", res.ExitCode, clierrors.ExitGeneral, res.Stderr)
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0 (5xx should degrade, not fail)\nstderr: %s", res.ExitCode, res.Stderr)
 	}
-	if !strings.Contains(res.Stderr, "failed to load API key metadata") {
-		t.Fatalf("stderr = %s, want API key metadata error", res.Stderr)
+	if !strings.Contains(res.Stderr, "/v3/api_keys/self") || !strings.Contains(res.Stderr, "transient") {
+		t.Fatalf("stderr = %s, want a transient-server warning naming the endpoint", res.Stderr)
 	}
+	credMeta := credentialBlock(t, res.Stdout)
+	reason, ok := credMeta["permissions_unavailable"].(string)
+	if !ok || !strings.Contains(reason, "500") {
+		t.Fatalf("credential.permissions_unavailable = %v, want an inline reason naming HTTP 500", credMeta["permissions_unavailable"])
+	}
+	if _, leaked := credMeta["scope_mode"]; leaked {
+		t.Fatalf("scope_mode must be absent when the metadata call failed: %v", credMeta)
+	}
+}
+
+// 401 is the one class that must stay fatal. Degrading it would render
+// "credential present, from local file" for a revoked key — false reassurance
+// about the single question `auth status` exists to answer.
+func TestAuthStatus_APIKeySelfUnauthorizedStaysFatal(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/api_keys/self": {
+			StatusCode: 401,
+			Body:       `{"error":{"code":"auth_error","message":"api key is revoked"}}`,
+		},
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"user@example.com"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode == 0 {
+		t.Fatalf("ExitCode = 0, want non-zero: a rejected credential must fail\nstdout: %s", res.Stdout)
+	}
+	if !strings.Contains(res.Stderr, "api key is revoked") {
+		t.Fatalf("stderr = %s, want the upstream rejection surfaced", res.Stderr)
+	}
+}
+
+// A 403 degrades like the rest, but must NOT read like the routine
+// not-deployed-yet state: /v3/api_keys/self is scope-exempt, so a 403 there is
+// an anomaly (exemption regression, or an upstream proxy intercepting).
+func TestAuthStatus_APIKeySelfForbiddenDegradesButReadsAsAnomalous(t *testing.T) {
+	srv := setupTestServer(t, map[string]testHandler{
+		"GET /v3/api_keys/self": {
+			StatusCode: 403,
+			Body:       `{"error":{"code":"forbidden","message":"forbidden"}}`,
+		},
+		"GET /v3/users/me": {
+			StatusCode: 200,
+			Body:       `{"data":{"email":"user@example.com"}}`,
+		},
+	})
+	defer srv.Close()
+
+	res := runCommand(t, srv.URL, "test-key", "auth", "status")
+
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0 (403 degrades)\nstderr: %s", res.ExitCode, res.Stderr)
+	}
+	reason, ok := credentialBlock(t, res.Stdout)["permissions_unavailable"].(string)
+	if !ok {
+		t.Fatalf("want an inline permissions_unavailable reason, stdout: %s", res.Stdout)
+	}
+	if !strings.Contains(reason, "unexpected") || !strings.Contains(reason, "no scope grant") {
+		t.Fatalf("reason = %q, want it flagged as unexpected for a scope-exempt endpoint", reason)
+	}
+	// The distinguishing property: it must not read as the 404 case.
+	if strings.Contains(reason, "does not support") {
+		t.Fatalf("reason = %q, must not render as the routine pre-deploy state", reason)
+	}
+}
+
+func credentialBlock(t *testing.T, stdout string) map[string]any {
+	t.Helper()
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, stdout)
+	}
+	credMeta, ok := parsed["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("credential block missing: %v", parsed)
+	}
+	return credMeta
 }
 
 func TestAuthStatus_APIKeySelfNotFoundFallsBack(t *testing.T) {
@@ -88,6 +176,11 @@ func TestAuthStatus_APIKeySelfNotFoundFallsBack(t *testing.T) {
 	}
 	if !strings.Contains(res.Stderr, `"warning"`) || !strings.Contains(res.Stderr, "/v3/api_keys/self") {
 		t.Fatalf("stderr = %s, want structured endpoint-unavailable warning", res.Stderr)
+	}
+	// The calm end of the taxonomy: 404 is the expected pre-deploy state, and
+	// must stay distinguishable from the 403 anomaly wording.
+	if reason, ok := credentialBlock(t, res.Stdout)["permissions_unavailable"].(string); !ok || !strings.Contains(reason, "does not support") {
+		t.Fatalf("credential.permissions_unavailable = %v, want the calm not-deployed-yet reason", reason)
 	}
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {


### PR DESCRIPTION
## Description

Adds API-key governance details to the existing `heygen auth status` command. When the active credential is an API key, the CLI calls `GET /v3/api_keys/self` and reports the key name, status, permission mode and scopes, lifecycle timestamps, and expiration alongside the local credential-source information. It continues to include account information when the key has `account.read`; a valid custom-scoped key without that permission still gets its own metadata instead of failing status. JSON output keeps the existing top-level `data` and `credential` envelope, while `--human` now renders both available sections instead of hiding credential metadata.

OAuth behavior is unchanged and does not call the API-key-only endpoint. This is intentionally a hand-written enhancement to `auth status`; the backend endpoint is excluded from generated CLI commands and remains excluded from MCP.

Backend dependency: heygen-com/experiment-framework#49894 provides the enriched API-key metadata endpoint. The CLI PR can merge independently because endpoint failures degrade to labeled partial status, but this change must not be cut or released until #49894 is merged and deployed to production: https://github.com/heygen-com/experiment-framework/pull/49894

## Testing

- `go test ./...`
- `golangci-lint run ./...` (v2.11.4)
- `make build`
- Focused API-key, OAuth, missing-`account.read`, malformed-response, error-path, and human-output tests
