### PR TITLE
codegen: keep generated fixtures on LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Description
On Windows with core.autocrlf=true, the codegen golden tests compare LF generated output with CRLF checked-in fixtures, and the surface allowlist regex sees the carriage return. Add a repository-level text policy that keeps text files on LF so a clean Windows checkout passes the same tests without changing generated source or runtime behavior. Fixes #339.

## Testing
In a fresh clone of this branch with core.autocrlf=true, go test ./codegen -run TestGoldenFiles|TestSurfaceAllowlistCoversEveryTemplateField|TestSurfaceAllowlistMatchesRealGeneratedLines -count=1 passes all 6 tests. The full go test ./... run reports 1,159 passed, 2 failed, and 6 skipped; the two failures invoke WSL bash, which is unavailable in this native Windows environment.